### PR TITLE
Feat 177 migrate events page to use db

### DIFF
--- a/src/main/java/com/wcc/platform/domain/cms/pages/events/EventsPage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/events/EventsPage.java
@@ -2,15 +2,15 @@ package com.wcc.platform.domain.cms.pages.events;
 
 import com.wcc.platform.domain.cms.attributes.Contact;
 import com.wcc.platform.domain.cms.attributes.HeroSection;
-import com.wcc.platform.domain.cms.pages.Page;
 import com.wcc.platform.domain.cms.pages.PageData;
 import com.wcc.platform.domain.cms.pages.PageMetadata;
 import com.wcc.platform.domain.platform.Event;
+import jakarta.validation.constraints.NotNull;
 
 /** Events page details. */
 public record EventsPage(
-    PageMetadata metadata,
-    HeroSection heroSection,
-    Page page,
-    Contact contact,
-    PageData<Event> data) {}
+    @NotNull String id,
+    @NotNull PageMetadata metadata,
+    @NotNull HeroSection hero,
+    @NotNull Contact contact,
+    @NotNull PageData<Event> data) {}

--- a/src/main/java/com/wcc/platform/service/EventService.java
+++ b/src/main/java/com/wcc/platform/service/EventService.java
@@ -1,16 +1,16 @@
 package com.wcc.platform.service;
 
 import static com.wcc.platform.domain.cms.PageType.EVENTS;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wcc.platform.domain.cms.pages.PageData;
 import com.wcc.platform.domain.cms.pages.PageMetadata;
 import com.wcc.platform.domain.cms.pages.Pagination;
 import com.wcc.platform.domain.cms.pages.events.EventsPage;
+import com.wcc.platform.domain.exceptions.ContentNotFoundException;
+import com.wcc.platform.domain.exceptions.ContentNotFoundException;
 import com.wcc.platform.domain.exceptions.PlatformInternalException;
 import com.wcc.platform.domain.platform.Event;
