### PR TITLE
Add ad hoc timeline API

### DIFF
--- a/src/main/java/com/wcc/platform/controller/MentorshipController.java
+++ b/src/main/java/com/wcc/platform/controller/MentorshipController.java
@@ -1,6 +1,7 @@
 package com.wcc.platform.controller;
 
 import com.wcc.platform.domain.cms.pages.mentorship.MentorsPage;
+import com.wcc.platform.domain.cms.pages.mentorship.MentorshipAdHocTimelinePage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipCodeOfConductPage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipFaqPage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipPage;
@@ -64,5 +65,12 @@ public class MentorshipController {
   @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<MentorsPage> getMentors() {
     return ResponseEntity.ok(service.getMentors());
+  }
+
+  @GetMapping("/ad-hoc-timeline")
+  @Operation(summary = "API to retrieve ad hoc timeline page")
+  @ResponseStatus(HttpStatus.OK)
+  public ResponseEntity<MentorshipAdHocTimelinePage> getAdHocTimeline() {
+    return ResponseEntity.ok(service.getAdHocTimeline());
   }
 }

--- a/src/main/java/com/wcc/platform/domain/cms/PageType.java
+++ b/src/main/java/com/wcc/platform/domain/cms/PageType.java
@@ -23,7 +23,8 @@ public enum PageType {
   CODE_OF_CONDUCT("codeOfConductPage.json", "page:CODE_OF_CONDUCT"),
   CELEBRATE_HER("celebrateHerPage.json", "page:CELEBRATE_HER"),
   PARTNERS("partnersPage.json", "page:PARTNERS"),
-  STUDY_GROUPS("mentorshipStudyGroupsPage.json", "page:STUDY_GROUPS");
+  STUDY_GROUPS("mentorshipStudyGroupsPage.json", "page:STUDY_GROUPS"),
+  AD_HOC_TIMELINE("adHocTimelinePage.json", "page:AD_HOC_TIMELINE");
 
   public static final String ID_PREFIX = "page:";
 

--- a/src/main/java/com/wcc/platform/domain/cms/pages/mentorship/MentorshipAdHocTimelinePage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/mentorship/MentorshipAdHocTimelinePage.java
@@ -1,0 +1,17 @@
+package com.wcc.platform.domain.cms.pages.mentorship;
+
+import com.wcc.platform.domain.cms.attributes.HeroSection;
+import com.wcc.platform.domain.cms.attributes.ListSection;
+import com.wcc.platform.domain.platform.AdHocTimelineMilestone;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * CMS Ad Hoc Timeline Page details.
+ *
+ * @param heroSection hero section to be shown on the ad hoc timeline page
+ * @param adHocTimelineMilestones section to explain the timeline for applying for an ad hoc mentor
+ */
+public record MentorshipAdHocTimelinePage(
+    @NotNull String id,
+    @NotNull HeroSection heroSection,
+    @NotNull ListSection<AdHocTimelineMilestone> adHocTimelineMilestones) {}

--- a/src/main/java/com/wcc/platform/domain/platform/AdHocTimelineMilestone.java
+++ b/src/main/java/com/wcc/platform/domain/platform/AdHocTimelineMilestone.java
@@ -1,0 +1,21 @@
+package com.wcc.platform.domain.platform;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/** AdHocTimelineMilestone class representing the structure of an ad hoc timeline. */
+@Getter
+@EqualsAndHashCode
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AdHocTimelineMilestone {
+  @NotEmpty private String title;
+  @NotEmpty private String description;
+}

--- a/src/main/java/com/wcc/platform/service/MentorshipService.java
+++ b/src/main/java/com/wcc/platform/service/MentorshipService.java
@@ -1,5 +1,6 @@
 package com.wcc.platform.service;
 
+import static com.wcc.platform.domain.cms.PageType.AD_HOC_TIMELINE;
 import static com.wcc.platform.domain.cms.PageType.MENTORS;
 import static com.wcc.platform.domain.cms.PageType.MENTORSHIP;
 import static com.wcc.platform.domain.cms.PageType.MENTORSHIP_CONDUCT;
@@ -8,6 +9,7 @@ import static com.wcc.platform.domain.cms.PageType.STUDY_GROUPS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorsPage;
+import com.wcc.platform.domain.cms.pages.mentorship.MentorshipAdHocTimelinePage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipCodeOfConductPage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipFaqPage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipPage;
@@ -114,5 +116,22 @@ public class MentorshipService {
       }
     }
     return repository.getFallback(MENTORS, MentorsPage.class, objectMapper);
+  }
+
+  /**
+   * API to retrieve information about ad hoc timeline.
+   *
+   * @return Mentorship ad hoc timeline page.
+   */
+  public MentorshipAdHocTimelinePage getAdHocTimeline() {
+    final var page = repository.findById(AD_HOC_TIMELINE.getId());
+    if (page.isPresent()) {
+      try {
+        return objectMapper.convertValue(page.get(), MentorshipAdHocTimelinePage.class);
+      } catch (IllegalArgumentException e) {
+        throw new PlatformInternalException(e.getMessage(), e);
+      }
+    }
+    return repository.getFallback(AD_HOC_TIMELINE, MentorshipAdHocTimelinePage.class, objectMapper);
   }
 }

--- a/src/main/resources/adHocTimelinePage.json
+++ b/src/main/resources/adHocTimelinePage.json
@@ -1,0 +1,38 @@
+{
+  "id": "page:AD_HOC_TIMELINE",
+  "heroSection": {
+    "title": "Ad Hoc Timeline"
+  },
+  "adHocTimelineMilestones": {
+    "items": [
+      {
+        "title": "Application period",
+        "description": "Every month (from June to November), interested mentees will have the opportunity to apply to the one-time mentorship session program. The application opens at the beginning of each month and it is possible to apply for a mentor during the first 10 days of each month."
+      },
+      {
+        "title": "Mentee selection",
+        "description": "Once the application period has ended, the Mentorship Programme Team will review the applications and select the mentees who will participate in the program for the month."
+      },
+      {
+        "title": "Mentor notification",
+        "description": "The Mentorship Programme Team will send a list of selected mentees to the mentors, along with their profiles and information about their goals and expectations for the mentorship."
+      },
+      {
+        "title": "Scheduling sessions",
+        "description": "The Mentorship Programme Team will share the mentor's Calendly link with the mentees if the mentor has provided it to the team. The team will also communicate this information via email to both the mentor and the mentee."
+      },
+      {
+        "title": "Session preparation",
+        "description": "Before each session, mentors and mentees should prepare and plan for the meeting, setting clear goals and objectives for the session."
+      },
+      {
+        "title": "Feedback",
+        "description": "After one-time session mentors will ask the mentee's feedback on the session and the program itself."
+      },
+      {
+        "title": "Program evaluation",
+        "description": "Both mentor and mentee are responsible for informing the Mentorship Programme Team about the session taking place and providing feedback afterwards. At the end of the year, the Mentorship Programme Team will collect feedback from mentors and evaluate feedback from mentees to identify areas for improvement and make any necessary adjustments."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the get API for the ad hoc timeline. This is required to have this timeline on the new website.

This PR closes issue https://github.com/Women-Coding-Community/wcc-backend/issues/328

## Related Issue

Please link to the issue here
Closes https://github.com/Women-Coding-Community/wcc-backend/issues/328

## Change Type

- [ ] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Test
- [ ] Other

## Screenshots

Screenshot from Swagger API:
<img width="1414" alt="image" src="https://github.com/user-attachments/assets/a6906e22-9101-4b22-a386-36bff99d39aa" />


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [ ] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->