### PR TITLE
feat: Add mentorship resources page endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -531,3 +531,22 @@ docker compose -f docker/docker-compose.yml up postgres
 - Generate Postman collection: `./gradlew postmanGenerate`
 
 See `docs/resource_api.md` for detailed resource API documentation.
+
+## Git Commit Conventions
+
+**IMPORTANT: DO NOT include AI attribution in commit messages**
+
+When creating commits:
+- ❌ **NEVER** add "Generated with Claude Code" or similar AI attribution lines
+- ❌ **NEVER** add "Co-Authored-By: Claude" or AI co-author tags
+- ✅ Use standard conventional commit format: `feat:`, `fix:`, `docs:`, etc.
+- ✅ Keep commit messages concise and focused on the "why" rather than the "what"
+- ✅ Follow the existing commit style in the repository
+
+**Example of correct commit message:**
+```
+feat: Add mentorship resources page endpoint
+
+Implement new CMS endpoint to serve downloadable mentorship resources
+including guides for mentees and mentors with Google Drive links.
+```

--- a/src/main/java/com/wcc/platform/controller/MentorshipController.java
+++ b/src/main/java/com/wcc/platform/controller/MentorshipController.java
@@ -10,6 +10,7 @@ import com.wcc.platform.domain.cms.pages.mentorship.MentorshipAdHocTimelinePage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipCodeOfConductPage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipFaqPage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipPage;
+import com.wcc.platform.domain.cms.pages.mentorship.MentorshipResourcesPage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipStudyGroupsPage;
 import com.wcc.platform.domain.platform.mentorship.MentorshipType;
 import com.wcc.platform.service.MentorshipPagesService;
@@ -108,5 +109,12 @@ public class MentorshipController {
   @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<MentorshipAdHocTimelinePage> getAdHocTimeline() {
     return ResponseEntity.ok(service.getAdHocTimeline());
+  }
+
+  @GetMapping("/resources")
+  @Operation(summary = "API to retrieve mentorship resources page")
+  @ResponseStatus(HttpStatus.OK)
+  public ResponseEntity<MentorshipResourcesPage> getMentorshipResources() {
+    return ResponseEntity.ok(service.getResources());
   }
 }

