### PR TITLE
feat: create custom style for background colour

### DIFF
--- a/src/main/java/com/wcc/platform/configuration/ObjectMapperConfig.java
+++ b/src/main/java/com/wcc/platform/configuration/ObjectMapperConfig.java
@@ -31,6 +31,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class ObjectMapperConfig {
 
+  public static final String DATE_TIME_FORMAT = "EEE, MMM dd, yyyy, h:mm a z";
+
   /** Create ObjectMapper bean and include custom serializer. */
   @Bean
   public ObjectMapper objectMapper() {
@@ -46,7 +48,7 @@ public class ObjectMapperConfig {
 
   private void registerCustomDeserializers(final ObjectMapper objectMapper) {
     final DateTimeFormatter formatter =
-        DateTimeFormatter.ofPattern("EEE, MMM dd, yyyy, h:mm a z", Locale.ENGLISH);
+        DateTimeFormatter.ofPattern(DATE_TIME_FORMAT, Locale.ENGLISH);
 
     final JavaTimeModule javaTimeModule = new JavaTimeModule();
     javaTimeModule.addDeserializer(ZonedDateTime.class, new ZonedDateTimeDeserializer(formatter));

--- a/src/main/java/com/wcc/platform/configuration/ObjectMapperConfig.java
+++ b/src/main/java/com/wcc/platform/configuration/ObjectMapperConfig.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr310.ser.ZonedDateTimeSerializer;
 import com.wcc.platform.deserializers.CmsIconDeserializer;
+import com.wcc.platform.deserializers.ColorShadeTypeDeserializer;
+import com.wcc.platform.deserializers.ColorTypeDeserializer;
 import com.wcc.platform.deserializers.ImageTypeDeserializer;
 import com.wcc.platform.deserializers.MemberTypeDeserializer;
 import com.wcc.platform.deserializers.ProgramTypeDeserializer;
@@ -14,6 +16,8 @@ import com.wcc.platform.deserializers.SocialNetworkTypeDeserializer;
 import com.wcc.platform.deserializers.ZonedDateTimeDeserializer;
 import com.wcc.platform.domain.cms.attributes.CmsIcon;
 import com.wcc.platform.domain.cms.attributes.ImageType;
+import com.wcc.platform.domain.cms.attributes.style.ColorShadeType;
+import com.wcc.platform.domain.cms.attributes.style.ColorType;
 import com.wcc.platform.domain.platform.MemberType;
 import com.wcc.platform.domain.platform.ProgramType;
 import com.wcc.platform.domain.platform.SocialNetworkType;
@@ -54,6 +58,8 @@ public class ObjectMapperConfig {
             new SimpleModule()
                 .addDeserializer(ProgramType.class, new ProgramTypeDeserializer())
                 .addDeserializer(MemberType.class, new MemberTypeDeserializer())
+                .addDeserializer(ColorType.class, new ColorTypeDeserializer())
+                .addDeserializer(ColorShadeType.class, new ColorShadeTypeDeserializer())
                 .addDeserializer(ImageType.class, new ImageTypeDeserializer())
                 .addDeserializer(CmsIcon.class, new CmsIconDeserializer())
                 .addDeserializer(SocialNetworkType.class, new SocialNetworkTypeDeserializer()));

--- a/src/main/java/com/wcc/platform/deserializers/ColorShadeTypeDeserializer.java
+++ b/src/main/java/com/wcc/platform/deserializers/ColorShadeTypeDeserializer.java
@@ -1,0 +1,24 @@
+package com.wcc.platform.deserializers;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.wcc.platform.domain.cms.attributes.style.ColorShadeType;
+import java.io.IOException;
+import java.util.Arrays;
+
+/** Custom deserializer for {@code ColorShadeType} enum. */
+public class ColorShadeTypeDeserializer extends JsonDeserializer<ColorShadeType> {
+
+  @Override
+  public ColorShadeType deserialize(
+      final JsonParser jsonParser, final DeserializationContext context) throws IOException {
+
+    final var value = jsonParser.getText();
+
+    return Arrays.stream(ColorShadeType.values())
+        .filter(type -> type.name().equalsIgnoreCase(value))
+        .findFirst()
+        .orElse(ColorShadeType.MAIN);
+  }
+}

--- a/src/main/java/com/wcc/platform/deserializers/ColorTypeDeserializer.java
+++ b/src/main/java/com/wcc/platform/deserializers/ColorTypeDeserializer.java
@@ -1,0 +1,24 @@
+package com.wcc.platform.deserializers;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.wcc.platform.domain.cms.attributes.style.ColorType;
+import java.io.IOException;
+import java.util.Arrays;
+
+/** Custom deserializer for {@code ColorType} enum. */
+public class ColorTypeDeserializer extends JsonDeserializer<ColorType> {
+
+  @Override
+  public ColorType deserialize(final JsonParser jsonParser, final DeserializationContext context)
+      throws IOException {
+
+    final var value = jsonParser.getText();
+
+    return Arrays.stream(ColorType.values())
+        .filter(type -> type.name().equalsIgnoreCase(value))
+        .findFirst()
+        .orElse(ColorType.PRIMARY);
+  }
+}

--- a/src/main/java/com/wcc/platform/domain/cms/attributes/HeroSection.java
+++ b/src/main/java/com/wcc/platform/domain/cms/attributes/HeroSection.java
@@ -1,5 +1,6 @@
 package com.wcc.platform.domain.cms.attributes;
 
+import com.wcc.platform.domain.cms.attributes.style.CustomStyle;
 import jakarta.validation.constraints.NotNull;
 
 /**
@@ -8,5 +9,7 @@ import jakarta.validation.constraints.NotNull;
  * @param title title of section
  * @param description section description not mandatory
  * @param image mandatory image
+ * @param customStyle custom style
  */
-public record HeroSection(@NotNull String title, String description, @NotNull Image image) {}
+public record HeroSection(
+    @NotNull String title, String description, @NotNull Image image, CustomStyle customStyle) {}

--- a/src/main/java/com/wcc/platform/domain/cms/attributes/style/BackgroundColourStyle.java
+++ b/src/main/java/com/wcc/platform/domain/cms/attributes/style/BackgroundColourStyle.java
@@ -1,0 +1,4 @@
+package com.wcc.platform.domain.cms.attributes.style;
+
+/** Background style to be used in the frontend based on MUI UI. */
+public record BackgroundColourStyle(ColorType color, ColorShade shade) {}

--- a/src/main/java/com/wcc/platform/domain/cms/attributes/style/BackgroundType.java
+++ b/src/main/java/com/wcc/platform/domain/cms/attributes/style/BackgroundType.java
@@ -1,0 +1,16 @@
+package com.wcc.platform.domain.cms.attributes.style;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/** Background colour options to be used in the frontend. */
+@AllArgsConstructor
+@Getter
+public enum BackgroundType {
+  PRIMARY(ColorType.PRIMARY, ColorShadeType.LIGHT),
+  SECONDARY(ColorType.SECONDARY, ColorShadeType.LIGHT),
+  TERTIARY(ColorType.TERTIARY, ColorShadeType.LIGHT);
+
+  private final ColorType color;
+  private final ColorShadeType shade;
+}

--- a/src/main/java/com/wcc/platform/domain/cms/attributes/style/ColorShade.java
+++ b/src/main/java/com/wcc/platform/domain/cms/attributes/style/ColorShade.java
@@ -1,0 +1,14 @@
+package com.wcc.platform.domain.cms.attributes.style;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** Custom color to be used in the frontend based on MUI UI. */
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ColorShade {
+  private ColorShadeType name;
+  private int value;
+}

--- a/src/main/java/com/wcc/platform/domain/cms/attributes/style/ColorShadeType.java
+++ b/src/main/java/com/wcc/platform/domain/cms/attributes/style/ColorShadeType.java
@@ -1,0 +1,25 @@
+package com.wcc.platform.domain.cms.attributes.style;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/** Colour Shade types to be used in the frontend based on MUI UI. */
+@Getter
+@AllArgsConstructor
+public enum ColorShadeType {
+  MAIN("main", 40),
+  LIGHT("light", 90),
+  DARK("dark", 10);
+
+  private final String description;
+  private final int shade;
+
+  @Override
+  public String toString() {
+    return description;
+  }
+
+  public ColorShade toColorShade() {
+    return new ColorShade(this, this.shade);
+  }
+}

--- a/src/main/java/com/wcc/platform/domain/cms/attributes/style/ColorType.java
+++ b/src/main/java/com/wcc/platform/domain/cms/attributes/style/ColorType.java
@@ -1,0 +1,15 @@
+package com.wcc.platform.domain.cms.attributes.style;
+
+import java.util.Locale;
+
+/** Colour types to be used in the frontend based on MUI UI. */
+public enum ColorType {
+  PRIMARY,
+  SECONDARY,
+  TERTIARY;
+
+  @Override
+  public String toString() {
+    return name().toLowerCase(Locale.ENGLISH);
+  }
+}

--- a/src/main/java/com/wcc/platform/domain/cms/attributes/style/CustomStyle.java
+++ b/src/main/java/com/wcc/platform/domain/cms/attributes/style/CustomStyle.java
@@ -1,0 +1,4 @@
+package com.wcc.platform.domain.cms.attributes.style;
+
+/** Custom frontend styles. */
+public record CustomStyle(BackgroundColourStyle backgroundColour) {}

--- a/src/main/java/com/wcc/platform/domain/cms/pages/Page.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/Page.java
@@ -2,6 +2,7 @@ package com.wcc.platform.domain.cms.pages;
 
 import com.wcc.platform.domain.cms.attributes.Image;
 import com.wcc.platform.domain.cms.attributes.LabelLink;
+import com.wcc.platform.domain.cms.attributes.style.CustomStyle;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
@@ -27,4 +28,5 @@ public class Page {
   private String description;
   private LabelLink link;
   private List<Image> images;
+  private CustomStyle customStyle;
 }

--- a/src/main/java/com/wcc/platform/domain/cms/pages/programme/ProgrammePage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/programme/ProgrammePage.java
@@ -1,6 +1,7 @@
 package com.wcc.platform.domain.cms.pages.programme;
 
 import com.wcc.platform.domain.cms.attributes.Contact;
+import com.wcc.platform.domain.cms.attributes.style.CustomStyle;
 import com.wcc.platform.domain.cms.pages.Page;
 import com.wcc.platform.domain.platform.EventSection;
 import com.wcc.platform.domain.platform.Programme;
@@ -26,5 +27,5 @@ public class ProgrammePage {
   @NotNull private Contact contact;
   @NotEmpty private List<Programme> programmeDetails;
   @NotNull private EventSection eventSection;
-  // TODO Add resources section
+  @NotNull private CustomStyle customStyle;
 }

--- a/src/main/resources/aboutUsPage.json
+++ b/src/main/resources/aboutUsPage.json
@@ -3,12 +3,12 @@
     "title": "About Us",
     "images": [
       {
-        "path": "https://drive.google.com/file/d/1rzQtZnlyPHxdWHI6lS8bd0UeMkJnh7HF",
+        "path": "https://drive.google.com/uc?id=1EHE_3m2QTAD-F-cdr2S4luqpyR4FnQX7&export=download",
         "alt": "Women coding community group photo",
         "type": "DESKTOP"
       },
       {
-        "path": "about_us_mobile.jpg",
+        "path": "https://drive.google.com/uc?id=1MrPVQ3r2kzKcK9n6BRlPaJUaUrpxGGPl&export=download",
         "alt": "Women coding community group photo",
         "type": "MOBILE"
       }

--- a/src/main/resources/bookClubPage.json
+++ b/src/main/resources/bookClubPage.json
@@ -76,5 +76,14 @@
         }
       }
     ]
+  },
+  "customStyle": {
+    "backgroundColour": {
+      "color": "PRIMARY",
+      "shade": {
+        "name": "LIGHT",
+        "value": 90
+      }
+    }
   }
 }