-import com.wcc.platform.utils.FileUtil;
+import com.wcc.platform.repository.PageRepository;
 import com.wcc.platform.utils.PaginationUtil;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,43 +21,48 @@ import org.springframework.stereotype.Service;
 public class EventService {
 
   private final ObjectMapper objectMapper;
+  private final PageRepository pageRepository;
 
   @Autowired
-  public EventService(final ObjectMapper objectMapper) {
+  public EventService(final ObjectMapper objectMapper, final PageRepository pageRepository) {
     this.objectMapper = objectMapper;
+    this.pageRepository = pageRepository;
   }
 
   /**
-   * Read Json and convert to paginated event page.
+   * Find Event Page in DB and convert to POJO paginated event page.
    *
    * @return POJO eventsPage
    */
   public EventsPage getEvents(final int currentPage, final int pageSize) {
-    try {
-      final var data = FileUtil.readFileAsString(EVENTS.getFileName());
+    final var pageOptional = pageRepository.findById(EVENTS.getId());
+    if (pageOptional.isPresent()) {
+      try {
+        final var page = objectMapper.convertValue(pageOptional.get(), EventsPage.class);
+        final var allEvents = page.data().items();
 
-      final var page = objectMapper.readValue(data, EventsPage.class);
-      final var allEvents = page.data().items();
+        final List<Event> paginatedEvents =
+            PaginationUtil.getPaginatedResult(allEvents, currentPage, pageSize);
 
-      final List<Event> paginatedEvents =
-          PaginationUtil.getPaginatedResult(allEvents, currentPage, pageSize);
-      final Pagination paginationRecord =
-          new Pagination(
-              allEvents.size(),
-              PaginationUtil.getTotalPages(allEvents, pageSize),
-              currentPage,
-              pageSize);
-      final PageData<Event> eventPageData = new PageData<>(paginatedEvents);
+        final Pagination paginationRecord =
+            new Pagination(
+                allEvents.size(),
+                PaginationUtil.getTotalPages(allEvents, pageSize),
+                currentPage,
+                pageSize);
+        final PageData<Event> eventPageData = new PageData<>(paginatedEvents);
 
-      return new EventsPage(
-          new PageMetadata(paginationRecord),
-          page.heroSection(),
-          page.page(),
-          page.contact(),
-          eventPageData);
+        return new EventsPage(
+            EVENTS.getId(),
+            new PageMetadata(paginationRecord),
+            page.hero(),
+            page.contact(),
+            eventPageData);
 
-    } catch (JsonProcessingException e) {
-      throw new PlatformInternalException(e.getMessage(), e);
+      } catch (IllegalArgumentException e) {
+        throw new PlatformInternalException(e.getMessage(), e);
+      }
     }
+    throw new ContentNotFoundException(EVENTS);
   }
 }

--- a/src/main/resources/eventsPage.json
+++ b/src/main/resources/eventsPage.json
@@ -1,4 +1,5 @@
 {
+  "id": "page:EVENTS",
   "metadata": {
     "pagination": {
       "totalItems": 1,

--- a/src/test/java/com/wcc/platform/factories/SetupEventFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetupEventFactories.java
@@ -5,6 +5,7 @@ import static com.wcc.platform.factories.SetupFactories.createHeroSectionTest;
 import static com.wcc.platform.factories.SetupFactories.createPageTest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.wcc.platform.domain.cms.PageType;
 import com.wcc.platform.domain.cms.attributes.LabelLink;
 import com.wcc.platform.domain.cms.pages.PageData;
 import com.wcc.platform.domain.cms.pages.PageMetadata;
@@ -60,7 +61,7 @@ public class SetupEventFactories {
         new PageMetadata(createPaginationTest(items, DEFAULT_CURRENT_PAGE, DEFAULT_PAGE_SIZE));
     var data = new PageData<>(items);
     return new EventsPage(
-        metadata, createHeroSectionTest(), createPageTest(), createContactTest(), data);
+        PageType.EVENTS.getId(), metadata, createHeroSectionTest(), createContactTest(), data);
   }
 
   /**

--- a/src/test/java/com/wcc/platform/service/EventServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/EventServiceTest.java
@@ -6,16 +6,19 @@ import static com.wcc.platform.factories.SetupEventFactories.createEventPageTest
 import static com.wcc.platform.factories.SetupEventFactories.createEventTest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.wcc.platform.domain.cms.PageType;
 import com.wcc.platform.domain.cms.pages.events.EventsPage;
-import com.wcc.platform.domain.exceptions.PlatformInternalException;
-import java.io.IOException;
+import com.wcc.platform.domain.exceptions.ContentNotFoundException;
+import com.wcc.platform.repository.PageRepository;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -24,33 +27,39 @@ public class EventServiceTest {
 
   private ObjectMapper objectMapper;
   private EventService service;
+  private PageRepository pageRepository;
 
   @BeforeEach
   void setUp() {
     objectMapper = Mockito.mock(ObjectMapper.class);
-    service = new EventService(objectMapper);
+    pageRepository = Mockito.mock(PageRepository.class);
+
+    service = new EventService(objectMapper, pageRepository);
   }
 
   @Test
-  void whenGetEventsValidJson() throws IOException {
-    var page = createEventPageTest(List.of(createEventTest()));
-    when(objectMapper.readValue(anyString(), eq(EventsPage.class))).thenReturn(page);
+  void whenGetEventsGivenRecordExistingInDatabaseThenReturnValidResponse() {
+    var eventsPage = createEventPageTest(List.of(createEventTest()));
+    var mapPage =
+        new ObjectMapper().registerModule(new JavaTimeModule()).convertValue(eventsPage, Map.class);
+
+    when(pageRepository.findById(PageType.EVENTS.getId())).thenReturn(Optional.of(mapPage));
+    when(objectMapper.convertValue(anyMap(), eq(EventsPage.class))).thenReturn(eventsPage);
 
     var response = service.getEvents(DEFAULT_CURRENT_PAGE, DEFAULT_PAGE_SIZE);
 
-    assertEquals(page, response);
+    assertEquals(eventsPage, response);
   }
 
   @Test
-  void whenGetEventsInValidJson() throws IOException {
-    when(objectMapper.readValue(anyString(), eq(EventsPage.class)))
-        .thenThrow(new JsonProcessingException("Invalid JSON") {});
+  void whenGetEventsGivenRecordNonExistingInDatabase() {
+    var exception = assertThrows(
+        ContentNotFoundException.class,
+        () -> service.getEvents(DEFAULT_CURRENT_PAGE, DEFAULT_PAGE_SIZE)
+    );
 
-    var exception =
-        assertThrows(
-            PlatformInternalException.class,
-            () -> service.getEvents(DEFAULT_CURRENT_PAGE, DEFAULT_CURRENT_PAGE));
+    assertEquals("Content of Page EVENTS not found", exception.getMessage());
 
-    assertEquals("Invalid JSON", exception.getMessage());
   }
+  
 }


### PR DESCRIPTION
## Description

Instead of reading Events Page from a file, should read from database

<!--
Example PR: https://github.com/Women-Coding-Community/wcc-backend/pull/118
-->

## Related Issue

Please link to the issue here
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Change Type

- [ ] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Test
- [ ] Other

## Screenshots

<!--  Please include screenshots from the Swagger API. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [ ] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->