### PR TITLE
feat: Add partners section to Landing page

### DIFF
--- a/src/main/java/com/wcc/platform/domain/cms/pages/LandingPage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/LandingPage.java
@@ -6,6 +6,7 @@ import com.wcc.platform.domain.cms.attributes.ListSection;
 import com.wcc.platform.domain.cms.pages.mentorship.FeedbackSection;
 import com.wcc.platform.domain.cms.pages.programme.ProgrammeItem;
 import com.wcc.platform.domain.platform.Event;
+import com.wcc.platform.domain.platform.Partner;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,4 +31,5 @@ public class LandingPage {
   private ListSection<Event> events;
   private FeedbackSection feedbackSection;
   @NotNull private CommonSection volunteerSection;
+  private ListSection<Partner> partners;
 }

--- a/src/main/java/com/wcc/platform/domain/platform/Partner.java
+++ b/src/main/java/com/wcc/platform/domain/platform/Partner.java
@@ -4,7 +4,6 @@ import com.wcc.platform.domain.cms.attributes.Image;
 import com.wcc.platform.domain.cms.attributes.LabelLink;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -20,8 +19,8 @@ import lombok.ToString;
 @NoArgsConstructor
 @Builder
 public class Partner {
-  @NotEmpty private List<Image> images;
+  @NotEmpty private Image image;
   @NotBlank private String name;
   private String description;
-  private LabelLink link;
+  @NotEmpty private LabelLink link;
 }

--- a/src/main/java/com/wcc/platform/domain/platform/Partner.java
+++ b/src/main/java/com/wcc/platform/domain/platform/Partner.java
@@ -4,6 +4,7 @@ import com.wcc.platform.domain.cms.attributes.Image;
 import com.wcc.platform.domain.cms.attributes.LabelLink;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -22,5 +23,5 @@ public class Partner {
   @NotEmpty private Image image;
   @NotBlank private String name;
   private String description;
-  @NotEmpty private LabelLink link;
+  @NotNull private LabelLink link;
 }

--- a/src/main/java/com/wcc/platform/domain/platform/Partner.java
+++ b/src/main/java/com/wcc/platform/domain/platform/Partner.java
@@ -22,6 +22,6 @@ import lombok.ToString;
 public class Partner {
   @NotEmpty private List<Image> images;
   @NotBlank private String name;
-  @NotBlank private String description;
-  @NotEmpty private LabelLink link;
+  private String description;
+  private LabelLink link;
 }

