### PR TITLE
refactor: Remove mentor deprecated availability

### DIFF
--- a/src/main/java/com/wcc/platform/domain/platform/mentorship/Mentor.java
+++ b/src/main/java/com/wcc/platform/domain/platform/mentorship/Mentor.java
@@ -98,23 +98,7 @@ public class Mentor extends Member {
    * @return a MentorDto containing the mentor's details and availability information
    */
   public MentorDto toDto(final MentorshipCycle mentorshipCycle) {
-    final var mentor = this;
-    final var mentorBuilder = buildFromMentor(mentor);
-    final var menteeSection = mentor.getMenteeSection();
-
-    if (mentorshipCycle.cycle() == MentorshipType.LONG_TERM) {
-      final boolean isAvailable = menteeSection.longTerm() != null;
-      mentorBuilder.availability(new MentorAvailability(mentorshipCycle.cycle(), isAvailable));
-    } else if (mentorshipCycle.cycle() == MentorshipType.AD_HOC) {
-      final var adHoc = menteeSection.adHoc();
-      final boolean isAvailable =
-          adHoc != null
-              && adHoc.stream()
-                  .anyMatch(availability -> availability.month() == mentorshipCycle.month());
-      mentorBuilder.availability(new MentorAvailability(mentorshipCycle.cycle(), isAvailable));
-    }
-
-    return mentorBuilder.build();
+    return buildFromMentor(this).build();
   }
 
   /**
@@ -130,7 +114,6 @@ public class Mentor extends Member {
   private MentorDtoBuilder buildFromMentor(final Mentor mentor) {
     return MentorDto.mentorDtoBuilder()
         .id(mentor.getId())
-        .availability(null)
         .fullName(mentor.getFullName())
         .position(mentor.getPosition())
         .email(mentor.getEmail())

--- a/src/main/java/com/wcc/platform/domain/platform/mentorship/MentorDto.java
+++ b/src/main/java/com/wcc/platform/domain/platform/mentorship/MentorDto.java
@@ -31,7 +31,6 @@ import org.springframework.util.CollectionUtils;
 public class MentorDto extends MemberDto {
 
   private ProfileStatus profileStatus;
-  private MentorAvailability availability;
   private Skills skills;
   private List<String> spokenLanguages;
   private String bio;
@@ -59,8 +58,7 @@ public class MentorDto extends MemberDto {
       @NotNull final Skills skills,
       @NotNull final MenteeSection menteeSection,
       final FeedbackSection feedbackSection,
-      final MentorResource resources,
-      final MentorAvailability availability) {
+      final MentorResource resources) {
     super(
         id,
         fullName,
@@ -73,7 +71,6 @@ public class MentorDto extends MemberDto {
         null, // TODO to be fixe this will cleanup member types
         images,
         network);
-    this.availability = availability;
     this.skills = skills;
     this.spokenLanguages = spokenLanguages;
     this.bio = bio;

--- a/src/main/java/com/wcc/platform/service/MentorshipService.java
+++ b/src/main/java/com/wcc/platform/service/MentorshipService.java
@@ -180,7 +180,6 @@ public class MentorshipService {
         .companyName(dto.getCompanyName())
         .images(List.of(profilePicture.get()))
         .network(dto.getNetwork())
-        .availability(dto.getAvailability())
         .skills(dto.getSkills())
         .spokenLanguages(dto.getSpokenLanguages())
         .bio(dto.getBio())

--- a/src/test/java/com/wcc/platform/domain/platform/mentorship/MentorDtoTest.java
+++ b/src/test/java/com/wcc/platform/domain/platform/mentorship/MentorDtoTest.java
@@ -83,15 +83,13 @@ class MentorDtoTest {
     MentorDto mentor =
         MentorDto.mentorDtoBuilder()
             .bio("bio info")
-            .availability(new MentorAvailability(MentorshipType.AD_HOC, true))
             .spokenLanguages(List.of("English", "Spanish"))
             .fullName("Jane Doe")
             .id(1L)
             .profileStatus(ProfileStatus.PENDING)
             .build();
     var expected =
-        "MentorDto(profileStatus=PENDING, availability=MentorAvailability[mentorshipType=Ad-Hoc, available=true]"
-            + ", skills=null, spokenLanguages=[English, Spanish], bio=bio info, menteeSection=null,"
+        "MentorDto(profileStatus=PENDING, skills=null, spokenLanguages=[English, Spanish], bio=bio info, menteeSection=null,"
             + " feedbackSection=null, resources=null)";
 
     assertEquals(expected, mentor.toString());


### PR DESCRIPTION


## Description

Simplified `MentorDto` by eliminating `availability` field and its related logic. Updated corresponding methods, tests, and builders to reflect the changes.

## Related Issue

closes #502

## Change Type

- [x] Bug Fix
- [x] Code Refactor

## Screenshots
Before: 
<img width="1288" height="1518" alt="image" src="https://github.com/user-attachments/assets/7e2eae9f-e304-4e67-8126-ba10399b2842" />


After:
<img width="1383" height="818" alt="image" src="https://github.com/user-attachments/assets/083f2697-aada-414b-bb8e-ddf483592faa" />


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->