### PR TITLE
chore: Change auto_stop_machines setting from 'on' to 'suspend' prod

### DIFF
--- a/fly-prod.toml
+++ b/fly-prod.toml
@@ -14,7 +14,7 @@ SPRING_PROFILES_ACTIVE = "flyio"
 [http_service]
 internal_port = 8080
 force_https = true
-auto_stop_machines = 'on'
+auto_stop_machines = 'suspend'
 auto_start_machines = true
 min_machines_running = 0
 processes = ['app']


### PR DESCRIPTION
## Description

Temporary for prod to turn of the machine when idle 

## Related Issue
Relate to #443 a #451

## Change Type

- [x] Bug Fix
- [x] Deployment

