### PR TITLE
Feat: Expose mentorship ad hoc availability details to public API

### DIFF
--- a/src/main/java/com/wcc/platform/domain/cms/pages/mentorship/MenteeSection.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/mentorship/MenteeSection.java
@@ -39,13 +39,12 @@ public record MenteeSection(
   }
 
   /**
-   * Converts the current MenteeSection instance into a new MenteeSection DTO. The DTO excludes
-   * ad-hoc availability details for public display.
+   * Converts the current MenteeSection instance into a new MenteeSection DTO.
    *
-   * @return a new MenteeSection instance with the same idealMentee, additional, and longTerm
-   *     fields, but with an empty adHoc list.
+   * @return a new MenteeSection instance with the same idealMentee, additional, longTerm and ad-hoc
+   *     availabilities.
    */
   public MenteeSection toDto() {
-    return new MenteeSection(idealMentee, additional, longTerm, List.of());
+    return new MenteeSection(idealMentee, additional, longTerm, adHoc);
   }
 }


### PR DESCRIPTION
## Description

This PR exposes the mentor ad hoc availability in the public api (`GET /api/platform/v1/mentors`) by changing the empty list in the MenteeSection toDto() method by passing the `adHoc` field to the method instead of passing an empty list.

## Related Issue

#496 

## Change Type

- [X] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Test
- [ ] Other

## Screenshots

<img width="1183" height="444" alt="Successful response screenshot" src="https://github.com/user-attachments/assets/fd35d304-a628-4594-8d85-f2daab151359" />

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [X] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->