--- a/src/main/java/com/wcc/platform/domain/cms/PageType.java
+++ b/src/main/java/com/wcc/platform/domain/cms/PageType.java
@@ -26,7 +26,8 @@ public enum PageType {
   CELEBRATE_HER("init-data/celebrateHerPage.json", "page:CELEBRATE_HER"),
   PARTNERS("init-data/partnersPage.json", "page:PARTNERS"),
   STUDY_GROUPS("init-data/mentorshipStudyGroupsPage.json", "page:STUDY_GROUPS"),
-  AD_HOC_TIMELINE("init-data/adHocTimelinePage.json", "page:AD_HOC_TIMELINE");
+  AD_HOC_TIMELINE("init-data/adHocTimelinePage.json", "page:AD_HOC_TIMELINE"),
+  MENTORSHIP_RESOURCES("init-data/mentorshipResourcesPage.json", "page:MENTORSHIP_RESOURCES");
 
   public static final String ID_PREFIX = "page:";
 

--- a/src/main/java/com/wcc/platform/domain/cms/pages/mentorship/MentorshipResource.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/mentorship/MentorshipResource.java
@@ -1,0 +1,25 @@
+package com.wcc.platform.domain.cms.pages.mentorship;
+
+import com.wcc.platform.domain.cms.attributes.Image;
+import com.wcc.platform.domain.cms.attributes.LabelLink;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/** MentorshipResource class representing the structure of a mentorship resource. */
+@Getter
+@EqualsAndHashCode
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MentorshipResource {
+  @NotEmpty private String title;
+  @NotNull private LabelLink link;
+  @NotNull private Image image;
+}

--- a/src/main/java/com/wcc/platform/domain/cms/pages/mentorship/MentorshipResourcesPage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/mentorship/MentorshipResourcesPage.java
@@ -1,0 +1,15 @@
+package com.wcc.platform.domain.cms.pages.mentorship;
+
+import com.wcc.platform.domain.cms.attributes.CommonSection;
+import com.wcc.platform.domain.cms.attributes.HeroSection;
+import com.wcc.platform.domain.cms.attributes.ListSection;
+import com.wcc.platform.domain.cms.attributes.style.CustomStyle;
+import jakarta.validation.constraints.NotNull;
+
+/** Represents the Mentorship Resources page. */
+public record MentorshipResourcesPage(
+    @NotNull String id,
+    @NotNull HeroSection heroSection,
+    @NotNull CommonSection section,
+    @NotNull ListSection<MentorshipResource> resourcesSection,
+    @NotNull CustomStyle customStyle) {}

--- a/src/main/java/com/wcc/platform/domain/platform/type/ResourceType.java
+++ b/src/main/java/com/wcc/platform/domain/platform/type/ResourceType.java
@@ -16,7 +16,8 @@ public enum ResourceType {
   OTHER(5),
   MENTOR_RESOURCE(6),
   IMAGE(7),
-  RESOURCE(8);
+  RESOURCE(8),
+  MENTORSHIP(9);
 
   private final int resourceTypeId;
 
@@ -54,6 +55,7 @@ public enum ResourceType {
           StringUtils.trimToEmpty(properties.getEventsFolder());
       case MENTOR_RESOURCE -> StringUtils.trimToEmpty(properties.getMentorsFolder());
       case IMAGE -> StringUtils.trimToEmpty(properties.getImagesFolder());
+      case MENTORSHIP -> StringUtils.trimToEmpty(properties.getResourcesFolder());
       default -> StringUtils.trimToEmpty(properties.getResourcesFolder());
     };
   }

--- a/src/main/java/com/wcc/platform/service/MentorshipPagesService.java
+++ b/src/main/java/com/wcc/platform/service/MentorshipPagesService.java
@@ -6,6 +6,7 @@ import static com.wcc.platform.domain.cms.PageType.MENTORSHIP;
 import static com.wcc.platform.domain.cms.PageType.MENTORSHIP_CONDUCT;
 import static com.wcc.platform.domain.cms.PageType.MENTORSHIP_FAQ;
 import static com.wcc.platform.domain.cms.PageType.MENTORSHIP_LONG_TIMELINE;
+import static com.wcc.platform.domain.cms.PageType.MENTORSHIP_RESOURCES;
 import static com.wcc.platform.domain.cms.PageType.STUDY_GROUPS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,6 +17,7 @@ import com.wcc.platform.domain.cms.pages.mentorship.MentorshipAdHocTimelinePage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipCodeOfConductPage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipFaqPage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipPage;
+import com.wcc.platform.domain.cms.pages.mentorship.MentorshipResourcesPage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipStudyGroupsPage;
 import com.wcc.platform.domain.exceptions.PlatformInternalException;
 import com.wcc.platform.repository.PageRepository;
@@ -172,5 +174,23 @@ public class MentorshipPagesService {
       }
     }
     return repository.getFallback(AD_HOC_TIMELINE, MentorshipAdHocTimelinePage.class, objectMapper);
+  }
+
+  /**
+   * API to retrieve information about mentorship resources.
+   *
+   * @return Mentorship resources page.
+   */
+  public MentorshipResourcesPage getResources() {
+    final var page = repository.findById(MENTORSHIP_RESOURCES.getId());
+    if (page.isPresent()) {
+      try {
+        return objectMapper.convertValue(page.get(), MentorshipResourcesPage.class);
+      } catch (IllegalArgumentException e) {
+        throw new PlatformInternalException(e.getMessage(), e);
+      }
+    }
+    return repository.getFallback(
+        MENTORSHIP_RESOURCES, MentorshipResourcesPage.class, objectMapper);
   }
 }

