### PR TITLE
fix: Make slackDisplayName attribute mandatory

### DIFF
--- a/src/main/java/com/wcc/platform/domain/platform/mentorship/Mentor.java
+++ b/src/main/java/com/wcc/platform/domain/platform/mentorship/Mentor.java
@@ -47,7 +47,7 @@ public class Mentor extends Member {
       @NotBlank final String fullName,
       @NotBlank final String position,
       @NotBlank @Email final String email,
-      final String slackDisplayName,
+      @NotBlank final String slackDisplayName,
       @NotBlank final Country country,
       @NotBlank final String city,
       final String companyName,


### PR DESCRIPTION
## Description

Have a Slack account in our community is mandatory to be mentor, and this was not correct configured.

This change only affects the API definition for now, it will be included in the validation and next steps for mentor approval step as well. 

## Change Type

- [x] Bug Fix