### PR TITLE
bug: DB table is not created when starting the app

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
     username: postgres
     password: MFpFnhhICniFNPA
     driver-class-name: org.postgresql.Driver
+  sql:
+    init:
+      mode: always   # Tells Spring to run schema.sql at startup
 
 security:
   api:

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,6 +1,1 @@
-CREATE database wcc;
-
--- Connect to the database
--- \c wcc
-
 CREATE TABLE IF NOT EXISTS page(id TEXT PRIMARY KEY, data JSONB NOT NULL);


### PR DESCRIPTION
## Bug description
DB table "page" is not created when app is started.

![Screenshot (6)](https://github.com/user-attachments/assets/5e5275a9-6f77-490a-9ed9-888a75f69e71)


## Steps to reproduce:
1. Update repo to latest changes
2. Build app (jar) and start docker-compose
3. Open localhost Swagger and try to execute POST page
4. Notice the error: Table page does not exist

## Solution
Add command to application properties yml file to execute sql schema at startup. 
Remove DB create command from the schema.sql since it is created from docker-compose.yml

## Change Type

- [X] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Test
- [ ] Other

## Screenshots

<!--  Please include screenshots from the Swagger API. -->

POST
![Screenshot (8)](https://github.com/user-attachments/assets/3aee4939-432f-4e3e-9fe5-5b986bcb83f9)

GET
![Screenshot (9)](https://github.com/user-attachments/assets/edce392e-b88b-411c-9395-ea2a9f7930a0)


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [X] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->