### PR TITLE
NO TICKET: Pin vercel-action version with commit hash

### DIFF
--- a/.github/workflows/deploy-admin-frontend-dev.yml
+++ b/.github/workflows/deploy-admin-frontend-dev.yml
@@ -33,7 +33,7 @@ jobs:
           NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
 
       - name: Deploy to Vercel (Dev)
-        uses: amondnet/vercel-action@v25
+        uses: amondnet/vercel-action@16e87c0a08142b0d0d33b76aeaf20823c381b9b9 #v25
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/deploy-admin-frontend-prod.yml
+++ b/.github/workflows/deploy-admin-frontend-prod.yml
@@ -29,7 +29,7 @@ jobs:
           NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL_PROD }}
 
       - name: Deploy to Vercel (Prod)
-        uses: amondnet/vercel-action@v25
+        uses: amondnet/vercel-action@16e87c0a08142b0d0d33b76aeaf20823c381b9b9 #v25
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN_PROD }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID_PROD }}


### PR DESCRIPTION
## Description

- On [PR-214](https://github.com/Women-Coding-Community/wcc-frontend/pull/214), SonarQube raised an issue with using the v25 tag for the amondnet/vercel-action in the GitHub Actions workflow. Tags are mutable and can lead to unexpected changes, which is why it was recommended to use a specific commit SHA instead (16e87c0a08142b0d0d33b76aeaf20823c381b9b9 for v25 according to [this](https://github.com/amondnet/vercel-action/releases/tag/v25)) for the amondnet/vercel-action instead of the version tag (v25). This ensures immutability and prevents unexpected changes caused by updates to the tag.

## Related Issue
#444 
#446 

## Change Type

- [ ] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Test
- [X] Other (Security)

## Screenshots

<!--  Please include screenshots from the Swagger API. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [X] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->