### PR TITLE
introduced alias in order to use non-relative import

### DIFF
--- a/integration-test/tests/cms/codeofconduct.test.ts
+++ b/integration-test/tests/cms/codeofconduct.test.ts
@@ -1,5 +1,6 @@
 import {expect, test} from '@playwright/test';
-import { codeofconductExepctedInformation } from '../../utils/datafactory/codeofconduct.data';
+import { codeofconductExepctedInformation } from '@utils/datafactory/codeofconduct.data';
+
 test('GET /api/cms/v1/code-of-conduct returns correct data', async ({request}) => {
     const response = await request.get(`/api/cms/v1/code-of-conduct`);
  

--- a/integration-test/tests/cms/footer.test.ts
+++ b/integration-test/tests/cms/footer.test.ts
@@ -1,7 +1,7 @@
 import {expect, test} from '@playwright/test';
-import { footerExpectedInformation } from '../../utils/datafactory/footer.data';
-import { validateSchema } from '../../utils/helpers/schema.validation';
-import { footerSchema } from '../../utils/datafactory/schemas/footer.schema';
+import { footerExpectedInformation } from '@utils/datafactory/footer.data';
+import { validateSchema } from '@utils/helpers/schema.validation';
+import { footerSchema } from '@utils/datafactory/schemas/footer.schema';
 
 
 test('GET /api/cms/v1/footer returns correct footer data', async ({request}) => {

--- a/integration-test/tsconfig.json
+++ b/integration-test/tsconfig.json
@@ -1,10 +1,23 @@
 {
   "compilerOptions": {
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+    "target": "es2016", 
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "baseUrl": ".", 
+    "paths": {
+      "@utils/*": ["utils/*"],  
+      "@integration-test/*": ["*"]  
+    }
+  },
+  "include": [
+    "**/*" 
+  ],
+  "exclude": [
+    "node_modules",
+    "eslint.config.js",
+    "playwright.config.ts"
+  ]
 }


### PR DESCRIPTION
Introduced alias in `tsconfig.json` file and replaced relative import:
```
import { codeofconductExepctedInformation } from '../../utils/datafactory/codeofconduct.data';
```

to non-relative:
````
import { codeofconductExepctedInformation } from '@utils/datafactory/codeofconduct.data';
````
