### PR TITLE
chore: Rename Page java Class and respective REST Response

### DIFF
--- a/src/main/java/com/wcc/platform/domain/cms/attributes/CommonSection.java
+++ b/src/main/java/com/wcc/platform/domain/cms/attributes/CommonSection.java
@@ -1,9 +1,6 @@
-package com.wcc.platform.domain.cms.pages;
+package com.wcc.platform.domain.cms.attributes;
 
-import com.wcc.platform.domain.cms.attributes.Image;
-import com.wcc.platform.domain.cms.attributes.LabelLink;
 import com.wcc.platform.domain.cms.attributes.style.CustomStyle;
-import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -21,9 +18,9 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode
 @Builder
-public class Page {
+public class CommonSection {
   private UUID id;
-  @NotNull private String title;
+  private String title;
   private String subtitle;
   private String description;
   private LabelLink link;

--- a/src/main/java/com/wcc/platform/domain/cms/attributes/CommonSection.java
+++ b/src/main/java/com/wcc/platform/domain/cms/attributes/CommonSection.java
@@ -2,7 +2,6 @@ package com.wcc.platform.domain.cms.attributes;
 
 import com.wcc.platform.domain.cms.attributes.style.CustomStyle;
 import java.util.List;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -19,7 +18,6 @@ import lombok.ToString;
 @EqualsAndHashCode
 @Builder
 public class CommonSection {
-  private UUID id;
   private String title;
   private String subtitle;
   private String description;

--- a/src/main/java/com/wcc/platform/domain/cms/attributes/ListSection.java
+++ b/src/main/java/com/wcc/platform/domain/cms/attributes/ListSection.java
@@ -1,0 +1,8 @@
+package com.wcc.platform.domain.cms.attributes;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+/** CMS Simple ListSection to be included in the pages. */
+public record ListSection<T>(
+    @NotBlank String title, String description, LabelLink link, List<T> items) {}

--- a/src/main/java/com/wcc/platform/domain/cms/attributes/PageSection.java
+++ b/src/main/java/com/wcc/platform/domain/cms/attributes/PageSection.java
@@ -1,8 +1,0 @@
-package com.wcc.platform.domain.cms.attributes;
-
-import jakarta.validation.constraints.NotBlank;
-import java.util.List;
-
-/** CMS Page Section which allows to listed related topics. */
-public record PageSection(
-    @NotBlank String title, String description, LabelLink link, List<String> topics) {}

--- a/src/main/java/com/wcc/platform/domain/cms/pages/AboutUsPage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/AboutUsPage.java
@@ -2,6 +2,7 @@ package com.wcc.platform.domain.cms.pages;
 
 import com.wcc.platform.domain.cms.attributes.Contact;
 import com.wcc.platform.domain.cms.attributes.HeroSection;
+import com.wcc.platform.domain.cms.attributes.ListSection;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -16,5 +17,5 @@ import java.util.List;
 public record AboutUsPage(
     @NotNull String id,
     @NotNull HeroSection heroSection,
-    @NotEmpty List<Section<String>> items,
+    @NotEmpty List<ListSection<String>> items,
     @NotEmpty Contact contact) {}

--- a/src/main/java/com/wcc/platform/domain/cms/pages/CodeOfConductPage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/CodeOfConductPage.java
@@ -10,11 +10,11 @@ import java.util.List;
 /**
  * CMS Code of conduct page.
  *
- * @param commonSection CommonSection details as title and description
+ * @param section CommonSection details as title and description
  * @param items all details
  */
 public record CodeOfConductPage(
     @NotNull String id,
     @NotNull HeroSection heroSection,
-    @NotNull CommonSection commonSection,
+    @NotNull CommonSection section,
     @NotEmpty List<ListSection<String>> items) {}

--- a/src/main/java/com/wcc/platform/domain/cms/pages/CodeOfConductPage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/CodeOfConductPage.java
@@ -1,6 +1,8 @@
 package com.wcc.platform.domain.cms.pages;
 
+import com.wcc.platform.domain.cms.attributes.CommonSection;
 import com.wcc.platform.domain.cms.attributes.HeroSection;
+import com.wcc.platform.domain.cms.attributes.ListSection;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -8,11 +10,11 @@ import java.util.List;
 /**
  * CMS Code of conduct page.
  *
- * @param page Page details as title and description
+ * @param commonSection CommonSection details as title and description
  * @param items all details
  */
 public record CodeOfConductPage(
     @NotNull String id,
     @NotNull HeroSection heroSection,
-    @NotNull Page page,
-    @NotEmpty List<Section<String>> items) {}
+    @NotNull CommonSection commonSection,
+    @NotEmpty List<ListSection<String>> items) {}

--- a/src/main/java/com/wcc/platform/domain/cms/pages/CollaboratorPage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/CollaboratorPage.java
@@ -1,5 +1,6 @@
 package com.wcc.platform.domain.cms.pages;
 
+import com.wcc.platform.domain.cms.attributes.CommonSection;
 import com.wcc.platform.domain.cms.attributes.Contact;
 import com.wcc.platform.domain.cms.attributes.HeroSection;
 import com.wcc.platform.domain.platform.Member;
@@ -12,6 +13,6 @@ public record CollaboratorPage(
     @NotNull String id,
     @NotNull PageMetadata metadata,
     @NotNull HeroSection heroSection,
-    @NotNull Page page,
+    @NotNull CommonSection commonSection,
     @NotNull Contact contact,
     @NotEmpty List<Member> collaborators) {}

--- a/src/main/java/com/wcc/platform/domain/cms/pages/CollaboratorPage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/CollaboratorPage.java
@@ -13,6 +13,6 @@ public record CollaboratorPage(
     @NotNull String id,
     @NotNull PageMetadata metadata,
     @NotNull HeroSection heroSection,
-    @NotNull CommonSection commonSection,
+    @NotNull CommonSection section,
     @NotNull Contact contact,
     @NotEmpty List<Member> collaborators) {}

--- a/src/main/java/com/wcc/platform/domain/cms/pages/LandingPage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/LandingPage.java
@@ -1,6 +1,8 @@
 package com.wcc.platform.domain.cms.pages;
 
+import com.wcc.platform.domain.cms.attributes.CommonSection;
 import com.wcc.platform.domain.cms.attributes.HeroSection;
+import com.wcc.platform.domain.cms.attributes.ListSection;
 import com.wcc.platform.domain.cms.pages.programme.ProgrammeItem;
 import com.wcc.platform.domain.platform.Event;
 import jakarta.validation.constraints.NotNull;
@@ -21,9 +23,9 @@ import lombok.ToString;
 public class LandingPage {
   @NotNull private String id;
   @NotNull private HeroSection heroSection;
-  @NotNull private Page fullBannerSection;
-  @NotNull private Section<ProgrammeItem> programmes;
-  private Section<Event> announcements;
-  private Section<Event> events;
-  @NotNull private Page volunteerSection;
+  @NotNull private CommonSection fullBannerSection;
+  @NotNull private ListSection<ProgrammeItem> programmes;
+  private ListSection<Event> announcements;
+  private ListSection<Event> events;
+  @NotNull private CommonSection volunteerSection;
 }

--- a/src/main/java/com/wcc/platform/domain/cms/pages/Section.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/Section.java
@@ -1,9 +1,0 @@
-package com.wcc.platform.domain.cms.pages;
-
-import com.wcc.platform.domain.cms.attributes.LabelLink;
-import jakarta.validation.constraints.NotBlank;
-import java.util.List;
-
-/** CMS Simple Section to be included in the pages. */
-public record Section<T>(
-    @NotBlank String title, String description, LabelLink link, List<T> items) {}

--- a/src/main/java/com/wcc/platform/domain/cms/pages/TeamPage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/TeamPage.java
@@ -1,5 +1,6 @@
 package com.wcc.platform.domain.cms.pages;
 
+import com.wcc.platform.domain.cms.attributes.CommonSection;
 import com.wcc.platform.domain.cms.attributes.Contact;
 import com.wcc.platform.domain.cms.attributes.HeroSection;
 import com.wcc.platform.domain.cms.attributes.MemberByType;
@@ -9,6 +10,6 @@ import jakarta.validation.constraints.NotNull;
 public record TeamPage(
     @NotNull String id,
     @NotNull HeroSection heroSection,
-    @NotNull Page page,
+    @NotNull CommonSection commonSection,
     @NotNull Contact contact,
     @NotNull MemberByType membersByType) {}

--- a/src/main/java/com/wcc/platform/domain/cms/pages/TeamPage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/TeamPage.java
@@ -10,6 +10,6 @@ import jakarta.validation.constraints.NotNull;
 public record TeamPage(
     @NotNull String id,
     @NotNull HeroSection heroSection,
-    @NotNull CommonSection commonSection,
+    @NotNull CommonSection section,
     @NotNull Contact contact,
     @NotNull MemberByType membersByType) {}

--- a/src/main/java/com/wcc/platform/domain/cms/pages/events/EventsPage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/events/EventsPage.java
@@ -13,6 +13,6 @@ public record EventsPage(
     @NotNull String id,
     @NotNull PageMetadata metadata,
     @NotNull HeroSection heroSection,
-    @NotNull CommonSection commonSection,
+    @NotNull CommonSection section,
     @NotNull Contact contact,
     @NotNull PageData<Event> data) {}

--- a/src/main/java/com/wcc/platform/domain/cms/pages/events/EventsPage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/events/EventsPage.java
@@ -1,8 +1,8 @@
 package com.wcc.platform.domain.cms.pages.events;
 
+import com.wcc.platform.domain.cms.attributes.CommonSection;
 import com.wcc.platform.domain.cms.attributes.Contact;
 import com.wcc.platform.domain.cms.attributes.HeroSection;
-import com.wcc.platform.domain.cms.pages.Page;
 import com.wcc.platform.domain.cms.pages.PageData;
 import com.wcc.platform.domain.cms.pages.PageMetadata;
 import com.wcc.platform.domain.platform.Event;
@@ -13,6 +13,6 @@ public record EventsPage(
     @NotNull String id,
     @NotNull PageMetadata metadata,
     @NotNull HeroSection heroSection,
-    @NotNull Page page,
+    @NotNull CommonSection commonSection,
     @NotNull Contact contact,
     @NotNull PageData<Event> data) {}

--- a/src/main/java/com/wcc/platform/domain/cms/pages/mentorship/MentorshipPage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/mentorship/MentorshipPage.java
@@ -1,14 +1,14 @@
 package com.wcc.platform.domain.cms.pages.mentorship;
 
+import com.wcc.platform.domain.cms.attributes.CommonSection;
 import com.wcc.platform.domain.cms.attributes.HeroSection;
-import com.wcc.platform.domain.cms.attributes.PageSection;
-import com.wcc.platform.domain.cms.pages.Page;
+import com.wcc.platform.domain.cms.attributes.ListSection;
 import jakarta.validation.constraints.NotNull;
 
 /**
  * CMS Mentorship Page Overview details.
  *
- * @param page basic page details
+ * @param commonSection basic page details
  * @param mentorSection section to highlight why you apply to a become a mentor
  * @param menteeSection section to highlight why you apply to a become a mentee
  * @param feedbackSection section related to mentorship feedbacks
@@ -16,7 +16,7 @@ import jakarta.validation.constraints.NotNull;
 public record MentorshipPage(
     @NotNull String id,
     @NotNull HeroSection heroSection,
-    @NotNull Page page,
-    @NotNull PageSection mentorSection,
-    @NotNull PageSection menteeSection,
+    @NotNull CommonSection commonSection,
+    @NotNull ListSection<String> mentorSection,
+    @NotNull ListSection<String> menteeSection,
     FeedbackSection feedbackSection) {}

--- a/src/main/java/com/wcc/platform/domain/cms/pages/mentorship/MentorshipPage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/mentorship/MentorshipPage.java
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.NotNull;
 /**
  * CMS Mentorship Page Overview details.
  *
- * @param commonSection basic page details
+ * @param section basic page details
  * @param mentorSection section to highlight why you apply to a become a mentor
  * @param menteeSection section to highlight why you apply to a become a mentee
  * @param feedbackSection section related to mentorship feedbacks
@@ -16,7 +16,7 @@ import jakarta.validation.constraints.NotNull;
 public record MentorshipPage(
     @NotNull String id,
     @NotNull HeroSection heroSection,
-    @NotNull CommonSection commonSection,
+    @NotNull CommonSection section,
     @NotNull ListSection<String> mentorSection,
     @NotNull ListSection<String> menteeSection,
     FeedbackSection feedbackSection) {}

--- a/src/main/java/com/wcc/platform/domain/cms/pages/programme/ProgrammePage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/programme/ProgrammePage.java
@@ -1,9 +1,9 @@
 package com.wcc.platform.domain.cms.pages.programme;
 
+import com.wcc.platform.domain.cms.attributes.CommonSection;
 import com.wcc.platform.domain.cms.attributes.Contact;
 import com.wcc.platform.domain.cms.attributes.HeroSection;
 import com.wcc.platform.domain.cms.attributes.style.CustomStyle;
-import com.wcc.platform.domain.cms.pages.Page;
 import com.wcc.platform.domain.platform.EventSection;
 import com.wcc.platform.domain.platform.Programme;
 import jakarta.validation.constraints.NotBlank;
@@ -27,7 +27,7 @@ import lombok.ToString;
 public class ProgrammePage {
   @NotBlank private String id;
   @NotNull private HeroSection heroSection;
-  @NotNull private Page page;
+  @NotNull private CommonSection commonSection;
   @NotNull private Contact contact;
   @NotEmpty private List<Programme> programmeDetails;
   @NotNull private EventSection eventSection;

--- a/src/main/java/com/wcc/platform/domain/cms/pages/programme/ProgrammePage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/programme/ProgrammePage.java
@@ -27,7 +27,7 @@ import lombok.ToString;
 public class ProgrammePage {
   @NotBlank private String id;
   @NotNull private HeroSection heroSection;
-  @NotNull private CommonSection commonSection;
+  @NotNull private CommonSection section;
   @NotNull private Contact contact;
   @NotEmpty private List<Programme> programmeDetails;
   @NotNull private EventSection eventSection;

--- a/src/main/java/com/wcc/platform/domain/platform/Programme.java
+++ b/src/main/java/com/wcc/platform/domain/platform/Programme.java
@@ -1,6 +1,6 @@
 package com.wcc.platform.domain.platform;
 
-import com.wcc.platform.domain.cms.pages.Page;
+import com.wcc.platform.domain.cms.attributes.CommonSection;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -20,5 +20,5 @@ import lombok.ToString;
 public class Programme {
   @NotBlank private String title;
   @NotBlank private String description;
-  @NotNull private Page card;
+  @NotNull private CommonSection card;
 }

--- a/src/main/java/com/wcc/platform/service/CmsService.java
+++ b/src/main/java/com/wcc/platform/service/CmsService.java
@@ -118,7 +118,7 @@ public class CmsService {
             PageType.COLLABORATOR.getId(),
             new PageMetadata(paginationRecord),
             page.heroSection(),
-            page.commonSection(),
+            page.section(),
             page.contact(),
             pagCollaborators);
 

--- a/src/main/java/com/wcc/platform/service/CmsService.java
+++ b/src/main/java/com/wcc/platform/service/CmsService.java
@@ -118,7 +118,7 @@ public class CmsService {
             PageType.COLLABORATOR.getId(),
             new PageMetadata(paginationRecord),
             page.heroSection(),
-            page.page(),
+            page.commonSection(),
             page.contact(),
             pagCollaborators);
 

--- a/src/main/java/com/wcc/platform/service/EventService.java
+++ b/src/main/java/com/wcc/platform/service/EventService.java
@@ -56,7 +56,7 @@ public class EventService {
             EVENTS.getId(),
             new PageMetadata(paginationRecord),
             page.heroSection(),
-            page.commonSection(),
+            page.section(),
             page.contact(),
             eventPageData);
 

--- a/src/main/java/com/wcc/platform/service/EventService.java
+++ b/src/main/java/com/wcc/platform/service/EventService.java
@@ -56,7 +56,7 @@ public class EventService {
             EVENTS.getId(),
             new PageMetadata(paginationRecord),
             page.heroSection(),
-            page.page(),
+            page.commonSection(),
             page.contact(),
             eventPageData);
 

--- a/src/main/resources/bookClubPage.json
+++ b/src/main/resources/bookClubPage.json
@@ -10,7 +10,7 @@
       }
     ]
   },
-  "page": {
+  "commonSection": {
     "description": "What sets our book club apart are the lively conversations, valuable insights and an opportunity to connect with like-minded individuals. The books we read are selected by the community, offering a diverse selection of tech books and essential soft skills topics.The book club meets monthly to share views, exchange ideas, and inspire personal and professional growth."
   },
   "contact": {

--- a/src/main/resources/bookClubPage.json
+++ b/src/main/resources/bookClubPage.json
@@ -10,7 +10,7 @@
       }
     ]
   },
-  "commonSection": {
+  "section": {
     "description": "What sets our book club apart are the lively conversations, valuable insights and an opportunity to connect with like-minded individuals. The books we read are selected by the community, offering a diverse selection of tech books and essential soft skills topics.The book club meets monthly to share views, exchange ideas, and inspire personal and professional growth."
   },
   "contact": {

--- a/src/main/resources/codeOfConductPage.json
+++ b/src/main/resources/codeOfConductPage.json
@@ -3,7 +3,7 @@
   "heroSection": {
     "title": "WCC Code of Conduct"
   },
-  "page": {
+  "commonSection": {
     "description": "At Women Coding Community we are committed to a vibrant, supportive community where women can network, share experiences, and foster professional relationships, regardless of age, gender, visible or invisible disability, ethnicity, gender expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, sexual orientation or preferred programming language(s)."
   },
   "items": [

--- a/src/main/resources/codeOfConductPage.json
+++ b/src/main/resources/codeOfConductPage.json
@@ -3,7 +3,7 @@
   "heroSection": {
     "title": "WCC Code of Conduct"
   },
-  "commonSection": {
+  "section": {
     "description": "At Women Coding Community we are committed to a vibrant, supportive community where women can network, share experiences, and foster professional relationships, regardless of age, gender, visible or invisible disability, ethnicity, gender expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, sexual orientation or preferred programming language(s)."
   },
   "items": [

--- a/src/main/resources/collaboratorPage.json
+++ b/src/main/resources/collaboratorPage.json
@@ -11,7 +11,7 @@
   "heroSection": {
     "title": "WCC Collaborators"
   },
-  "page": {
+  "commonSection": {
     "description": "Our collaborators are the backbone of our community, offering vital expertise and support that drive our initiatives forward and enhance our digital presence."
   },
   "contact": {

--- a/src/main/resources/collaboratorPage.json
+++ b/src/main/resources/collaboratorPage.json
@@ -11,7 +11,7 @@
   "heroSection": {
     "title": "WCC Collaborators"
   },
-  "commonSection": {
+  "section": {
     "description": "Our collaborators are the backbone of our community, offering vital expertise and support that drive our initiatives forward and enhance our digital presence."
   },
   "contact": {

--- a/src/main/resources/eventsPage.json
+++ b/src/main/resources/eventsPage.json
@@ -18,7 +18,7 @@
       }
     ]
   },
-  "commonSection": {
+  "section": {
     "description": "Join the Women Coding Community for events and meetups that enhance your skills, deepen your knowledge, and expand your professional network.\n\nOur events include webinars, hands-on workshops, study groups, panel discussions, and keynotes with industry experts. Whether online or in-person, these gatherings offer valuable opportunities to share insights, learn collaboratively, and stay updated on the latest trends. Connect, grow, and thrive with fellow members in a supportive environment."
   },
   "contact": {

--- a/src/main/resources/eventsPage.json
+++ b/src/main/resources/eventsPage.json
@@ -18,7 +18,7 @@
       }
     ]
   },
-  "page": {
+  "commonSection": {
     "description": "Join the Women Coding Community for events and meetups that enhance your skills, deepen your knowledge, and expand your professional network.\n\nOur events include webinars, hands-on workshops, study groups, panel discussions, and keynotes with industry experts. Whether online or in-person, these gatherings offer valuable opportunities to share insights, learn collaboratively, and stay updated on the latest trends. Connect, grow, and thrive with fellow members in a supportive environment."
   },
   "contact": {

--- a/src/main/resources/mentorshipPage.json
+++ b/src/main/resources/mentorshipPage.json
@@ -3,7 +3,7 @@
   "heroSection": {
     "title": "Mentorship Programme"
   },
-  "commonSection": {
+  "section": {
     "description": "Mentorship is a fantastic way to get support for your personal growth and career development. Mentorship relationships can be rewarding to both people, personally and professionally. It's an opportunity to develop communication skills, expand your viewpoints, and consider new ways of approaching situations. And both partners can advance their careers in the process."
   },
   "mentorSection": {

--- a/src/main/resources/mentorshipPage.json
+++ b/src/main/resources/mentorshipPage.json
@@ -3,13 +3,13 @@
   "heroSection": {
     "title": "Mentorship Programme"
   },
-  "page": {
+  "commonSection": {
     "description": "Mentorship is a fantastic way to get support for your personal growth and career development. Mentorship relationships can be rewarding to both people, personally and professionally. It's an opportunity to develop communication skills, expand your viewpoints, and consider new ways of approaching situations. And both partners can advance their careers in the process."
   },
   "mentorSection": {
     "title": "Become a Mentor",
     "description": "You should apply to be a mentor if you:",
-    "topics": [
+    "items": [
       "Want to extend your professional network",
       "Want to contribute to the community",
       "You are ready to share expertise",
@@ -23,7 +23,7 @@
   "menteeSection": {
     "title": "Become a Mentee",
     "description": "You should apply to be a mentee if you:",
-    "topics": [
+    "items": [
       "Want to start career in software engineering",
       "Want to find a better job",
       "Want to be promoted at work",

--- a/src/main/resources/teamPage.json
+++ b/src/main/resources/teamPage.json
@@ -3,7 +3,7 @@
   "heroSection": {
     "title": "WCC Core Team"
   },
-  "page": {
+  "commonSection": {
     "description": "The core team of our community is composed of visionary directors and dynamic leaders, who bring a wealth of experience and dedication to empowering women in technology. These esteemed professionals are committed to fostering an environment of growth, inclusivity and support, guiding our community toward achieving its mission and goals."
   },
   "contact": {

--- a/src/main/resources/teamPage.json
+++ b/src/main/resources/teamPage.json
@@ -3,7 +3,7 @@
   "heroSection": {
     "title": "WCC Core Team"
   },
-  "commonSection": {
+  "section": {
     "description": "The core team of our community is composed of visionary directors and dynamic leaders, who bring a wealth of experience and dedication to empowering women in technology. These esteemed professionals are committed to fostering an environment of growth, inclusivity and support, guiding our community toward achieving its mission and goals."
   },
   "contact": {

--- a/src/test/java/com/wcc/platform/controller/DefaultControllerTest.java
+++ b/src/test/java/com/wcc/platform/controller/DefaultControllerTest.java
@@ -12,9 +12,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wcc.platform.configuration.SecurityConfig;
 import com.wcc.platform.domain.cms.attributes.CmsIcon;
 import com.wcc.platform.domain.cms.attributes.LabelLink;
+import com.wcc.platform.domain.cms.attributes.ListSection;
 import com.wcc.platform.domain.cms.pages.FooterSection;
 import com.wcc.platform.domain.cms.pages.LandingPage;
-import com.wcc.platform.domain.cms.pages.Section;
 import com.wcc.platform.domain.cms.pages.programme.ProgrammeItem;
 import com.wcc.platform.domain.exceptions.PlatformInternalException;
 import com.wcc.platform.domain.platform.Event;
@@ -106,8 +106,8 @@ class DefaultControllerTest {
         LandingPage.builder()
             .heroSection(SetupFactories.createHeroSectionTest())
             .programmes(createSectionProgramme())
-            .events(createSection("Events", ProgramType.TECH_TALK))
-            .announcements(createSection("Announcements", ProgramType.OTHERS))
+            .events(createSectionEvent("Events", ProgramType.TECH_TALK))
+            .announcements(createSectionEvent("Announcements", ProgramType.OTHERS))
             .build();
 
     when(service.getLandingPage()).thenReturn(page);
@@ -120,16 +120,16 @@ class DefaultControllerTest {
         .andExpect(content().json(objectMapper.writeValueAsString(page)));
   }
 
-  private Section<Event> createSection(final String title, final ProgramType techTalk) {
-    return new Section<>(
+  private ListSection<Event> createSectionEvent(final String title, final ProgramType techTalk) {
+    return new ListSection<>(
         title,
         "check our latest " + techTalk,
         SetupFactories.createLinkTest(),
         List.of(SetupEventFactories.createEventTest(techTalk)));
   }
 
-  private Section<ProgrammeItem> createSectionProgramme() {
-    return new Section<>(
+  private ListSection<ProgrammeItem> createSectionProgramme() {
+    return new ListSection<>(
         "Programmes ",
         "Description Programme",
         null,

--- a/src/test/java/com/wcc/platform/domain/cms/pages/LandingPageTest.java
+++ b/src/test/java/com/wcc/platform/domain/cms/pages/LandingPageTest.java
@@ -19,7 +19,7 @@ class LandingPageTest {
   @BeforeEach
   void setUp() {
     var hero = SetupFactories.createHeroSectionTest();
-    var volunteer = SetupFactories.createPageTest(VOLUNTEER_TITLE);
+    var volunteer = SetupFactories.createCommonSectionTest(VOLUNTEER_TITLE);
     page1 = LandingPage.builder().heroSection(hero).build();
     page2 = LandingPage.builder().heroSection(hero).build();
     page3 = LandingPage.builder().heroSection(hero).volunteerSection(volunteer).build();

--- a/src/test/java/com/wcc/platform/domain/cms/pages/programme/ProgrammePageTest.java
+++ b/src/test/java/com/wcc/platform/domain/cms/pages/programme/ProgrammePageTest.java
@@ -20,7 +20,7 @@ class ProgrammePageTest {
 
   public static final String PROG_ID = "1";
   private final HeroSection heroSection = createHeroSectionTest();
-  private final CommonSection commonSection = new CommonSection();
+  private final CommonSection section = new CommonSection();
   private final Contact contact = createContactTest();
   private final List<Programme> programmeDetails = List.of(new Programme());
   private final EventSection eventSection = new EventSection();
@@ -31,7 +31,7 @@ class ProgrammePageTest {
   void noArgsConstructor() {
     ProgrammePage programmePage = new ProgrammePage();
     assertNull(programmePage.getHeroSection());
-    assertNull(programmePage.getCommonSection());
+    assertNull(programmePage.getSection());
     assertNull(programmePage.getContact());
     assertNull(programmePage.getProgrammeDetails());
     assertNull(programmePage.getEventSection());
@@ -43,10 +43,10 @@ class ProgrammePageTest {
   void allArgsConstructor() {
     ProgrammePage programmePage =
         new ProgrammePage(
-            "id", heroSection, commonSection, contact, programmeDetails, eventSection, customStyle);
+            "id", heroSection, section, contact, programmeDetails, eventSection, customStyle);
 
     assertEquals(heroSection, programmePage.getHeroSection());
-    assertEquals(commonSection, programmePage.getCommonSection());
+    assertEquals(section, programmePage.getSection());
     assertEquals(contact, programmePage.getContact());
     assertEquals(programmeDetails, programmePage.getProgrammeDetails());
     assertEquals(eventSection, programmePage.getEventSection());
@@ -58,14 +58,14 @@ class ProgrammePageTest {
     ProgrammePage programmePage =
         ProgrammePage.builder()
             .heroSection(heroSection)
-            .commonSection(commonSection)
+            .section(section)
             .contact(contact)
             .programmeDetails(programmeDetails)
             .eventSection(eventSection)
             .build();
 
     assertEquals(heroSection, programmePage.getHeroSection());
-    assertEquals(commonSection, programmePage.getCommonSection());
+    assertEquals(section, programmePage.getSection());
     assertEquals(contact, programmePage.getContact());
     assertEquals(programmeDetails, programmePage.getProgrammeDetails());
     assertEquals(eventSection, programmePage.getEventSection());
@@ -78,22 +78,10 @@ class ProgrammePageTest {
   void equalsAndHashCode() {
     ProgrammePage programmePage1 =
         new ProgrammePage(
-            PROG_ID,
-            heroSection,
-            commonSection,
-            contact,
-            programmeDetails,
-            eventSection,
-            customStyle);
+            PROG_ID, heroSection, section, contact, programmeDetails, eventSection, customStyle);
     ProgrammePage programmePage2 =
         new ProgrammePage(
-            PROG_ID,
-            heroSection,
-            commonSection,
-            contact,
-            programmeDetails,
-            eventSection,
-            customStyle);
+            PROG_ID, heroSection, section, contact, programmeDetails, eventSection, customStyle);
 
     assertEquals(programmePage1, programmePage2);
     assertEquals(programmePage1.hashCode(), programmePage2.hashCode());
@@ -106,20 +94,14 @@ class ProgrammePageTest {
   void testToString() {
     ProgrammePage programmePage =
         new ProgrammePage(
-            PROG_ID,
-            heroSection,
-            commonSection,
-            contact,
-            programmeDetails,
-            eventSection,
-            customStyle);
+            PROG_ID, heroSection, section, contact, programmeDetails, eventSection, customStyle);
     String expected =
         "ProgrammePage(id="
             + PROG_ID
             + ", heroSection="
             + heroSection
-            + ", commonSection="
-            + commonSection
+            + ", section="
+            + section
             + ", contact="
             + contact
             + ", programmeDetails="

--- a/src/test/java/com/wcc/platform/domain/cms/pages/programme/ProgrammePageTest.java
+++ b/src/test/java/com/wcc/platform/domain/cms/pages/programme/ProgrammePageTest.java
@@ -6,10 +6,10 @@ import static com.wcc.platform.factories.SetupFactories.createHeroSectionTest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import com.wcc.platform.domain.cms.attributes.CommonSection;
 import com.wcc.platform.domain.cms.attributes.Contact;
 import com.wcc.platform.domain.cms.attributes.HeroSection;
 import com.wcc.platform.domain.cms.attributes.style.CustomStyle;
-import com.wcc.platform.domain.cms.pages.Page;
 import com.wcc.platform.domain.platform.EventSection;
 import com.wcc.platform.domain.platform.Programme;
 import java.util.List;
@@ -20,7 +20,7 @@ class ProgrammePageTest {
 
   public static final String PROG_ID = "1";
   private final HeroSection heroSection = createHeroSectionTest();
-  private final Page page = new Page();
+  private final CommonSection commonSection = new CommonSection();
   private final Contact contact = createContactTest();
   private final List<Programme> programmeDetails = List.of(new Programme());
   private final EventSection eventSection = new EventSection();
@@ -31,7 +31,7 @@ class ProgrammePageTest {
   void noArgsConstructor() {
     ProgrammePage programmePage = new ProgrammePage();
     assertNull(programmePage.getHeroSection());
-    assertNull(programmePage.getPage());
+    assertNull(programmePage.getCommonSection());
     assertNull(programmePage.getContact());
     assertNull(programmePage.getProgrammeDetails());
     assertNull(programmePage.getEventSection());
@@ -43,10 +43,10 @@ class ProgrammePageTest {
   void allArgsConstructor() {
     ProgrammePage programmePage =
         new ProgrammePage(
-            "id", heroSection, page, contact, programmeDetails, eventSection, customStyle);
+            "id", heroSection, commonSection, contact, programmeDetails, eventSection, customStyle);
 
     assertEquals(heroSection, programmePage.getHeroSection());
-    assertEquals(page, programmePage.getPage());
+    assertEquals(commonSection, programmePage.getCommonSection());
     assertEquals(contact, programmePage.getContact());
     assertEquals(programmeDetails, programmePage.getProgrammeDetails());
     assertEquals(eventSection, programmePage.getEventSection());
@@ -58,14 +58,14 @@ class ProgrammePageTest {
     ProgrammePage programmePage =
         ProgrammePage.builder()
             .heroSection(heroSection)
-            .page(page)
+            .commonSection(commonSection)
             .contact(contact)
             .programmeDetails(programmeDetails)
             .eventSection(eventSection)
             .build();
 
     assertEquals(heroSection, programmePage.getHeroSection());
-    assertEquals(page, programmePage.getPage());
+    assertEquals(commonSection, programmePage.getCommonSection());
     assertEquals(contact, programmePage.getContact());
     assertEquals(programmeDetails, programmePage.getProgrammeDetails());
     assertEquals(eventSection, programmePage.getEventSection());
@@ -78,10 +78,22 @@ class ProgrammePageTest {
   void equalsAndHashCode() {
     ProgrammePage programmePage1 =
         new ProgrammePage(
-            PROG_ID, heroSection, page, contact, programmeDetails, eventSection, customStyle);
+            PROG_ID,
+            heroSection,
+            commonSection,
+            contact,
+            programmeDetails,
+            eventSection,
+            customStyle);
     ProgrammePage programmePage2 =
         new ProgrammePage(
-            PROG_ID, heroSection, page, contact, programmeDetails, eventSection, customStyle);
+            PROG_ID,
+            heroSection,
+            commonSection,
+            contact,
+            programmeDetails,
+            eventSection,
+            customStyle);
 
     assertEquals(programmePage1, programmePage2);
     assertEquals(programmePage1.hashCode(), programmePage2.hashCode());
@@ -94,14 +106,20 @@ class ProgrammePageTest {
   void testToString() {
     ProgrammePage programmePage =
         new ProgrammePage(
-            PROG_ID, heroSection, page, contact, programmeDetails, eventSection, customStyle);
+            PROG_ID,
+            heroSection,
+            commonSection,
+            contact,
+            programmeDetails,
+            eventSection,
+            customStyle);
     String expected =
         "ProgrammePage(id="
             + PROG_ID
             + ", heroSection="
             + heroSection
-            + ", page="
-            + page
+            + ", commonSection="
+            + commonSection
             + ", contact="
             + contact
             + ", programmeDetails="

--- a/src/test/java/com/wcc/platform/domain/platform/ProgrammeTest.java
+++ b/src/test/java/com/wcc/platform/domain/platform/ProgrammeTest.java
@@ -6,25 +6,22 @@ import static com.wcc.platform.factories.SetupProgrammeFactories.createProgramme
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /** Test class for {@link Programme}. */
 class ProgrammeTest {
 
-  private final UUID uuid = UUID.randomUUID();
-
   Programme testProgramme;
 
   @BeforeEach
   void setup() {
-    testProgramme = createProgramme(uuid);
+    testProgramme = createProgramme();
   }
 
   @Test
   void testEquals() {
-    assertEquals(testProgramme, createProgramme(uuid));
+    assertEquals(testProgramme, createProgramme());
   }
 
   @Test
@@ -34,7 +31,7 @@ class ProgrammeTest {
 
   @Test
   void testHashCode() {
-    assertEquals(testProgramme.hashCode(), createProgramme(uuid).hashCode());
+    assertEquals(testProgramme.hashCode(), createProgramme().hashCode());
   }
 
   @Test

--- a/src/test/java/com/wcc/platform/factories/SetupEventFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetupEventFactories.java
@@ -1,8 +1,8 @@
 package com.wcc.platform.factories;
 
+import static com.wcc.platform.factories.SetupFactories.createCommonSectionTest;
 import static com.wcc.platform.factories.SetupFactories.createContactTest;
 import static com.wcc.platform.factories.SetupFactories.createHeroSectionTest;
-import static com.wcc.platform.factories.SetupFactories.createPageTest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.wcc.platform.domain.cms.PageType;
@@ -64,7 +64,7 @@ public class SetupEventFactories {
         PageType.EVENTS.getId(),
         metadata,
         createHeroSectionTest(),
-        createPageTest(),
+        createCommonSectionTest(),
         createContactTest(),
         data);
   }

--- a/src/test/java/com/wcc/platform/factories/SetupFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetupFactories.java
@@ -9,22 +9,21 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wcc.platform.configuration.ObjectMapperConfig;
 import com.wcc.platform.domain.cms.PageType;
+import com.wcc.platform.domain.cms.attributes.CommonSection;
 import com.wcc.platform.domain.cms.attributes.Contact;
 import com.wcc.platform.domain.cms.attributes.Country;
 import com.wcc.platform.domain.cms.attributes.HeroSection;
 import com.wcc.platform.domain.cms.attributes.Image;
 import com.wcc.platform.domain.cms.attributes.ImageType;
 import com.wcc.platform.domain.cms.attributes.LabelLink;
+import com.wcc.platform.domain.cms.attributes.ListSection;
 import com.wcc.platform.domain.cms.attributes.MemberByType;
-import com.wcc.platform.domain.cms.attributes.PageSection;
 import com.wcc.platform.domain.cms.pages.AboutUsPage;
 import com.wcc.platform.domain.cms.pages.CodeOfConductPage;
 import com.wcc.platform.domain.cms.pages.CollaboratorPage;
 import com.wcc.platform.domain.cms.pages.FooterSection;
-import com.wcc.platform.domain.cms.pages.Page;
 import com.wcc.platform.domain.cms.pages.PageMetadata;
 import com.wcc.platform.domain.cms.pages.Pagination;
-import com.wcc.platform.domain.cms.pages.Section;
 import com.wcc.platform.domain.cms.pages.TeamPage;
 import com.wcc.platform.domain.platform.LeadershipMember;
 import com.wcc.platform.domain.platform.Member;
@@ -58,7 +57,7 @@ public class SetupFactories {
     return new TeamPage(
         pageId,
         createNoImageHeroSectionTest(),
-        createPageTest(),
+        createCommonSectionTest(),
         createContactTest(),
         createMemberByTypeTest());
   }
@@ -80,7 +79,7 @@ public class SetupFactories {
         pageId,
         createPaginationTest(),
         createNoImageHeroSectionTest(),
-        createPageTest(),
+        createCommonSectionTest(),
         createContactTest(),
         List.of(createCollaboratorsTest()));
   }
@@ -99,7 +98,10 @@ public class SetupFactories {
   public static CodeOfConductPage createCodeOfConductPageTest() {
     final String pageId = PageType.CODE_OF_CONDUCT.getId();
     return new CodeOfConductPage(
-        pageId, createNoImageHeroSectionTest(), createPageTest(), List.of(createSectionTest()));
+        pageId,
+        createNoImageHeroSectionTest(),
+        createCommonSectionTest(),
+        List.of(createListSectionTest()));
   }
 
   /** Code of conduct factory for testing. */
@@ -128,9 +130,9 @@ public class SetupFactories {
     return new PageMetadata(new Pagination(1, 1, DEFAULT_CURRENT_PAGE, DEFAULT_PAGE_SIZE));
   }
 
-  /** Factory test for page. */
-  public static Page createPageTest(final String title) {
-    return Page.builder()
+  /** Factory test for commonSection. */
+  public static CommonSection createCommonSectionTest(final String title) {
+    return CommonSection.builder()
         .title("title " + title)
         .subtitle("subtitle " + title)
         .description("desc " + title)
@@ -139,12 +141,12 @@ public class SetupFactories {
         .build();
   }
 
-  public static Page createPageTest() {
-    return createPageTest("defaultPage");
+  public static CommonSection createCommonSectionTest() {
+    return createCommonSectionTest("defaultPage");
   }
 
-  public static Section<String> createSectionTest() {
-    return new Section<>("title", "description", null, List.of("item_1", "item_2", "item_3"));
+  public static ListSection<String> createListSectionTest() {
+    return new ListSection<>("title", "description", null, List.of("item_1", "item_2", "item_3"));
   }
 
   /** Factory test. */
@@ -273,8 +275,8 @@ public class SetupFactories {
   }
 
   /** Factory test for page section. */
-  public static PageSection createPageSectionTest(final String title) {
-    return new PageSection(
+  public static ListSection<String> createListSectionTest(final String title) {
+    return new ListSection<>(
         title,
         title + "description",
         createLinkTest(),
@@ -305,7 +307,7 @@ public class SetupFactories {
   public static AboutUsPage createAboutUsPageTest() {
     final String pageId = PageType.ABOUT_US.getId();
     return new AboutUsPage(
-        pageId, createHeroSectionTest(), List.of(createSectionTest()), createContactTest());
+        pageId, createHeroSectionTest(), List.of(createListSectionTest()), createContactTest());
   }
 
   /** About Us factory for testing. */

--- a/src/test/java/com/wcc/platform/factories/SetupFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetupFactories.java
@@ -130,7 +130,7 @@ public class SetupFactories {
     return new PageMetadata(new Pagination(1, 1, DEFAULT_CURRENT_PAGE, DEFAULT_PAGE_SIZE));
   }
 
-  /** Factory test for commonSection. */
+  /** Factory test for CommonSection. */
   public static CommonSection createCommonSectionTest(final String title) {
     return CommonSection.builder()
         .title("title " + title)
@@ -141,12 +141,23 @@ public class SetupFactories {
         .build();
   }
 
+  /** Factory test for CommonSection. */
   public static CommonSection createCommonSectionTest() {
     return createCommonSectionTest("defaultPage");
   }
 
+  /** Factory test for ListSection. */
   public static ListSection<String> createListSectionTest() {
     return new ListSection<>("title", "description", null, List.of("item_1", "item_2", "item_3"));
+  }
+
+  /** Factory test for ListSection. */
+  public static ListSection<String> createListSectionTest(final String title) {
+    return new ListSection<>(
+        title,
+        title + "description",
+        createLinkTest(),
+        List.of("topic1 " + title, "topic2 " + title));
   }
 
   /** Factory test. */
@@ -272,15 +283,6 @@ public class SetupFactories {
 
   public static LabelLink createLinkTest() {
     return new LabelLink("link_title", "link_label", "link_uri");
-  }
-
-  /** Factory test for page section. */
-  public static ListSection<String> createListSectionTest(final String title) {
-    return new ListSection<>(
-        title,
-        title + "description",
-        createLinkTest(),
-        List.of("topic1 " + title, "topic2 " + title));
   }
 
   /**

--- a/src/test/java/com/wcc/platform/factories/SetupMentorshipFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetupMentorshipFactories.java
@@ -1,9 +1,9 @@
 package com.wcc.platform.factories;
 
 import static com.wcc.platform.factories.SetupFactories.OBJECT_MAPPER;
+import static com.wcc.platform.factories.SetupFactories.createCommonSectionTest;
+import static com.wcc.platform.factories.SetupFactories.createListSectionTest;
 import static com.wcc.platform.factories.SetupFactories.createNoImageHeroSectionTest;
-import static com.wcc.platform.factories.SetupFactories.createPageSectionTest;
-import static com.wcc.platform.factories.SetupFactories.createPageTest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.wcc.platform.domain.cms.PageType;
@@ -33,9 +33,9 @@ public class SetupMentorshipFactories {
     return new MentorshipPage(
         pageId,
         createNoImageHeroSectionTest(),
-        createPageTest(),
-        createPageSectionTest("Mentor"),
-        createPageSectionTest("Mentee"),
+        createCommonSectionTest(),
+        createListSectionTest("Mentor"),
+        createListSectionTest("Mentee"),
         createFeedbackSectionTest());
   }
 

--- a/src/test/java/com/wcc/platform/factories/SetupProgrammeFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetupProgrammeFactories.java
@@ -4,8 +4,8 @@ import static com.wcc.platform.factories.SetUpStyleFactories.createCustomStyleTe
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.wcc.platform.domain.cms.attributes.CmsIcon;
+import com.wcc.platform.domain.cms.attributes.CommonSection;
 import com.wcc.platform.domain.cms.attributes.LabelLink;
-import com.wcc.platform.domain.cms.pages.Page;
 import com.wcc.platform.domain.cms.pages.programme.ProgrammeItem;
 import com.wcc.platform.domain.cms.pages.programme.ProgrammePage;
 import com.wcc.platform.domain.platform.ProgramType;
@@ -42,7 +42,7 @@ public class SetupProgrammeFactories {
     return new ProgrammePage(
         "page:program",
         SetupFactories.createHeroSectionTest(),
-        SetupFactories.createPageTest(),
+        SetupFactories.createCommonSectionTest(),
         SetupFactories.createContactTest(),
         Collections.singletonList(createProgramme(UUID.randomUUID())),
         SetupEventFactories.createEventSection(),
@@ -69,7 +69,7 @@ public class SetupProgrammeFactories {
         .title("What We Are Reading")
         .description("Every month we vote we read a book this is current month book.")
         .card(
-            new Page(
+            new CommonSection(
                 uuid,
                 "Test book title",
                 "Author of the book",

--- a/src/test/java/com/wcc/platform/factories/SetupProgrammeFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetupProgrammeFactories.java
@@ -13,7 +13,6 @@ import com.wcc.platform.domain.platform.Programme;
 import com.wcc.platform.utils.FileUtil;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 
 /** Test factories for Programme. */
 public class SetupProgrammeFactories {
@@ -44,7 +43,7 @@ public class SetupProgrammeFactories {
         SetupFactories.createHeroSectionTest(),
         SetupFactories.createCommonSectionTest(),
         SetupFactories.createContactTest(),
-        Collections.singletonList(createProgramme(UUID.randomUUID())),
+        Collections.singletonList(createProgramme()),
         SetupEventFactories.createEventSection(),
         createCustomStyleTest());
   }
@@ -52,7 +51,7 @@ public class SetupProgrammeFactories {
   /** Create Factory. */
   public static Programme createProgrammeByType(final ProgramType type) {
     if (ProgramType.BOOK_CLUB.equals(type)) {
-      createProgramme(UUID.randomUUID());
+      createProgramme();
     } else {
       return createProgrammeWithoutCard();
     }
@@ -64,7 +63,7 @@ public class SetupProgrammeFactories {
    *
    * @return Programme object
    */
-  public static Programme createProgramme(final UUID uuid) {
+  public static Programme createProgramme() {
     return Programme.builder()
         .title("What We Are Reading")
         .description("Every month we vote we read a book this is current month book.")

--- a/src/test/java/com/wcc/platform/factories/SetupProgrammeFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetupProgrammeFactories.java
@@ -70,7 +70,6 @@ public class SetupProgrammeFactories {
         .description("Every month we vote we read a book this is current month book.")
         .card(
             new CommonSection(
-                uuid,
                 "Test book title",
                 "Author of the book",
                 "test book description",

--- a/src/test/java/com/wcc/platform/integrationtests/CmsServiceIntegrationTest.java
+++ b/src/test/java/com/wcc/platform/integrationtests/CmsServiceIntegrationTest.java
@@ -17,8 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.wcc.platform.domain.cms.pages.CollaboratorPage;
 import com.wcc.platform.domain.cms.pages.CodeOfConductPage;
+import com.wcc.platform.domain.cms.pages.CollaboratorPage;
 import com.wcc.platform.repository.PageRepository;
 import com.wcc.platform.service.CmsService;
 import java.util.Map;
@@ -52,7 +52,7 @@ class CmsServiceIntegrationTest extends SurrealDbIntegrationTest {
     pageRepository.create(objectMapper.convertValue(teamPage, Map.class));
     var result = service.getTeam();
 
-    assertEquals(teamPage.page(), result.page());
+    assertEquals(teamPage.commonSection(), result.commonSection());
     assertEquals(teamPage.contact(), result.contact());
 
     assertEquals(1, result.membersByType().directors().size());
@@ -86,7 +86,7 @@ class CmsServiceIntegrationTest extends SurrealDbIntegrationTest {
     pageRepository.create(objectMapper.convertValue(collaboratorPage, Map.class));
     var result = service.getCollaborator(DEFAULT_CURRENT_PAGE, DEFAULT_PAGE_SIZE);
 
-    assertEquals(collaboratorPage.page(), result.page());
+    assertEquals(collaboratorPage.commonSection(), result.commonSection());
     assertEquals(collaboratorPage.contact(), result.contact());
     assertEquals(collaboratorPage.metadata(), result.metadata());
 
@@ -103,7 +103,7 @@ class CmsServiceIntegrationTest extends SurrealDbIntegrationTest {
 
     var result = service.getCodeOfConduct();
 
-    assertEquals(codeOfConductPage.page(), result.page());
+    assertEquals(codeOfConductPage.commonSection(), result.commonSection());
     assertEquals(codeOfConductPage.items().size(), result.items().size());
   }
 

--- a/src/test/java/com/wcc/platform/integrationtests/CmsServiceIntegrationTest.java
+++ b/src/test/java/com/wcc/platform/integrationtests/CmsServiceIntegrationTest.java
@@ -52,7 +52,7 @@ class CmsServiceIntegrationTest extends SurrealDbIntegrationTest {
     pageRepository.create(objectMapper.convertValue(teamPage, Map.class));
     var result = service.getTeam();
 
-    assertEquals(teamPage.commonSection(), result.commonSection());
+    assertEquals(teamPage.section(), result.section());
     assertEquals(teamPage.contact(), result.contact());
 
     assertEquals(1, result.membersByType().directors().size());
@@ -86,7 +86,7 @@ class CmsServiceIntegrationTest extends SurrealDbIntegrationTest {
     pageRepository.create(objectMapper.convertValue(collaboratorPage, Map.class));
     var result = service.getCollaborator(DEFAULT_CURRENT_PAGE, DEFAULT_PAGE_SIZE);
 
-    assertEquals(collaboratorPage.commonSection(), result.commonSection());
+    assertEquals(collaboratorPage.section(), result.section());
     assertEquals(collaboratorPage.contact(), result.contact());
     assertEquals(collaboratorPage.metadata(), result.metadata());
 
@@ -103,7 +103,7 @@ class CmsServiceIntegrationTest extends SurrealDbIntegrationTest {
 
     var result = service.getCodeOfConduct();
 
-    assertEquals(codeOfConductPage.commonSection(), result.commonSection());
+    assertEquals(codeOfConductPage.section(), result.section());
     assertEquals(codeOfConductPage.items().size(), result.items().size());
   }
 

--- a/src/test/java/com/wcc/platform/service/CmsServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/CmsServiceTest.java
@@ -31,8 +31,8 @@ class CmsServiceTest {
       LandingPage.builder()
           .id(PageType.LANDING_PAGE.getId())
           .heroSection(SetupFactories.createHeroSectionTest())
-          .fullBannerSection(SetupFactories.createPageTest("Page banner section"))
-          .volunteerSection(SetupFactories.createPageTest("Volunteer"))
+          .fullBannerSection(SetupFactories.createCommonSectionTest("Page banner section"))
+          .volunteerSection(SetupFactories.createCommonSectionTest("Volunteer"))
           .build();
   @Mock private PageRepository pageRepository;
   @Mock private ObjectMapper objectMapper;

--- a/src/test/java/com/wcc/platform/service/ProgrammeServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/ProgrammeServiceTest.java
@@ -41,7 +41,7 @@ class ProgrammeServiceTest {
 
     var response = service.getProgramme(BOOK_CLUB);
 
-    assertEquals(programmePage.getCommonSection(), response.getCommonSection());
+    assertEquals(programmePage.getSection(), response.getSection());
     assertEquals(programmePage.getContact(), response.getContact());
     assertEquals(programmePage.getProgrammeDetails(), response.getProgrammeDetails());
   }

--- a/src/test/java/com/wcc/platform/service/ProgrammeServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/ProgrammeServiceTest.java
@@ -41,7 +41,7 @@ class ProgrammeServiceTest {
 
     var response = service.getProgramme(BOOK_CLUB);
 
-    assertEquals(programmePage.getPage(), response.getPage());
+    assertEquals(programmePage.getCommonSection(), response.getCommonSection());
     assertEquals(programmePage.getContact(), response.getContact());
     assertEquals(programmePage.getProgrammeDetails(), response.getProgrammeDetails());
   }

--- a/src/test/resources/bookClubPage.json
+++ b/src/test/resources/bookClubPage.json
@@ -10,7 +10,7 @@
       }
     ]
   },
-  "page": {
+  "commonSection": {
     "description": "What sets our book club apart are the lively conversations, valuable insights and an opportunity to connect with like-minded individuals. The books we read are selected by the community, offering a diverse selection of tech books and essential soft skills topics.The book club meets monthly to share views, exchange ideas, and inspire personal and professional growth."
   },
   "contact": {

--- a/src/test/resources/bookClubPage.json
+++ b/src/test/resources/bookClubPage.json
@@ -10,7 +10,7 @@
       }
     ]
   },
-  "commonSection": {
+  "section": {
     "description": "What sets our book club apart are the lively conversations, valuable insights and an opportunity to connect with like-minded individuals. The books we read are selected by the community, offering a diverse selection of tech books and essential soft skills topics.The book club meets monthly to share views, exchange ideas, and inspire personal and professional growth."
   },
   "contact": {

--- a/src/test/resources/codeOfConductPage.json
+++ b/src/test/resources/codeOfConductPage.json
@@ -3,7 +3,7 @@
   "heroSection": {
     "title": "WCC Code of Conduct"
   },
-  "page": {
+  "commonSection": {
     "description": "At Women Coding Community we are committed to a vibrant, supportive community where women can network, share experiences, and foster professional relationships, regardless of age, gender, visible or invisible disability, ethnicity, gender expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, sexual orientation or preferred programming language(s)."
   },
   "items": [

--- a/src/test/resources/codeOfConductPage.json
+++ b/src/test/resources/codeOfConductPage.json
@@ -3,7 +3,7 @@
   "heroSection": {
     "title": "WCC Code of Conduct"
   },
-  "commonSection": {
+  "section": {
     "description": "At Women Coding Community we are committed to a vibrant, supportive community where women can network, share experiences, and foster professional relationships, regardless of age, gender, visible or invisible disability, ethnicity, gender expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, sexual orientation or preferred programming language(s)."
   },
   "items": [

--- a/src/test/resources/collaboratorPage.json
+++ b/src/test/resources/collaboratorPage.json
@@ -11,7 +11,7 @@
   "heroSection": {
     "title": "WCC Collaborators"
   },
-  "page": {
+  "commonSection": {
     "description": "description"
   },
   "contact": {

--- a/src/test/resources/collaboratorPage.json
+++ b/src/test/resources/collaboratorPage.json
@@ -11,7 +11,7 @@
   "heroSection": {
     "title": "WCC Collaborators"
   },
-  "commonSection": {
+  "section": {
     "description": "description"
   },
   "contact": {

--- a/src/test/resources/eventsPage.json
+++ b/src/test/resources/eventsPage.json
@@ -18,7 +18,7 @@
       }
     ]
   },
-  "commonSection": {
+  "section": {
     "description": "Join the Women Coding Community for events and meetups that enhance your skills, deepen your knowledge, and expand your professional network.\n\nOur events include webinars, hands-on workshops, study groups, panel discussions, and keynotes with industry experts. Whether online or in-person, these gatherings offer valuable opportunities to share insights, learn collaboratively, and stay updated on the latest trends. Connect, grow, and thrive with fellow members in a supportive environment."
   },
   "contact": {

--- a/src/test/resources/eventsPage.json
+++ b/src/test/resources/eventsPage.json
@@ -18,7 +18,7 @@
       }
     ]
   },
-  "page": {
+  "commonSection": {
     "description": "Join the Women Coding Community for events and meetups that enhance your skills, deepen your knowledge, and expand your professional network.\n\nOur events include webinars, hands-on workshops, study groups, panel discussions, and keynotes with industry experts. Whether online or in-person, these gatherings offer valuable opportunities to share insights, learn collaboratively, and stay updated on the latest trends. Connect, grow, and thrive with fellow members in a supportive environment."
   },
   "contact": {

--- a/src/test/resources/mentorshipPage.json
+++ b/src/test/resources/mentorshipPage.json
@@ -3,7 +3,7 @@
   "heroSection": {
     "title": "Mentorship Programme"
   },
-  "commonSection": {
+  "section": {
     "description": "Mentorship is a fantastic way to get support for your personal growth and career development."
   },
   "mentorSection": {

--- a/src/test/resources/mentorshipPage.json
+++ b/src/test/resources/mentorshipPage.json
@@ -3,13 +3,13 @@
   "heroSection": {
     "title": "Mentorship Programme"
   },
-  "page": {
+  "commonSection": {
     "description": "Mentorship is a fantastic way to get support for your personal growth and career development."
   },
   "mentorSection": {
     "title": "Become a Mentor",
     "description": "You should apply to be a mentor if you:",
-    "topics": [
+    "items": [
       "Want to extend your professional network",
       "Want to contribute to the community",
       "You are ready to share expertise",
@@ -23,7 +23,7 @@
   "menteeSection": {
     "title": "Become a Mentee",
     "description": "You should apply to be a mentee if you:",
-    "topics": [
+    "items": [
       "Want to start career in software engineering",
       "Want to find a better job",
       "Want to be promoted at work",

--- a/src/test/resources/teamPage.json
+++ b/src/test/resources/teamPage.json
@@ -3,7 +3,7 @@
   "heroSection": {
     "title": "WCC Core Team"
   },
-  "page": {
+  "commonSection": {
     "description": "description"
   },
   "contact": {

--- a/src/test/resources/teamPage.json
+++ b/src/test/resources/teamPage.json
@@ -3,7 +3,7 @@
   "heroSection": {
     "title": "WCC Core Team"
   },
-  "commonSection": {
+  "section": {
     "description": "description"
   },
   "contact": {


### PR DESCRIPTION
## Description

- Describe your changes in detail.

Code refactoring:
- Rename Page to CommonSection (and remove uuid field)
- Rename Section to ListSection
- Remove PageSection.java and use ListSection
- Use variable name "section" for CommonSection objects instead of "page"

Update json files
Update and rename tests

- Why is this change required?

The component "Page" has to be renamed to reflect its real usage. It is used as a section of the page, and it does not correspond to the complete page (like complete About us page, or Landing page). It is just a segment used on the page, thus requiring the renaming.

- What problem does it solve?

Confusion while implementing API and front-end functionalities (the names of the fields have to reflect there actual usages).

- Add Notes if anything is left unclear or not completed

## Related Issue

Please link to the issue here:
https://github.com/Women-Coding-Community/wcc-backend/issues/187

## Change Type

- [ ] Bug Fix
- [ ] New Feature
- [X] Code Refactor
- [ ] Documentation
- [ ] Test
- [ ] Other

## Screenshots

<!--  Please include screenshots from the Swagger API. -->
Tested for all APIs, including just for the reference two screenshots:

![Screenshot (155)](https://github.com/user-attachments/assets/1f07fbfd-e6d9-4781-8bfa-e1280ec5c36f)

![Screenshot (154)](https://github.com/user-attachments/assets/cdae9d99-d6ae-4c18-96db-b9812b0a30f1)

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [X] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->