### PR TITLE
chore: Fly io prod disable stop machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ api-flows/results.html
 .env
 node_modules
 .DS_Store
+/fly.toml

--- a/fly-prod.toml
+++ b/fly-prod.toml
@@ -14,7 +14,7 @@ SPRING_PROFILES_ACTIVE = "flyio"
 [http_service]
 internal_port = 8080
 force_https = true
-auto_stop_machines = 'suspend'
+auto_stop_machines = 'off'
 auto_start_machines = true
 min_machines_running = 0
 processes = ['app']


### PR DESCRIPTION
## Description

- Changed `auto_stop_machines` to 'off' in `fly-prod.toml` to disable auto-stop.
- Updated `.gitignore` to exclude `/fly.toml` from version control.

## Change Type

- [x] Infra

<!--  Thanks for sending a pull request! -->