--- a/src/main/resources/init-data/mentorshipResourcesPage.json
+++ b/src/main/resources/init-data/mentorshipResourcesPage.json
@@ -1,0 +1,60 @@
+{
+  "id": "page:MENTORSHIP_RESOURCES",
+  "heroSection": {
+    "title": "Mentorship Resources"
+  },
+  "section": {
+    "description": "Whether you’re a mentee looking to navigate your journey, a mentor aiming to provide the best guidance, or a seasoned mentor seeking quick tips, we have the tools you need. Explore our guides for insightful mentorship advice and strategies."
+  },
+  "resourcesSection": {
+    "title": "Available Resources",
+    "description": "Download and explore our curated mentorship materials",
+    "items": [
+      {
+        "title": "Mentees Guide",
+        "link": {
+          "label": "Download PDF",
+          "uri": "https://drive.google.com/file/d/1xPbW8BlQoLXkuAJ7m0RuvOV02Opyr445"
+        },
+        "image": {
+          "path": "https://drive.google.com/file/d/1C-hgV5xWTeTQ4T_sO4puvNQfo8ez-rTX",
+          "alt": "woman working on a laptop",
+          "type": "desktop"
+        }
+      },
+      {
+        "title": "Mentor's Pocketbook",
+        "link": {
+          "label": "Download PDF",
+          "uri": "https://drive.google.com/file/d/1rgoOTqqG4Gu6e4tw45efFspDnoYRgYd9"
+        },
+        "image": {
+          "path": "https://drive.google.com/file/d/1AQKAp76gjk1kMX7pB7pnY5G5TMnxmDVk",
+          "alt": "Image decorative",
+          "type": "desktop"
+        }
+      },
+      {
+        "title": "Mentor's Guide",
+        "link": {
+          "label": "Download PDF",
+          "uri": "https://drive.google.com/file/d/1wTkCSG95BVg-0XX4r7FnFiV24_SXlbM_"
+        },
+        "image": {
+          "path": "https://drive.google.com/file/d/1opnOPWSxFP_Rq9Pylr02mxveLUYOjNkJ",
+          "alt": "two women sitting by a desk and talking together",
+          "type": "desktop"
+        }
+      }
+    ]
+  },
+  "customStyle": {
+    "backgroundColour": {
+      "color": "primary",
+      "shade": {
+        "name": "light",
+        "value": 90
+      }
+    }
+  }
+}

--- a/src/test/java/com/wcc/platform/controller/MentorshipControllerTest.java
+++ b/src/test/java/com/wcc/platform/controller/MentorshipControllerTest.java
@@ -3,6 +3,7 @@ package com.wcc.platform.controller;
 import static com.wcc.platform.domain.cms.PageType.MENTORSHIP;
 import static com.wcc.platform.domain.cms.PageType.MENTORSHIP_CONDUCT;
 import static com.wcc.platform.domain.cms.PageType.MENTORSHIP_LONG_TIMELINE;
+import static com.wcc.platform.domain.cms.PageType.MENTORSHIP_RESOURCES;
 import static com.wcc.platform.domain.cms.PageType.STUDY_GROUPS;
 import static com.wcc.platform.factories.SetupMentorshipFactories.createLongTermTimeLinePageTest;
 import static com.wcc.platform.factories.SetupMentorshipFactories.createMentorPageTest;
@@ -10,6 +11,7 @@ import static com.wcc.platform.factories.SetupMentorshipFactories.createMentorsh
 import static com.wcc.platform.factories.SetupMentorshipFactories.createMentorshipConductPageTest;
 import static com.wcc.platform.factories.SetupMentorshipFactories.createMentorshipFaqPageTest;
 import static com.wcc.platform.factories.SetupMentorshipFactories.createMentorshipPageTest;