--- a/src/main/resources/landingPage.json
+++ b/src/main/resources/landingPage.json
@@ -5,9 +5,9 @@
     "description": "Empowering Women in Their Tech Careers",
     "customStyle": {
       "backgroundColour": {
-        "color": "PRIMARY",
+        "color": "primary",
         "shade": {
-          "name": "LIGHT",
+          "name": "light",
           "value": 90
         }
       }
@@ -159,8 +159,8 @@
       {
         "topics": "TECH_TALK",
         "eventType": "ONLINE_MEETUP",
-        "startDate": "THU, JUN 30, 2024, 8:00 PM CEST",
-        "endDate": "THU, JUN 30, 2024, 9:30 PM CEST",
+        "startDate": "Sun, Jun 30, 2024, 8:00 PM CEST",
+        "endDate": "Sun, Jun 30, 2024, 9:30 PM CEST",
         "title": "Coding Club with Women Coding Community",
         "hostProfile": {
           "label": "Irina Kamalova",

--- a/src/main/resources/landingPage.json
+++ b/src/main/resources/landingPage.json
@@ -1,18 +1,22 @@
 {
-  "id": "LANDING_PAGE",
+  "id": "page:LANDING_PAGE",
   "heroSection": {
     "title": "Women Coding Community",
     "description": "Empowering Women in Their Tech Careers",
+    "customStyle": {
+      "backgroundColour": {
+        "color": "PRIMARY",
+        "shade": {
+          "name": "LIGHT",
+          "value": 90
+        }
+      }
+    },
     "images": [
       {
-        "path": "https://drive.google.com/file/d/1rzQtZnlyPHxdWHI6lS8bd0UeMkJnh7HF",
+        "path": "https://drive.google.com/uc?id=1rzQtZnlyPHxdWHI6lS8bd0UeMkJnh7HF&export=download",
         "alt": "There are two women talking during a productive mentoring session",
         "type": "desktop"
-      },
-      {
-        "path": "home_16x9_ratio.jpg",
-        "alt": "There are two women talking during a productive mentoring session",
-        "type": "mobile"
       }
     ]
   },
@@ -190,7 +194,7 @@
     },
     "images": [
       {
-        "path": "square_image_2.jpg",
+        "path": "https://drive.google.com/uc?id=1fWzte4q2adiMf7MFAjMRlNDbccZVs7iL&export=download",
         "alt": "There are two women talking during a productive mentoring session",
         "type": "desktop"
       }

--- a/src/main/resources/landingPage.json
+++ b/src/main/resources/landingPage.json
@@ -25,14 +25,9 @@
     "description": "Ready to empower and be empowered in tech? Become a mentor! Expand your network, give back, share expertise, and discover new perspectives.\n",
     "images": [
       {
-        "path": "home_21x9_ratio.jpg",
+        "path": "https://drive.google.com/uc?id=1efbBcw8yaASbSx3pgqcj06tIN-P2Wf55&export=download",
         "alt": "There are two women talking during a productive mentoring session",
         "type": "desktop"
-      },
-      {
-        "path": "square_ratio_1.jpg",
-        "alt": "There are two women talking during a productive mentoring session",
-        "type": "mobile"
       }
     ],
     "link": {

--- a/src/test/java/com/wcc/platform/deserializers/MemberTypeDeserializerTest.java
+++ b/src/test/java/com/wcc/platform/deserializers/MemberTypeDeserializerTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.wcc.platform.domain.platform.MemberType;
 import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
@@ -37,6 +38,7 @@ class MemberTypeDeserializerTest {
     assertEquals(type, response);
   }
 
+  @Test
   void testDeserializeInvalid() throws IOException {
     when(jsonParser.getText()).thenReturn("UNDEFINED");
 

--- a/src/test/java/com/wcc/platform/deserializers/ZonedDateTimeDeserializerTest.java
+++ b/src/test/java/com/wcc/platform/deserializers/ZonedDateTimeDeserializerTest.java
@@ -1,0 +1,58 @@
+package com.wcc.platform.deserializers;
+
+import static com.wcc.platform.configuration.ObjectMapperConfig.DATE_TIME_FORMAT;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Locale;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ZonedDateTimeDeserializerTest {
+
+  private final ZonedDateTimeDeserializer deserializer =
+      new ZonedDateTimeDeserializer(DateTimeFormatter.ofPattern(DATE_TIME_FORMAT, Locale.ENGLISH));
+
+  @Mock private JsonParser jsonParser;
+  @Mock private DeserializationContext context;
+
+  @Test
+  void testDeserializeValid() throws IOException {
+    when(jsonParser.getText()).thenReturn("Thu, May 30, 2024, 9:30 PM CEST");
+
+    var response = deserializer.deserialize(jsonParser, context);
+
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals("2024-05-30T21:30+02:00[Europe/Paris]", response.toString());
+    Assertions.assertEquals(
+        ZonedDateTime.of(2024, 5, 30, 21, 30, 0, 0, ZoneId.of("Europe/Paris")), response);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "Thu, May 30, 2024",
+        "2024-05-30T21:30:00",
+        "May 30, 2024, 9:30 PM",
+        "30-05-2024 21:30",
+        "Fri, May 30, 2024, 9:30 PM CEST"
+      })
+  void testDeserializeInvalidFormat(final String invalidDate) throws IOException {
+    when(jsonParser.getText()).thenReturn(invalidDate);
+
+    assertThrows(DateTimeParseException.class, () -> deserializer.deserialize(jsonParser, context));
+  }
+}

--- a/src/test/java/com/wcc/platform/domain/cms/attributes/style/ColorShadeTypeTest.java
+++ b/src/test/java/com/wcc/platform/domain/cms/attributes/style/ColorShadeTypeTest.java
@@ -1,0 +1,17 @@
+package com.wcc.platform.domain.cms.attributes.style;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Locale;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class ColorShadeTypeTest {
+
+  @ParameterizedTest
+  @EnumSource(ColorShadeType.class)
+  void testToString(ColorShadeType shadeType) {
+    String expected = shadeType.name().toLowerCase(Locale.ENGLISH);
+    assertEquals(expected, shadeType.toString());
+  }
+}

--- a/src/test/java/com/wcc/platform/domain/cms/attributes/style/ColorShadeTypeTest.java
+++ b/src/test/java/com/wcc/platform/domain/cms/attributes/style/ColorShadeTypeTest.java
@@ -10,8 +10,8 @@ class ColorShadeTypeTest {
 
   @ParameterizedTest
   @EnumSource(ColorShadeType.class)
-  void testToString(ColorShadeType shadeType) {
-    String expected = shadeType.name().toLowerCase(Locale.ENGLISH);
+  void testToString(final ColorShadeType shadeType) {
+    final String expected = shadeType.name().toLowerCase(Locale.ENGLISH);
     assertEquals(expected, shadeType.toString());
   }
 }

--- a/src/test/java/com/wcc/platform/domain/cms/attributes/style/ColorTypeTest.java
+++ b/src/test/java/com/wcc/platform/domain/cms/attributes/style/ColorTypeTest.java
@@ -1,0 +1,17 @@
+package com.wcc.platform.domain.cms.attributes.style;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Locale;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class ColorTypeTest {
+
+  @ParameterizedTest
+  @EnumSource(ColorType.class)
+  void testToString(ColorType colorType) {
+    String expected = colorType.name().toLowerCase(Locale.ENGLISH);
+    assertEquals(expected, colorType.toString());
+  }
+}

--- a/src/test/java/com/wcc/platform/domain/cms/attributes/style/ColorTypeTest.java
+++ b/src/test/java/com/wcc/platform/domain/cms/attributes/style/ColorTypeTest.java
@@ -10,8 +10,8 @@ class ColorTypeTest {
 
   @ParameterizedTest
   @EnumSource(ColorType.class)
-  void testToString(ColorType colorType) {
-    String expected = colorType.name().toLowerCase(Locale.ENGLISH);
+  void testToString(final ColorType colorType) {
+    final String expected = colorType.name().toLowerCase(Locale.ENGLISH);
     assertEquals(expected, colorType.toString());
   }
 }

--- a/src/test/java/com/wcc/platform/domain/cms/pages/programme/ProgrammePageTest.java
+++ b/src/test/java/com/wcc/platform/domain/cms/pages/programme/ProgrammePageTest.java
@@ -1,10 +1,12 @@
 package com.wcc.platform.domain.cms.pages.programme;
 
+import static com.wcc.platform.factories.SetUpStyleFactories.createCustomStyleTest;
 import static com.wcc.platform.factories.SetupFactories.createContactTest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.wcc.platform.domain.cms.attributes.Contact;
+import com.wcc.platform.domain.cms.attributes.style.CustomStyle;
 import com.wcc.platform.domain.cms.pages.Page;
 import com.wcc.platform.domain.platform.EventSection;
 import com.wcc.platform.domain.platform.Programme;
@@ -18,6 +20,7 @@ class ProgrammePageTest {
   private final Contact contact = createContactTest();
   private final List<Programme> programmeDetails = List.of(new Programme());
   private final EventSection eventSection = new EventSection();
+  private final CustomStyle customStyle = createCustomStyleTest();
 
   @Test
   @DisplayName("Given no-args constructor, when initialized, then fields should be null")
@@ -34,7 +37,8 @@ class ProgrammePageTest {
   @DisplayName(
       "Given all-args constructor, when initialized, then fields should be correctly assigned")
   void allArgsConstructor() {
-    ProgrammePage programmePage = new ProgrammePage(page, contact, programmeDetails, eventSection);
+    ProgrammePage programmePage =
+        new ProgrammePage(page, contact, programmeDetails, eventSection, customStyle);
 
     assertEquals(page, programmePage.getPage());
     assertEquals(contact, programmePage.getContact());
@@ -64,8 +68,10 @@ class ProgrammePageTest {
       "Given two identical ProgrammePage objects, "
           + "when compared, then they should be equal and hash codes should match")
   void equalsAndHashCode() {
-    ProgrammePage programmePage1 = new ProgrammePage(page, contact, programmeDetails, eventSection);
-    ProgrammePage programmePage2 = new ProgrammePage(page, contact, programmeDetails, eventSection);
+    ProgrammePage programmePage1 =
+        new ProgrammePage(page, contact, programmeDetails, eventSection, customStyle);
+    ProgrammePage programmePage2 =
+        new ProgrammePage(page, contact, programmeDetails, eventSection, customStyle);
 
     assertEquals(programmePage1, programmePage2);
     assertEquals(programmePage1.hashCode(), programmePage2.hashCode());
@@ -76,7 +82,8 @@ class ProgrammePageTest {
       "Given ProgrammePage, when toString is called, "
           + "then it should return correct string representation")
   void testToString() {
-    ProgrammePage programmePage = new ProgrammePage(page, contact, programmeDetails, eventSection);
+    ProgrammePage programmePage =
+        new ProgrammePage(page, contact, programmeDetails, eventSection, customStyle);
     String expected =
         "ProgrammePage(page="
             + page
@@ -86,6 +93,8 @@ class ProgrammePageTest {
             + programmeDetails
             + ", eventSection="
             + eventSection
+            + ", customStyle="
+            + customStyle
             + ")";
 
     assertEquals(expected, programmePage.toString());

--- a/src/test/java/com/wcc/platform/factories/SetUpStyleFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetUpStyleFactories.java
@@ -1,0 +1,21 @@
+package com.wcc.platform.factories;
+
+import com.wcc.platform.domain.cms.attributes.style.BackgroundColourStyle;
+import com.wcc.platform.domain.cms.attributes.style.ColorShadeType;
+import com.wcc.platform.domain.cms.attributes.style.ColorType;
+import com.wcc.platform.domain.cms.attributes.style.CustomStyle;
+
+/** Style set-up factories. */
+public class SetUpStyleFactories {
+
+  /** Create the filters object. */
+  public static CustomStyle createCustomStyleTest() {
+    return new CustomStyle(
+        new BackgroundColourStyle(ColorType.PRIMARY, ColorShadeType.LIGHT.toColorShade()));
+  }
+
+  public static CustomStyle backgroundSecondary() {
+    return new CustomStyle(
+        new BackgroundColourStyle(ColorType.SECONDARY, ColorShadeType.DARK.toColorShade()));
+  }
+}

--- a/src/test/java/com/wcc/platform/factories/SetupFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetupFactories.java
@@ -1,5 +1,7 @@
 package com.wcc.platform.factories;
 
+import static com.wcc.platform.factories.SetUpStyleFactories.backgroundSecondary;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -273,7 +275,7 @@ public class SetupFactories {
 
   /** Factory test for hero section. */
   public static HeroSection createHeroSectionTest() {
-    return new HeroSection("title", "hero description", createImageTest());
+    return new HeroSection("title", "hero description", createImageTest(), backgroundSecondary());
   }
 
   /** About Us factory for testing. */

--- a/src/test/java/com/wcc/platform/factories/SetupProgrammeFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetupProgrammeFactories.java
@@ -1,5 +1,7 @@
 package com.wcc.platform.factories;
 
+import static com.wcc.platform.factories.SetUpStyleFactories.createCustomStyleTest;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.wcc.platform.domain.cms.attributes.CmsIcon;
 import com.wcc.platform.domain.cms.attributes.LabelLink;
@@ -41,7 +43,8 @@ public class SetupProgrammeFactories {
         SetupFactories.createPageTest(),
         SetupFactories.createContactTest(),
         Collections.singletonList(createProgramme(UUID.randomUUID())),
-        SetupEventFactories.createEventSection());
+        SetupEventFactories.createEventSection(),
+        createCustomStyleTest());
   }
 
   /** Create Factory. */
@@ -70,7 +73,8 @@ public class SetupProgrammeFactories {
                 "Author of the book",
                 "test book description",
                 new LabelLink("Title Link", "Good read", "http://link"),
-                List.of()))
+                List.of(),
+                createCustomStyleTest()))
         .build();
   }
 

--- a/src/test/java/com/wcc/platform/factories/SetupProgrammeFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetupProgrammeFactories.java
@@ -74,7 +74,7 @@ public class SetupProgrammeFactories {
                 "test book description",
                 new LabelLink("Title Link", "Good read", "http://link"),
                 List.of(),
-                createCustomStyleTest()))
+                null))
         .build();
   }
 


### PR DESCRIPTION
## Description

Initialise custom style for background colours.
Only will be part of hero sections, but could be extended later for other components.

```
"customStyle": {
    "backgroundColour": {
      "color": "primary",
      "shade": {
        "name": "light",
        "value": 90
      }
    }
  }
```

## Related Issue

Closes https://github.com/Women-Coding-Community/wcc-backend/issues/188

## Change Type

- [x] Code Refactor

## Screenshots

![image](https://github.com/user-attachments/assets/786d24d6-118a-4404-a7c1-61174aa7ee26)

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->