### PR TITLE
feat: DB update migrations

### DIFF
--- a/src/main/resources/db/migration/V3__update_members_data_model.sql
+++ b/src/main/resources/db/migration/V3__update_members_data_model.sql
@@ -1,0 +1,4 @@
+-- Update the MEMBERS table to remove permission_id and set email as NOT NULL
+ALTER TABLE MEMBERS
+    DROP COLUMN permission_id,
+    ALTER COLUMN email SET NOT NULL;


### PR DESCRIPTION
## Description

Add V3__update_members_table.sql:
- new schema to db.migrations to update members table:
   - remove permissions_id column
   - update email column to "not null"

- This change is required:
   -  to remove reference to the permission table since the member can have more permissions and we are to discuss about this implementation. 
   -  email column must be NOT NULL

## Change Type

- [ ] Bug Fix
- [X] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Test
- [ ] Other

## Screenshots

<!--  Please include screenshots from the Swagger API. -->

Running the app and migrations:
![Screenshot (2)](https://github.com/user-attachments/assets/7ea9f4ac-60c8-4a9a-88da-5ce032a3cdf9)

Updated table:
![Screenshot (3)](https://github.com/user-attachments/assets/bfc0f55e-e91c-443c-bd92-8ff39af05db0)

Add AboutUs page:
![Screenshot (4)](https://github.com/user-attachments/assets/4c2b7875-5407-40ef-b249-7fb0e5e35ed7)


Page added to the DB and visible in page table:
![Screenshot (5)](https://github.com/user-attachments/assets/d4aff239-1ea8-4748-853a-0ffd46a954a3)


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [X] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->