+import static com.wcc.platform.factories.SetupMentorshipFactories.createMentorshipResourcesPageTest;
 import static com.wcc.platform.factories.SetupMentorshipFactories.createMentorshipStudyGroupPageTest;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -28,6 +30,7 @@ import com.wcc.platform.domain.exceptions.PlatformInternalException;
 import com.wcc.platform.factories.MockMvcRequestFactory;
 import com.wcc.platform.service.MentorshipPagesService;
 import com.wcc.platform.utils.FileUtil;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -49,6 +52,7 @@ public class MentorshipControllerTest {
   public static final String API_STUDY_GROUPS = "/api/cms/v1/mentorship/study-groups";
   public static final String API_MENTORSHIP_MENTORS = "/api/cms/v1/mentorship/mentors";
   public static final String API_AD_HOC_TIMELINE = "/api/cms/v1/mentorship/ad-hoc-timeline";
+  public static final String API_MENTORSHIP_RESOURCES = "/api/cms/v1/mentorship/resources";
 
   @Autowired private MockMvc mockMvc;
   @Autowired private ObjectMapper objectMapper;
@@ -178,5 +182,20 @@ public class MentorshipControllerTest {
             MockMvcRequestFactory.getRequest(API_AD_HOC_TIMELINE).contentType(APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().json(objectMapper.writeValueAsString(adHocTimelinePage)));
+  }
+
+  @Test
+  @DisplayName("Given resources page exists, when GET /resources, then return OK with JSON")
+  void shouldReturnOkResponseForMentorshipResources() throws Exception {
+    var fileName = MENTORSHIP_RESOURCES.getFileName();
+    var expectedJson = FileUtil.readFileAsString(fileName);
+
+    when(service.getResources()).thenReturn(createMentorshipResourcesPageTest(fileName));
+
+    mockMvc
+        .perform(
+            MockMvcRequestFactory.getRequest(API_MENTORSHIP_RESOURCES).contentType(APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson));
   }
 }

--- a/src/test/java/com/wcc/platform/factories/SetupMentorshipFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetupMentorshipFactories.java
@@ -14,6 +14,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.wcc.platform.domain.cms.PageType;
 import com.wcc.platform.domain.cms.attributes.CommonSection;
 import com.wcc.platform.domain.cms.attributes.FaqItem;
+import com.wcc.platform.domain.cms.attributes.Image;
+import com.wcc.platform.domain.cms.attributes.ImageType;
 import com.wcc.platform.domain.cms.attributes.LabelLink;
 import com.wcc.platform.domain.cms.attributes.Languages;
 import com.wcc.platform.domain.cms.attributes.ListSection;
@@ -30,6 +32,8 @@ import com.wcc.platform.domain.cms.pages.mentorship.MentorshipAdHocTimelinePage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipCodeOfConductPage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipFaqPage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipPage;
+import com.wcc.platform.domain.cms.pages.mentorship.MentorshipResource;
+import com.wcc.platform.domain.cms.pages.mentorship.MentorshipResourcesPage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipStudyGroupsPage;
 import com.wcc.platform.domain.cms.pages.mentorship.StudyGroup;
 import com.wcc.platform.domain.platform.member.Member;
@@ -45,6 +49,7 @@ import java.time.Year;
 import java.util.List;
 
 /** Mentorship test factories. */
+@SuppressWarnings("PMD.TooManyMethods")
 public class SetupMentorshipFactories {
 
   /** Test factory. */
@@ -200,6 +205,44 @@ public class SetupMentorshipFactories {
         createCommonSectionTest(),
         createContactTest(),
         new ListSection<>("Study Groups", null, null, List.of(studyGroup)),
+        createCustomStyleTest());
+  }
+
+  /** Test factory for Mentorship Resources Page with file. */
+  public static MentorshipResourcesPage createMentorshipResourcesPageTest(final String fileName) {
+    try {
+      final String content = FileUtil.readFileAsString(fileName);
+      return OBJECT_MAPPER.readValue(content, MentorshipResourcesPage.class);
+    } catch (JsonProcessingException e) {
+      return createMentorshipResourcesPageTest();
+    }
+  }
+
+  /** Test factory for Mentorship Resources Page. */
+  public static MentorshipResourcesPage createMentorshipResourcesPageTest() {
+    final String pageId = PageType.MENTORSHIP_RESOURCES.getId();
+
+    MentorshipResource resource1 =
+        MentorshipResource.builder()
+            .title("Mentees Guide")
+            .link(
+                new LabelLink(
+                    "Download PDF",
+                    "Download PDF",
+                    "https://drive.google.com/file/d/1xPbW8BlQoLXkuAJ7m0RuvOV02Opyr445"))
+            .image(
+                new Image(
+                    "/assets/images/resources/stock-unsplash-resources-mentee-guide.jpg",
+                    "woman working on a laptop",
+                    ImageType.DESKTOP))
+            .build();
+
+    return new MentorshipResourcesPage(
+        pageId,
+        createNoImageHeroSectionTest(),
+        createCommonSectionTest(),
+        new ListSection<>(
+            "Available Resources", "Download and explore our resources", null, List.of(resource1)),
         createCustomStyleTest());
   }
 