--- a/src/main/resources/landingPage.json
+++ b/src/main/resources/landingPage.json
@@ -231,7 +231,7 @@
         "image": {
           "path": "https://drive.google.com/uc?id=1sxYKgOSzql2sFX9FLnEHAQhmskOHwBzI&export=download",
           "alt": "SurrealDB logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "SurrealDB",
         "link": {
@@ -242,7 +242,7 @@
         "image": {
           "path": "https://drive.google.com/uc?id=1aR_a7gAA31YdlEST9gGgT9J8t1DHZr_y&export=download",
           "alt": "Amazon logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "Amazon",
         "link": {
@@ -253,7 +253,7 @@
         "image": {
           "path": "https://drive.google.com/uc?id=1t6N6QEB3KQVZLLlrk3G6MOalAfxIwk-8&export=download",
           "alt": "JetBrains logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "JetBrains",
         "link": {
@@ -264,7 +264,7 @@
         "image": {
           "path": "https://drive.google.com/uc?id=1YO0SUlMEvYsP0AdgVWT6X3HR1Lq5x6bZ&export=download",
           "alt": "Devoxx UK logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "Devoxx UK",
         "link": {
@@ -275,7 +275,7 @@
         "image": {
           "path": "https://drive.google.com/uc?id=1tNYfg0f5Hv78q89Q8tD15tmWyFNQ7fUZ&export=download",
           "alt": "WomenTech Network logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "WomenTech Network",
         "link": {

--- a/src/main/resources/landingPage.json
+++ b/src/main/resources/landingPage.json
@@ -223,5 +223,85 @@
         "type": "desktop"
       }
     ]
+  },
+  "partners": {
+    "title": "Community Partners",
+    "items": [
+      {
+        "images": [
+          {
+            "path": "https://drive.google.com/uc?id=1sxYKgOSzql2sFX9FLnEHAQhmskOHwBzI&export=download",
+            "alt": "SurrealDB logo",
+            "type": "desktop"
+          },
+          {
+            "path": "https://drive.google.com/uc?id=1sxYKgOSzql2sFX9FLnEHAQhmskOHwBzI&export=download",
+            "alt": "SurrealDB logo",
+            "type": "mobile"
+          }
+        ],
+        "name": "SurrealDB"
+      },
+      {
+        "images": [
+          {
+            "path": "https://drive.google.com/uc?id=1aR_a7gAA31YdlEST9gGgT9J8t1DHZr_y&export=download",
+            "alt": "Amazon logo",
+            "type": "desktop"
+          },
+          {
+            "path": "https://drive.google.com/uc?id=1aR_a7gAA31YdlEST9gGgT9J8t1DHZr_y&export=download",
+            "alt": "Amazon logo",
+            "type": "mobile"
+          }
+        ],
+        "name": "Amazon"
+      },
+      {
+        "images": [
+          {
+            "path": "https://drive.google.com/uc?id=1t6N6QEB3KQVZLLlrk3G6MOalAfxIwk-8&export=download",
+            "alt": "JetBrains logo",
+            "type": "desktop"
+          },
+          {
+            "path": "https://drive.google.com/uc?id=1t6N6QEB3KQVZLLlrk3G6MOalAfxIwk-8&export=download",
+            "alt": "JetBrains logo",
+            "type": "mobile"
+          }
+        ],
+        "name": "JetBrains"
+      },
+      {
+        "images": [
+          {
+            "path": "https://drive.google.com/uc?id=1YO0SUlMEvYsP0AdgVWT6X3HR1Lq5x6bZ&export=download",
+            "alt": "Devoxx UK logo",
+            "type": "desktop"
+          },
+          {
+            "path": "https://drive.google.com/uc?id=1YO0SUlMEvYsP0AdgVWT6X3HR1Lq5x6bZ&export=download",
+            "alt": "Devoxx UK logo",
+            "type": "mobile"
+          }
+        ],
+        "name": "Devoxx UK"
+      },
+      {
+        "images": [
+          {
+            "path": "https://drive.google.com/uc?id=1tNYfg0f5Hv78q89Q8tD15tmWyFNQ7fUZ&export=download",
+            "alt": "WomenTech Network logo",
+            "type": "desktop"
+          },
+          {
+            "path": "https://drive.google.com/uc?id=1tNYfg0f5Hv78q89Q8tD15tmWyFNQ7fUZ&export=download",
+            "alt": "WomenTech Network logo",
+            "type": "mobile"
+          }
+        ],
+        "name": "WomenTech Network"
+      }
+    ]
   }
 }

--- a/src/main/resources/landingPage.json
+++ b/src/main/resources/landingPage.json
@@ -228,79 +228,59 @@
     "title": "Community Partners",
     "items": [
       {
-        "images": [
-          {
-            "path": "https://drive.google.com/uc?id=1sxYKgOSzql2sFX9FLnEHAQhmskOHwBzI&export=download",
-            "alt": "SurrealDB logo",
-            "type": "desktop"
-          },
-          {
-            "path": "https://drive.google.com/uc?id=1sxYKgOSzql2sFX9FLnEHAQhmskOHwBzI&export=download",
-            "alt": "SurrealDB logo",
-            "type": "mobile"
-          }
-        ],
-        "name": "SurrealDB"
+        "image": {
+          "path": "https://drive.google.com/uc?id=1sxYKgOSzql2sFX9FLnEHAQhmskOHwBzI&export=download",
+          "alt": "SurrealDB logo",
+          "type": "mobile"
+        },
+        "name": "SurrealDB",
+        "link": {
+          "uri": "https://surrealdb.com/"
+        }
       },
       {
-        "images": [
-          {
-            "path": "https://drive.google.com/uc?id=1aR_a7gAA31YdlEST9gGgT9J8t1DHZr_y&export=download",
-            "alt": "Amazon logo",
-            "type": "desktop"
-          },
-          {
-            "path": "https://drive.google.com/uc?id=1aR_a7gAA31YdlEST9gGgT9J8t1DHZr_y&export=download",
-            "alt": "Amazon logo",
-            "type": "mobile"
-          }
-        ],
-        "name": "Amazon"
+        "image": {
+          "path": "https://drive.google.com/uc?id=1aR_a7gAA31YdlEST9gGgT9J8t1DHZr_y&export=download",
+          "alt": "Amazon logo",
+          "type": "mobile"
+        },
+        "name": "Amazon",
+        "link": {
+          "uri": "https://www.amazon.com/"
+        }
       },
       {
-        "images": [
-          {
-            "path": "https://drive.google.com/uc?id=1t6N6QEB3KQVZLLlrk3G6MOalAfxIwk-8&export=download",
-            "alt": "JetBrains logo",
-            "type": "desktop"
-          },
-          {
-            "path": "https://drive.google.com/uc?id=1t6N6QEB3KQVZLLlrk3G6MOalAfxIwk-8&export=download",
-            "alt": "JetBrains logo",
-            "type": "mobile"
-          }
-        ],
-        "name": "JetBrains"
+        "image": {
+          "path": "https://drive.google.com/uc?id=1t6N6QEB3KQVZLLlrk3G6MOalAfxIwk-8&export=download",
+          "alt": "JetBrains logo",
+          "type": "mobile"
+        },
+        "name": "JetBrains",
+        "link": {
+          "uri": "https://www.jetbrains.com/"
+        }
       },
       {
-        "images": [
-          {
-            "path": "https://drive.google.com/uc?id=1YO0SUlMEvYsP0AdgVWT6X3HR1Lq5x6bZ&export=download",
-            "alt": "Devoxx UK logo",
-            "type": "desktop"
-          },
-          {
-            "path": "https://drive.google.com/uc?id=1YO0SUlMEvYsP0AdgVWT6X3HR1Lq5x6bZ&export=download",
-            "alt": "Devoxx UK logo",
-            "type": "mobile"
-          }
-        ],
-        "name": "Devoxx UK"
+        "image": {
+          "path": "https://drive.google.com/uc?id=1YO0SUlMEvYsP0AdgVWT6X3HR1Lq5x6bZ&export=download",
+          "alt": "Devoxx UK logo",
+          "type": "mobile"
+        },
+        "name": "Devoxx UK",
+        "link": {
+          "uri": "https://www.devoxx.co.uk/"
+        }
       },
       {
-        "images": [
-          {
-            "path": "https://drive.google.com/uc?id=1tNYfg0f5Hv78q89Q8tD15tmWyFNQ7fUZ&export=download",
-            "alt": "WomenTech Network logo",
-            "type": "desktop"
-          },
-          {
-            "path": "https://drive.google.com/uc?id=1tNYfg0f5Hv78q89Q8tD15tmWyFNQ7fUZ&export=download",
-            "alt": "WomenTech Network logo",
-            "type": "mobile"
-          }
-        ],
-        "name": "WomenTech Network"
+        "image": {
+          "path": "https://drive.google.com/uc?id=1tNYfg0f5Hv78q89Q8tD15tmWyFNQ7fUZ&export=download",
+          "alt": "WomenTech Network logo",
+          "type": "mobile"
+        },
+        "name": "WomenTech Network",
+        "link": {
+          "uri": "https://www.womentech.net/"
+        }
       }
     ]
   }

--- a/src/main/resources/partnersPage.json
+++ b/src/main/resources/partnersPage.json
@@ -42,7 +42,7 @@
         "image": {
           "path": "https://drive.google.com/uc?id=1sxYKgOSzql2sFX9FLnEHAQhmskOHwBzI&export=download",
           "alt": "SurrealDB logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "SurrealDB",
         "description": "SurrealDB is an innovative, multi-model, cloud-ready database, suitable for modern and traditional applications. Its versatility, and focus on developer experience, along with the ability for deployment on cloud, on-premise, embedded, and in edge computing environments, allows developers and organizations to meet the needs of their applications, without needing to worry about scalability or keeping data consistent across multiple different database platforms.\n\nSurrealDB have also established the Women in Rust community, a meetup group where women can connect, collaborate, and grow their skills in Rust.",
@@ -55,7 +55,7 @@
         "image": {
           "path": "https://drive.google.com/uc?id=1aR_a7gAA31YdlEST9gGgT9J8t1DHZr_y&export=download",
           "alt": "Amazon logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "Amazon",
         "description": "Amazon is a global leader in e-commerce, redefining online shopping with its vast product selection, seamless customer experience, and advanced logistics network. With innovations like Amazon Prime, one-click purchasing, and a commitment to fast and reliable delivery, Amazon has transformed the way people shop worldwide.\n\nBeyond e-commerce, Amazon supports education and career growth through initiatives like Amazon Future Engineer, which provides opportunities for underrepresented groups in technology.",
@@ -68,7 +68,7 @@
         "image": {
           "path": "https://drive.google.com/uc?id=1t6N6QEB3KQVZLLlrk3G6MOalAfxIwk-8&export=download",
           "alt": "JetBrains logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "JetBrains",
         "description": "JetBrains creates intelligent software development tools used by over 11.4 million professionals and 88 Fortune Global Top 100 companies. Its lineup of more than 30 products includes IDEs for most programming languages and technologies, such as IntelliJ IDEA, PyCharm, and others, as well as products for team collaboration, like YouTrack and TeamCity.\n\nJetBrains is also known for creating the Kotlin programming language, a cross-platform language used by more than 5 million developers worldwide yearly and recommended by Google as the preferred language for Android development.",
@@ -81,7 +81,7 @@
         "image": {
           "path": "https://drive.google.com/uc?id=1YO0SUlMEvYsP0AdgVWT6X3HR1Lq5x6bZ&export=download",
           "alt": "Devoxx UK logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "Devoxx UK",
         "description": "Provide a first class tech conference where passionate developers can network, hack, get inspired and learn throughout. \n\nDevoxx is a conference by developers, for developers. It is offered at an affordable price so that every developer can enjoy the experience. \n\nDevoxx UK is a community effort. The team is made up of senior developers, user group leaders and passionate experts",
@@ -94,7 +94,7 @@
         "image": {
           "path": "https://drive.google.com/uc?id=1tNYfg0f5Hv78q89Q8tD15tmWyFNQ7fUZ&export=download",
           "alt": "WomenTech Network logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "WomenTech Network",
         "description": "WomenTech Network is one of the world's leading communities for women in tech with more than 9,000 Global Ambassadors representing 179 countries. \n\n70,000 tech leaders have collaborated with the network to date in order to cultivate a diverse global network that reaches 4.5 million people. WomenTech Network strives to empower women in tech through leadership development, professional growth, and mentorship programs. WomenTech Network hosts regular career networking events and a global tech conference for members to connect with like-minded professionals and learn about job opportunities at leading companies that value diversity.\n\nWomenTech Network’s mission is to empower women in tech through leadership development, professional growth, mentorship, and networking events. WomenTech Network is inspiring women to make a difference by building impactful and inclusive technology while introducing them to like-minded people, inspiring speakers, and opportunities at leading companies that aim to create diverse teams and a culture of belonging.",

--- a/src/main/resources/partnersPage.json
+++ b/src/main/resources/partnersPage.json
@@ -39,18 +39,11 @@
     "description": "Our partners are committed to supporting our mission and empowering",
     "items": [
       {
-        "images": [
-          {
-            "path": "https://drive.google.com/uc?id=1sxYKgOSzql2sFX9FLnEHAQhmskOHwBzI&export=download",
-            "alt": "SurrealDB logo",
-            "type": "desktop"
-          },
-          {
-            "path": "https://drive.google.com/uc?id=1sxYKgOSzql2sFX9FLnEHAQhmskOHwBzI&export=download",
-            "alt": "SurrealDB logo",
-            "type": "mobile"
-          }
-        ],
+        "image": {
+          "path": "https://drive.google.com/uc?id=1sxYKgOSzql2sFX9FLnEHAQhmskOHwBzI&export=download",
+          "alt": "SurrealDB logo",
+          "type": "mobile"
+        },
         "name": "SurrealDB",
         "description": "SurrealDB is an innovative, multi-model, cloud-ready database, suitable for modern and traditional applications. Its versatility, and focus on developer experience, along with the ability for deployment on cloud, on-premise, embedded, and in edge computing environments, allows developers and organizations to meet the needs of their applications, without needing to worry about scalability or keeping data consistent across multiple different database platforms.\n\nSurrealDB have also established the Women in Rust community, a meetup group where women can connect, collaborate, and grow their skills in Rust.",
         "link": {
@@ -59,18 +52,11 @@
         }
       },
       {
-        "images": [
-          {
-            "path": "https://drive.google.com/uc?id=1aR_a7gAA31YdlEST9gGgT9J8t1DHZr_y&export=download",
-            "alt": "Amazon logo",
-            "type": "desktop"
-          },
-          {
-            "path": "https://drive.google.com/uc?id=1aR_a7gAA31YdlEST9gGgT9J8t1DHZr_y&export=download",
-            "alt": "Amazon logo",
-            "type": "mobile"
-          }
-        ],
+        "image": {
+          "path": "https://drive.google.com/uc?id=1aR_a7gAA31YdlEST9gGgT9J8t1DHZr_y&export=download",
+          "alt": "Amazon logo",
+          "type": "mobile"
+        },
         "name": "Amazon",
         "description": "Amazon is a global leader in e-commerce, redefining online shopping with its vast product selection, seamless customer experience, and advanced logistics network. With innovations like Amazon Prime, one-click purchasing, and a commitment to fast and reliable delivery, Amazon has transformed the way people shop worldwide.\n\nBeyond e-commerce, Amazon supports education and career growth through initiatives like Amazon Future Engineer, which provides opportunities for underrepresented groups in technology.",
         "link": {
@@ -79,18 +65,11 @@
         }
       },
       {
-        "images": [
-          {
-            "path": "https://drive.google.com/uc?id=1t6N6QEB3KQVZLLlrk3G6MOalAfxIwk-8&export=download",
-            "alt": "JetBrains logo",
-            "type": "desktop"
-          },
-          {
-            "path": "https://drive.google.com/uc?id=1t6N6QEB3KQVZLLlrk3G6MOalAfxIwk-8&export=download",
-            "alt": "JetBrains logo",
-            "type": "mobile"
-          }
-        ],
+        "image": {
+          "path": "https://drive.google.com/uc?id=1t6N6QEB3KQVZLLlrk3G6MOalAfxIwk-8&export=download",
+          "alt": "JetBrains logo",
+          "type": "mobile"
+        },
         "name": "JetBrains",
         "description": "JetBrains creates intelligent software development tools used by over 11.4 million professionals and 88 Fortune Global Top 100 companies. Its lineup of more than 30 products includes IDEs for most programming languages and technologies, such as IntelliJ IDEA, PyCharm, and others, as well as products for team collaboration, like YouTrack and TeamCity.\n\nJetBrains is also known for creating the Kotlin programming language, a cross-platform language used by more than 5 million developers worldwide yearly and recommended by Google as the preferred language for Android development.",
         "link": {
@@ -99,18 +78,11 @@
         }
       },
       {
-        "images": [
-          {
-            "path": "https://drive.google.com/uc?id=1YO0SUlMEvYsP0AdgVWT6X3HR1Lq5x6bZ&export=download",
-            "alt": "Devoxx UK logo",
-            "type": "desktop"
-          },
-          {
-            "path": "https://drive.google.com/uc?id=1YO0SUlMEvYsP0AdgVWT6X3HR1Lq5x6bZ&export=download",
-            "alt": "Devoxx UK logo",
-            "type": "mobile"
-          }
-        ],
+        "image": {
+          "path": "https://drive.google.com/uc?id=1YO0SUlMEvYsP0AdgVWT6X3HR1Lq5x6bZ&export=download",
+          "alt": "Devoxx UK logo",
+          "type": "mobile"
+        },
         "name": "Devoxx UK",
         "description": "Provide a first class tech conference where passionate developers can network, hack, get inspired and learn throughout. \n\nDevoxx is a conference by developers, for developers. It is offered at an affordable price so that every developer can enjoy the experience. \n\nDevoxx UK is a community effort. The team is made up of senior developers, user group leaders and passionate experts",
         "link": {
@@ -119,18 +91,11 @@
         }
       },
       {
-        "images": [
-          {
-            "path": "https://drive.google.com/uc?id=1tNYfg0f5Hv78q89Q8tD15tmWyFNQ7fUZ&export=download",
-            "alt": "WomenTech Network logo",
-            "type": "desktop"
-          },
-          {
-            "path": "https://drive.google.com/uc?id=1tNYfg0f5Hv78q89Q8tD15tmWyFNQ7fUZ&export=download",
-            "alt": "WomenTech Network logo",
-            "type": "mobile"
-          }
-        ],
+        "image": {
+          "path": "https://drive.google.com/uc?id=1tNYfg0f5Hv78q89Q8tD15tmWyFNQ7fUZ&export=download",
+          "alt": "WomenTech Network logo",
+          "type": "mobile"
+        },
         "name": "WomenTech Network",
         "description": "WomenTech Network is one of the world's leading communities for women in tech with more than 9,000 Global Ambassadors representing 179 countries. \n\n70,000 tech leaders have collaborated with the network to date in order to cultivate a diverse global network that reaches 4.5 million people. WomenTech Network strives to empower women in tech through leadership development, professional growth, and mentorship programs. WomenTech Network hosts regular career networking events and a global tech conference for members to connect with like-minded professionals and learn about job opportunities at leading companies that value diversity.\n\nWomenTech Network’s mission is to empower women in tech through leadership development, professional growth, mentorship, and networking events. WomenTech Network is inspiring women to make a difference by building impactful and inclusive technology while introducing them to like-minded people, inspiring speakers, and opportunities at leading companies that aim to create diverse teams and a culture of belonging.",
         "link": {

--- a/src/test/java/com/wcc/platform/controller/DefaultControllerTest.java
+++ b/src/test/java/com/wcc/platform/controller/DefaultControllerTest.java
@@ -110,6 +110,7 @@ class DefaultControllerTest {
             .events(createSectionEvent("Events", ProgramType.TECH_TALK))
             .announcements(createSectionEvent("Announcements", ProgramType.OTHERS))
             .feedbackSection(SetupMentorshipFactories.createFeedbackSectionTest())
+            .partners(SetupFactories.createListSectionPartnerTest())
             .build();
 
     when(service.getLandingPage()).thenReturn(page);

--- a/src/test/java/com/wcc/platform/factories/SetupFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetupFactories.java
@@ -29,9 +29,9 @@ import com.wcc.platform.domain.cms.pages.TeamPage;
 import com.wcc.platform.domain.cms.pages.aboutus.AboutUsPage;
 import com.wcc.platform.domain.cms.pages.aboutus.CelebrateHerPage;
 import com.wcc.platform.domain.cms.pages.aboutus.CodeOfConductPage;
-import com.wcc.platform.domain.platform.AboutHer;
 import com.wcc.platform.domain.cms.pages.aboutus.PartnersPage;
 import com.wcc.platform.domain.cms.pages.programme.ProgrammeItem;
+import com.wcc.platform.domain.platform.AboutHer;
 import com.wcc.platform.domain.platform.Event;
 import com.wcc.platform.domain.platform.LeadershipMember;
 import com.wcc.platform.domain.platform.Member;
@@ -420,7 +420,6 @@ public class SetupFactories {
     }
   }
 
-
   /** CelebrateHer factory for testing. */
   public static CelebrateHerPage createCelebrateHerPageTest() {
     final String pageId = PageType.CELEBRATE_HER.getId();
@@ -460,7 +459,8 @@ public class SetupFactories {
         createListSectionEventTest(),
         createListSectionEventTest(),
         createFeedbackSectionTest(),
-        createCommonSectionTest("Volunteer Section"));
+        createCommonSectionTest("Volunteer Section"),
+        createListSectionPartnerTest());
   }
 
   /**
@@ -476,5 +476,4 @@ public class SetupFactories {
       return createLandingPageTest();
     }
   }
-
 }

--- a/src/test/java/com/wcc/platform/factories/SetupFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetupFactories.java
@@ -339,7 +339,7 @@ public class SetupFactories {
    */
   public static Partner createPartnerTest() {
     return new Partner(
-        createImageTest(ImageType.MOBILE), "Partner", "Partner description", createLinkTest());
+        createImageTest(ImageType.DESKTOP), "Partner", "Partner description", createLinkTest());
   }
 
   public static Image createImageTest(final ImageType type) {

--- a/src/test/java/com/wcc/platform/factories/SetupFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetupFactories.java
@@ -339,10 +339,7 @@ public class SetupFactories {
    */
   public static Partner createPartnerTest() {
     return new Partner(
-        List.of(createImageTest(ImageType.DESKTOP)),
-        "Partner",
-        "Partner description",
-        createLinkTest());
+        createImageTest(ImageType.MOBILE), "Partner", "Partner description", createLinkTest());
   }
 
   public static Image createImageTest(final ImageType type) {

--- a/src/test/java/com/wcc/platform/integrationtests/CmsServiceIntegrationTest.java
+++ b/src/test/java/com/wcc/platform/integrationtests/CmsServiceIntegrationTest.java
@@ -142,8 +142,8 @@ class CmsServiceIntegrationTest extends SurrealDbIntegrationTest {
     assertEquals(celebrateHerPage.items(), result.items());
   }
 
-  @SuppressWarnings("unchecked")
   @Test
+  @SuppressWarnings("unchecked")
   void testGetLandingPage() {
     var landingPage = createLandingPageTest(LANDING_PAGE.getFileName());
     pageRepository.create(objectMapper.convertValue(landingPage, Map.class));
@@ -157,6 +157,7 @@ class CmsServiceIntegrationTest extends SurrealDbIntegrationTest {
     assertEquals(
         landingPage.getFeedbackSection().feedbacks().size(),
         result.getFeedbackSection().feedbacks().size());
+    assertEquals(landingPage.getPartners().items().size(), result.getPartners().items().size());
   }
 
   @Test

--- a/src/test/java/com/wcc/platform/integrationtests/CmsServiceIntegrationTest.java
+++ b/src/test/java/com/wcc/platform/integrationtests/CmsServiceIntegrationTest.java
@@ -187,8 +187,8 @@ class CmsServiceIntegrationTest extends SurrealDbIntegrationTest {
     // Assert partner
     assertEquals(4, result.partners().items().size());
     assertEquals(
-        "https://drive.google.com/surrealdb-desktop-logo.png",
-        result.partners().items().getFirst().getImages().getFirst().path());
+        "https://drive.google.com/surrealdb-mobile-logo.png",
+        result.partners().items().getFirst().getImage().path());
     assertEquals("SurrealDB", result.partners().items().getFirst().getName());
     assertEquals(
         "SurrealDB is an innovative, multi-model, cloud-ready database, suitable"

--- a/src/test/java/com/wcc/platform/integrationtests/CmsServiceIntegrationTest.java
+++ b/src/test/java/com/wcc/platform/integrationtests/CmsServiceIntegrationTest.java
@@ -187,7 +187,7 @@ class CmsServiceIntegrationTest extends SurrealDbIntegrationTest {
     // Assert partner
     assertEquals(4, result.partners().items().size());
     assertEquals(
-        "https://drive.google.com/surrealdb-mobile-logo.png",
+        "https://drive.google.com/surrealdb-desktop-logo.png",
         result.partners().items().getFirst().getImage().path());
     assertEquals("SurrealDB", result.partners().items().getFirst().getName());
     assertEquals(

--- a/src/test/java/com/wcc/platform/service/CmsServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/CmsServiceTest.java
@@ -38,6 +38,7 @@ class CmsServiceTest {
           .fullBannerSection(SetupFactories.createCommonSectionTest("Page banner section"))
           .feedbackSection(SetupMentorshipFactories.createFeedbackSectionTest())
           .volunteerSection(SetupFactories.createCommonSectionTest("Volunteer"))
+          .partners(SetupFactories.createListSectionPartnerTest())
           .build();
   @Mock private PageRepository pageRepository;
   @Mock private ObjectMapper objectMapper;

--- a/src/test/resources/landingPage.json
+++ b/src/test/resources/landingPage.json
@@ -153,5 +153,70 @@
         "type": "DESKTOP"
       }
     ]
+  },
+  "partners": {
+    "title": "Community Partners",
+    "items": [
+      {
+        "images": [
+          {
+            "path": "https://drive.google.com/surrealdb-desktop-logo.png",
+            "alt": "SurrealDB logo",
+            "type": "desktop"
+          },
+          {
+            "path": "https://drive.google.com/surrealdb-mobile-logo.png",
+            "alt": "SurrealDB logo",
+            "type": "mobile"
+          }
+        ],
+        "name": "SurrealDB"
+      },
+      {
+        "images": [
+          {
+            "path": "https://drive.google.com/amazon-desktop-logo.png",
+            "alt": "Amazon logo",
+            "type": "desktop"
+          },
+          {
+            "path": "https://drive.google.com/amazon-mobile-logo.png",
+            "alt": "Amazon logo",
+            "type": "mobile"
+          }
+        ],
+        "name": "Amazon"
+      },
+      {
+        "images": [
+          {
+            "path": "jetbrains-desktop-logo.png",
+            "alt": "JetBrains logo",
+            "type": "desktop"
+          },
+          {
+            "path": "jetbrains-mobile-logo.png",
+            "alt": "JetBrains logo",
+            "type": "mobile"
+          }
+        ],
+        "name": "JetBrains"
+      },
+      {
+        "images": [
+          {
+            "path": "https://drive.google.com/devoxx-uk-desktop-logo.png",
+            "alt": "Devoxx UK logo",
+            "type": "desktop"
+          },
+          {
+            "path": "https://drive.google.com/devoxx-uk-mobile-logo.png",
+            "alt": "Devoxx UK logo",
+            "type": "mobile"
+          }
+        ],
+        "name": "Devoxx UK"
+      }
+    ]
   }
 }

--- a/src/test/resources/landingPage.json
+++ b/src/test/resources/landingPage.json
@@ -159,9 +159,9 @@
     "items": [
       {
         "image": {
-          "path": "https://drive.google.com/surrealdb-mobile-logo.png",
+          "path": "https://drive.google.com/surrealdb-desktop-logo.png",
           "alt": "SurrealDB logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "SurrealDB",
         "link": {
@@ -170,9 +170,9 @@
       },
       {
         "image": {
-          "path": "https://drive.google.com/amazon-mobile-logo.png",
+          "path": "https://drive.google.com/amazon-desktop-logo.png",
           "alt": "Amazon logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "Amazon",
         "link": {
@@ -181,9 +181,9 @@
       },
       {
         "image": {
-          "path": "jetbrains-mobile-logo.png",
+          "path": "https://drive.google.com/jetbrains-desktop-logo.png",
           "alt": "JetBrains logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "JetBrains",
         "link": {
@@ -192,9 +192,9 @@
       },
       {
         "image": {
-          "path": "https://drive.google.com/devoxx-uk-mobile-logo.png",
+          "path": "https://drive.google.com/devoxx-uk-desktop-logo.png",
           "alt": "Devoxx UK logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "Devoxx UK",
         "link": {

--- a/src/test/resources/landingPage.json
+++ b/src/test/resources/landingPage.json
@@ -158,64 +158,48 @@
     "title": "Community Partners",
     "items": [
       {
-        "images": [
-          {
-            "path": "https://drive.google.com/surrealdb-desktop-logo.png",
-            "alt": "SurrealDB logo",
-            "type": "desktop"
-          },
-          {
-            "path": "https://drive.google.com/surrealdb-mobile-logo.png",
-            "alt": "SurrealDB logo",
-            "type": "mobile"
-          }
-        ],
-        "name": "SurrealDB"
+        "image": {
+          "path": "https://drive.google.com/surrealdb-mobile-logo.png",
+          "alt": "SurrealDB logo",
+          "type": "mobile"
+        },
+        "name": "SurrealDB",
+        "link": {
+          "uri": "https://surrealdb.com/"
+        }
       },
       {
-        "images": [
-          {
-            "path": "https://drive.google.com/amazon-desktop-logo.png",
-            "alt": "Amazon logo",
-            "type": "desktop"
-          },
-          {
-            "path": "https://drive.google.com/amazon-mobile-logo.png",
-            "alt": "Amazon logo",
-            "type": "mobile"
-          }
-        ],
-        "name": "Amazon"
+        "image": {
+          "path": "https://drive.google.com/amazon-mobile-logo.png",
+          "alt": "Amazon logo",
+          "type": "mobile"
+        },
+        "name": "Amazon",
+        "link": {
+          "uri": "https://www.amazon.com/"
+        }
       },
       {
-        "images": [
-          {
-            "path": "jetbrains-desktop-logo.png",
-            "alt": "JetBrains logo",
-            "type": "desktop"
-          },
-          {
-            "path": "jetbrains-mobile-logo.png",
-            "alt": "JetBrains logo",
-            "type": "mobile"
-          }
-        ],
-        "name": "JetBrains"
+        "image": {
+          "path": "jetbrains-mobile-logo.png",
+          "alt": "JetBrains logo",
+          "type": "mobile"
+        },
+        "name": "JetBrains",
+        "link": {
+          "uri": "https://www.jetbrains.com/"
+        }
       },
       {
-        "images": [
-          {
-            "path": "https://drive.google.com/devoxx-uk-desktop-logo.png",
-            "alt": "Devoxx UK logo",
-            "type": "desktop"
-          },
-          {
-            "path": "https://drive.google.com/devoxx-uk-mobile-logo.png",
-            "alt": "Devoxx UK logo",
-            "type": "mobile"
-          }
-        ],
-        "name": "Devoxx UK"
+        "image": {
+          "path": "https://drive.google.com/devoxx-uk-mobile-logo.png",
+          "alt": "Devoxx UK logo",
+          "type": "mobile"
+        },
+        "name": "Devoxx UK",
+        "link": {
+          "uri": "https://www.devoxx.co.uk/"
+        }
       }
     ]
   }

--- a/src/test/resources/partnersPage.json
+++ b/src/test/resources/partnersPage.json
@@ -31,9 +31,9 @@
     "items": [
       {
         "image": {
-          "path": "https://drive.google.com/surrealdb-mobile-logo.png",
+          "path": "https://drive.google.com/surrealdb-desktop-logo.png",
           "alt": "SurrealDB logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "SurrealDB",
         "description": "SurrealDB is an innovative, multi-model, cloud-ready database, suitable for modern and traditional applications.",
@@ -44,9 +44,9 @@
       },
       {
         "image": {
-          "path": "https://drive.google.com/amazon-mobile-logo.png",
+          "path": "https://drive.google.com/amazon-desktop-logo.png",
           "alt": "Amazon logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "Amazon",
         "description": "Amazon is a global leader in e-commerce, redefining online shopping with its vast product selection, seamless customer experience, and advanced logistics network.",
@@ -57,9 +57,9 @@
       },
       {
         "image": {
-          "path": "jetbrains-mobile-logo.png",
+          "path": "https://drive.google.com/jetbrains-desktop-logo.png",
           "alt": "JetBrains logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "JetBrains",
         "description": "JetBrains creates intelligent software development tools used by over 11.4 million professionals and 88 Fortune Global Top 100 companies.",
@@ -70,9 +70,9 @@
       },
       {
         "image": {
-          "path": "https://drive.google.com/devoxx-uk-mobile-logo.png",
+          "path": "https://drive.google.com/devoxx-uk-desktop-logo.png",
           "alt": "Devoxx UK logo",
-          "type": "mobile"
+          "type": "desktop"
         },
         "name": "Devoxx UK",
         "description": "Provide a first class tech conference where passionate developers can network, hack, get inspired and learn throughout.",

--- a/src/test/resources/partnersPage.json
+++ b/src/test/resources/partnersPage.json
@@ -30,18 +30,11 @@
     "description": "Our partners are committed to supporting our mission and empowering",
     "items": [
       {
-        "images": [
-          {
-            "path": "https://drive.google.com/surrealdb-desktop-logo.png",
-            "alt": "SurrealDB logo",
-            "type": "desktop"
-          },
-          {
-            "path": "https://drive.google.com/surrealdb-mobile-logo.png",
-            "alt": "SurrealDB logo",
-            "type": "mobile"
-          }
-        ],
+        "image": {
+          "path": "https://drive.google.com/surrealdb-mobile-logo.png",
+          "alt": "SurrealDB logo",
+          "type": "mobile"
+        },
         "name": "SurrealDB",
         "description": "SurrealDB is an innovative, multi-model, cloud-ready database, suitable for modern and traditional applications.",
         "link": {
@@ -50,18 +43,11 @@
         }
       },
       {
-        "images": [
-          {
-            "path": "https://drive.google.com/amazon-desktop-logo.png",
-            "alt": "Amazon logo",
-            "type": "desktop"
-          },
-          {
-            "path": "https://drive.google.com/amazon-mobile-logo.png",
-            "alt": "Amazon logo",
-            "type": "mobile"
-          }
-        ],
+        "image": {
+          "path": "https://drive.google.com/amazon-mobile-logo.png",
+          "alt": "Amazon logo",
+          "type": "mobile"
+        },
         "name": "Amazon",
         "description": "Amazon is a global leader in e-commerce, redefining online shopping with its vast product selection, seamless customer experience, and advanced logistics network.",
         "link": {
@@ -70,18 +56,11 @@
         }
       },
       {
-        "images": [
-          {
-            "path": "jetbrains-desktop-logo.png",
-            "alt": "JetBrains logo",
-            "type": "desktop"
-          },
-          {
-            "path": "jetbrains-mobile-logo.png",
-            "alt": "JetBrains logo",
-            "type": "mobile"
-          }
-        ],
+        "image": {
+          "path": "jetbrains-mobile-logo.png",
+          "alt": "JetBrains logo",
+          "type": "mobile"
+        },
         "name": "JetBrains",
         "description": "JetBrains creates intelligent software development tools used by over 11.4 million professionals and 88 Fortune Global Top 100 companies.",
         "link": {
@@ -90,18 +69,11 @@
         }
       },
       {
-        "images": [
-          {
-            "path": "https://drive.google.com/devoxx-uk-desktop-logo.png",
-            "alt": "Devoxx UK logo",
-            "type": "desktop"
-          },
-          {
-            "path": "https://drive.google.com/devoxx-uk-mobile-logo.png",
-            "alt": "Devoxx UK logo",
-            "type": "mobile"
-          }
-        ],
+        "image": {
+          "path": "https://drive.google.com/devoxx-uk-mobile-logo.png",
+          "alt": "Devoxx UK logo",
+          "type": "mobile"
+        },
         "name": "Devoxx UK",
         "description": "Provide a first class tech conference where passionate developers can network, hack, get inspired and learn throughout.",
         "link": {


### PR DESCRIPTION
## Description

Update Landing page to include partners's images/icons at the bottom of the page (above the footer)

LandingPage.java:
 - add partners section at the bottom of the page

Partner.java:
  - updated validation constraints (since some fields are not mandatory for the landing page partners' section)
  
Update landingPage.json files (resources)
Update tests

NOTE: **There will be 6 to 8 partners in the row randomly displayed on the Landing page**.

NOTE: Partner.java class fields are updated. **images** field  is changed to **image**, it contains just **one** DESKTOP image which is used on all displays.

## Related Issue

Closes: https://github.com/Women-Coding-Community/wcc-backend/issues/316

## Change Type

- [ ] Bug Fix
- [X] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Test
- [ ] Other

## Screenshots

Landing page with new partners section.
![Screenshot (221)](https://github.com/user-attachments/assets/617e3d55-fb46-4bbb-991d-0d63c29b9ad6)

Updated Landing page:
![Screenshot (182)](https://github.com/user-attachments/assets/5af5e906-bb91-4e7a-b5d8-2234389e0417)


Updated Partner class (removed mandatory fields from description and link)
![Screenshot (181)](https://github.com/user-attachments/assets/f0101f37-c07c-4eaa-83c1-520e9300e23a)


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [X] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->