### PR TITLE
Fix for test: testReadFileAsString

### DIFF
--- a/src/test/java/com/wcc/platform/utils/FileUtilTest.java
+++ b/src/test/java/com/wcc/platform/utils/FileUtilTest.java
@@ -10,8 +10,8 @@ class FileUtilTest {
     @Test
     void testReadFileAsString() {
         String fileContent = FileUtil.readFileAsString("example.txt");
-
-        assertEquals("Line 1\nLine 2\nLine 3", fileContent);
+        String testContent = "Line 1" + System.lineSeparator() + "Line 2" + System.lineSeparator() + "Line 3";
+        assertEquals(testContent, fileContent);
     }
 
     @Test


### PR DESCRIPTION
Description:
Test testReadFileAsString() was failing on Windows system.
Fix for https://github.com/Women-Coding-Community/wcc-backend/issues/26

Solution:
Use System.lineSeparator() instead of "\n" in the string that is used as expected result:
`String testContent = "Line 1" + System.lineSeparator() + "Line 2" + System.lineSeparator() + "Line 3";`

All tests are passing:

![Screenshot (73)](https://github.com/Women-Coding-Community/wcc-backend/assets/17902969/748a040f-7794-4273-a670-1c317d0e5654)
