### PR TITLE
Automatically update the database with flyway

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
     implementation("org.postgresql:postgresql:42.7.2")
+    implementation("org.flywaydb:flyway-core")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.skyscreamer:jsonassert:1.5.3")

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -6,3 +6,10 @@ spring:
 file:
   storage:
     directory: /app/data
+
+logging:
+  level:
+    org:
+      springframework:
+        jdbc: WARN
+      flywaydb: WARN

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,19 @@ spring:
     username: postgres
     password: MFpFnhhICniFNPA
     driver-class-name: org.postgresql.Driver
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+    validate-on-migrate: true
+    clean-disabled: false
+
+logging:
+  level:
+    org:
+      springframework:
+        jdbc: DEBUG
+      flywaydb: DEBUG
 
 security:
   api:

--- a/src/main/resources/db/migration/V1__create_page_table.sql
+++ b/src/main/resources/db/migration/V1__create_page_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS page(
+                                   id TEXT PRIMARY KEY,
+                                   data JSONB NOT NULL
+);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,6 +1,0 @@
-CREATE database wcc;
-
--- Connect to the database
--- \c wcc
-
-CREATE TABLE IF NOT EXISTS page(id TEXT PRIMARY KEY, data JSONB NOT NULL);


### PR DESCRIPTION
## Description

Use Flyway to automatically update the database via migrations. 

## Change Type

- [x] New Feature

## Application log

``` 
2025-06-02T19:55:05.579+02:00  INFO 16446 --- [wcc-backend] [           main] o.f.core.internal.command.DbMigrate      : Current version of schema "public": << Empty Schema >>
2025-06-02T19:55:05.579+02:00 DEBUG 16446 --- [wcc-backend] [           main] o.flywaydb.core.internal.parser.Parser   : Parsing V1__create_page_table.sql ...
2025-06-02T19:55:05.580+02:00 DEBUG 16446 --- [wcc-backend] [           main] o.f.c.i.sqlscript.ParserSqlScript        : Found statement at line 1: CREATE TABLE IF NOT EXISTS page(id TEXT PRIMARY KEY,data JSONB NOT NULL)
2025-06-02T19:55:05.581+02:00 DEBUG 16446 --- [wcc-backend] [           main] o.f.core.internal.command.DbMigrate      : Starting migration of schema "public" to version "1 - create page table" ...
2025-06-02T19:55:05.583+02:00  INFO 16446 --- [wcc-backend] [           main] o.f.core.internal.command.DbMigrate      : Migrating schema "public" to version "1 - create page table"
2025-06-02T19:55:05.584+02:00 DEBUG 16446 --- [wcc-backend] [           main] o.f.c.i.s.DefaultSqlScriptExecutor       : Executing SQL: CREATE TABLE IF NOT EXISTS page(id TEXT PRIMARY KEY, data JSONB NOT NULL)
2025-06-02T19:55:05.589+02:00 DEBUG 16446 --- [wcc-backend] [           main] o.f.c.i.s.DefaultSqlScriptExecutor       : 0 rows affected
2025-06-02T19:55:05.589+02:00 DEBUG 16446 --- [wcc-backend] [           main] o.f.core.internal.command.DbMigrate      : Successfully completed migration of schema "public" to version "1 - create page table"
2025-06-02T19:55:05.593+02:00 DEBUG 16446 --- [wcc-backend] [           main] o.f.c.i.s.JdbcTableSchemaHistory         : Schema History table "public"."flyway_schema_history" successfully updated to reflect changes
2025-06-02T19:55:05.600+02:00  INFO 16446 --- [wcc-backend] [           main] o.f.core.internal.command.DbMigrate      : Successfully applied 1 migration to schema "public", now at version v1 (execution time 00:00.007s)
2025-06-02T19:55:05.603+02:00 DEBUG 16446 --- [wcc-backend] [           main] org.flywaydb.core.FlywayExecutor         : Memory usage: 63 of 96M
``` 

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->