--- a/src/test/java/com/wcc/platform/service/MentorshipPagesServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/MentorshipPagesServiceTest.java
@@ -6,6 +6,7 @@ import static com.wcc.platform.factories.SetupMentorshipFactories.createMentorsh
 import static com.wcc.platform.factories.SetupMentorshipFactories.createMentorshipConductPageTest;
 import static com.wcc.platform.factories.SetupMentorshipFactories.createMentorshipFaqPageTest;
 import static com.wcc.platform.factories.SetupMentorshipFactories.createMentorshipPageTest;
+import static com.wcc.platform.factories.SetupMentorshipFactories.createMentorshipResourcesPageTest;
 import static com.wcc.platform.factories.SetupMentorshipFactories.createMentorshipStudyGroupPageTest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -23,12 +24,14 @@ import com.wcc.platform.domain.cms.pages.mentorship.MentorshipAdHocTimelinePage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipCodeOfConductPage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipFaqPage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipPage;
+import com.wcc.platform.domain.cms.pages.mentorship.MentorshipResourcesPage;
 import com.wcc.platform.domain.cms.pages.mentorship.MentorshipStudyGroupsPage;
 import com.wcc.platform.domain.exceptions.PlatformInternalException;
 import com.wcc.platform.repository.PageRepository;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -255,5 +258,49 @@ class MentorshipPagesServiceTest {
 
     // Verify that getFallback is never called since the exception occurs before that
     verify(pageRepository, never()).getFallback(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("Given record exists in database, when getResources, then return valid response")
+  void shouldReturnMentorshipResourcesPageWhenRecordExistsInDatabase() {
+    var page = createMentorshipResourcesPageTest();
+    var mapPage =
+        new ObjectMapper().registerModule(new JavaTimeModule()).convertValue(page, Map.class);
+
+    when(pageRepository.findById(PageType.MENTORSHIP_RESOURCES.getId()))
+        .thenReturn(Optional.of(mapPage));
+    when(objectMapper.convertValue(anyMap(), eq(MentorshipResourcesPage.class))).thenReturn(page);
+
+    var response = service.getResources();
+
+    assertEquals(page, response);
+  }
+
+  @Test
+  @DisplayName("Given record not in database, when getResources, then return fallback")
+  void shouldReturnFallbackWhenMentorshipResourcesNotInDatabase() {
+    var page = createMentorshipResourcesPageTest();
+
+    when(pageRepository.findById(PageType.MENTORSHIP_RESOURCES.getId()))
+        .thenReturn(Optional.empty());
+    when(pageRepository.getFallback(any(), any(), any())).thenReturn(page);
+
+    var response = service.getResources();
+
+    assertEquals(page, response);
+    verify(pageRepository, times(1)).getFallback(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("Given conversion fails, when getResources, then throw PlatformInternalException")
+  void shouldThrowPlatformInternalExceptionWhenResourcesConversionFails() {
+    Map<String, Object> mapPage = Map.of("id", "page:MENTORSHIP_RESOURCES");
+
+    when(pageRepository.findById(PageType.MENTORSHIP_RESOURCES.getId()))
+        .thenReturn(Optional.of(mapPage));
+    when(objectMapper.convertValue(anyMap(), eq(MentorshipResourcesPage.class)))
+        .thenThrow(new IllegalArgumentException("Conversion failed"));
+
+    assertThrows(PlatformInternalException.class, service::getResources);
   }
 }


### PR DESCRIPTION
## Description

Implement new CMS endpoint to serve downloadable mentorship resources for mentors and mentees. Includes three resources (Mentees Guide, Mentor's Pocketbook, and Mentor's Guide) with Google Drive links and preview images.

The implementation follows the established hybrid repository pattern with JSON fallback, ensuring resources are available without database configuration. Adds MENTORSHIP resource type to ResourceType enum and comprehensive test coverage for service and controller layers.
## Related Issue

Closes #64 

## Change Type

- [x] New Feature

## Screenshots

<img width="1490" height="992" alt="image" src="https://github.com/user-attachments/assets/0f24e54a-d93b-45c9-9111-ee19ef31cdb3" />

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->