### PR TITLE
feat: Migrate Mentorship Overview Page to use Database #176 

### DIFF
--- a/src/main/java/com/wcc/platform/domain/cms/pages/mentorship/MentorshipPage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/mentorship/MentorshipPage.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.NotNull;
  * @param feedbackSection section related to mentorship feedbacks
  */
 public record MentorshipPage(
+    @NotNull String id,
     @NotNull Page page,
     @NotNull PageSection mentorSection,
     @NotNull PageSection menteeSection,

--- a/src/main/resources/mentorshipPage.json
+++ b/src/main/resources/mentorshipPage.json
@@ -1,4 +1,5 @@
 {
+  "id": "page:MENTORSHIP_OVERVIEW",
   "page": {
     "title": "Mentorship Programme",
     "description": "Mentorship is a fantastic way to get support for your personal growth and career development. Mentorship relationships can be rewarding to both people, personally and professionally. It's an opportunity to develop communication skills, expand your viewpoints, and consider new ways of approaching situations. And both partners can advance their careers in the process."

--- a/src/test/java/com/wcc/platform/factories/SetupMentorshipFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetupMentorshipFactories.java
@@ -5,6 +5,7 @@ import static com.wcc.platform.factories.SetupFactories.createPageSectionTest;
 import static com.wcc.platform.factories.SetupFactories.createPageTest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.wcc.platform.domain.cms.PageType;
 import com.wcc.platform.domain.cms.pages.mentorship.FeedbackItem;
 import com.wcc.platform.domain.cms.pages.mentorship.FeedbackSection;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipPage;
@@ -27,7 +28,9 @@ public class SetupMentorshipFactories {
 
   /** Test factory. */
   public static MentorshipPage createMentorshipPageTest() {
+    final String pageId = PageType.MENTORSHIP.getId();
     return new MentorshipPage(
+        pageId,
         createPageTest(),
         createPageSectionTest("Mentor"),
         createPageSectionTest("Mentee"),

--- a/src/test/java/com/wcc/platform/service/MentorshipServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/MentorshipServiceTest.java
@@ -54,8 +54,6 @@ class MentorshipServiceTest {
 
   @Test
   void whenGetOverviewGivenRecordNotInDatabaseThenThrowException() throws IOException {
-    // var page = createMentorshipPageTest();
-    // var mapPage = objectMapper.convertValue(page, Map.class);
 
     when(pageRepository.findById(PageType.MENTORSHIP.getId())).thenReturn(Optional.empty());
 

--- a/src/test/java/com/wcc/platform/service/MentorshipServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/MentorshipServiceTest.java
@@ -3,16 +3,19 @@ package com.wcc.platform.service;
 import static com.wcc.platform.factories.SetupMentorshipFactories.createMentorshipPageTest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.wcc.platform.domain.cms.PageType;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipPage;
-import com.wcc.platform.domain.exceptions.PlatformInternalException;
+import com.wcc.platform.domain.exceptions.ContentNotFoundException;
+import com.wcc.platform.repository.PageRepository;
 import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,19 +25,27 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class MentorshipServiceTest {
   private ObjectMapper objectMapper;
+  private PageRepository pageRepository;
 
   private MentorshipService service;
 
   @BeforeEach
   void setUp() {
     objectMapper = Mockito.mock(ObjectMapper.class);
-    service = new MentorshipService(objectMapper);
+    objectMapper.registerModule(new JavaTimeModule());
+    pageRepository = Mockito.mock(PageRepository.class);
+    service = new MentorshipService(objectMapper, pageRepository);
   }
 
   @Test
-  void whenGetOverviewGivenValidJson() throws IOException {
-    var page = createMentorshipPageTest("mentorshipPage.json");
-    when(objectMapper.readValue(any(String.class), eq(MentorshipPage.class))).thenReturn(page);
+  @SuppressWarnings("unchecked")
+  void whenGetOverviewGivenRecordExistingInDatabaseThenReturnValidResponse() {
+    var page = createMentorshipPageTest();
+    var mapPage =
+        new ObjectMapper().registerModule(new JavaTimeModule()).convertValue(page, Map.class);
+
+    when(pageRepository.findById(PageType.MENTORSHIP.getId())).thenReturn(Optional.of(mapPage));
+    when(objectMapper.convertValue(anyMap(), eq(MentorshipPage.class))).thenReturn(page);
 
     var response = service.getOverview();
 
@@ -42,12 +53,14 @@ class MentorshipServiceTest {
   }
 
   @Test
-  void whenGetOverviewGivenInvalidJson() throws IOException {
-    when(objectMapper.readValue(anyString(), eq(MentorshipPage.class)))
-        .thenThrow(new JsonProcessingException("Invalid JSON") {});
+  void whenGetOverviewGivenRecordNotInDatabaseThenThrowException() throws IOException {
+    // var page = createMentorshipPageTest();
+    // var mapPage = objectMapper.convertValue(page, Map.class);
 
-    var exception = assertThrows(PlatformInternalException.class, service::getOverview);
-    
-    assertEquals("Invalid JSON", exception.getMessage());
+    when(pageRepository.findById(PageType.MENTORSHIP.getId())).thenReturn(Optional.empty());
+
+    var exception = assertThrows(ContentNotFoundException.class, service::getOverview);
+
+    assertEquals("Content of Page MENTORSHIP not found", exception.getMessage());
   }
 }

--- a/src/test/resources/mentorshipPage.json
+++ b/src/test/resources/mentorshipPage.json
@@ -1,4 +1,5 @@
 {
+  "id": "page:MENTORSHIP_OVERVIEW",
   "page": {
     "title": "Mentorship Programme",
     "description": "Mentorship is a fantastic way to get support for your personal growth and career development."


### PR DESCRIPTION
#176

## Description

Current Mentorship API is using a json file as a mean to store data. We need to start using the database repository instead of a file. 

There are already general POST/DELETE functionalities for any page to DB. This PR updates the GET API functionality for Membership Overview page to read from DB and updates tests to reflect the change.

The change is required so that we can start using the database as persistent storage.

<!--
Example PR: https://github.com/Women-Coding-Community/wcc-backend/pull/118
-->

## Related Issue

Please link to the issue here
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Change Type

- [ ] Bug Fix
- [x] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Test
- [ ] Other

## Screenshots

1. Create page Mentorship Overview using POST
<img width="1487" alt="Screenshot 2025-01-22 at 20 35 55" src="https://github.com/user-attachments/assets/5febaa75-52ca-4019-8a24-34ad1a51e539" />

page created successfully

<img width="1437" alt="Screenshot 2025-01-22 at 20 37 11" src="https://github.com/user-attachments/assets/172d9b95-2ed3-4b56-ae3d-f7c41629e316" />


2. Get page Mentorship Overview using GET request

<img width="1483" alt="Screenshot 2025-01-22 at 20 28 39" src="https://github.com/user-attachments/assets/3d92c786-33bb-450b-84db-31302acf0bf1" />

<!--  Please include screenshots from the Swagger API. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->