### PR TITLE
Restrict Playwright GitHub Actions pipeline execution to main repo only to prevent unintended runs from forks.

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'Women-Coding-Community/wcc-backend'
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
## Description

Restrict Playwright GitHub Actions pipeline execution to main repo only to prevent unintended runs from forks.

## Related Issue
Closes https://github.com/Women-Coding-Community/wcc-backend/issues/360

## Change Type

- [x] Bug Fix

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.