### PR TITLE
fix: Handle DB constraint violations with 409 CONFLICT

### DIFF
--- a/src/main/java/com/wcc/platform/configuration/GlobalExceptionHandler.java
+++ b/src/main/java/com/wcc/platform/configuration/GlobalExceptionHandler.java
@@ -22,6 +22,7 @@ import com.wcc.platform.repository.file.FileRepositoryException;
 import jakarta.validation.ConstraintViolationException;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -83,9 +84,20 @@ public class GlobalExceptionHandler {
     return new ResponseEntity<>(errorDetails, HttpStatus.BAD_REQUEST);
   }
 
-  /**
-   * Receive {@link DuplicatedException} subclasses and return {@link HttpStatus#CONFLICT}.
-   */
+  /** Receive {@link DataAccessException} then return {@link HttpStatus#CONFLICT}. */
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  @ResponseStatus(HttpStatus.CONFLICT)
+  public ResponseEntity<ErrorDetails> handleDataAccessException(
+      final DataIntegrityViolationException ex, final WebRequest request) {
+    final var errorDetails =
+        new ErrorDetails(
+            HttpStatus.CONFLICT.value(),
+            ex.getMostSpecificCause().getMessage(),
+            request.getDescription(false));
+    return new ResponseEntity<>(errorDetails, HttpStatus.CONFLICT);
+  }
+
+  /** Receive {@link DuplicatedException} subclasses and return {@link HttpStatus#CONFLICT}. */
   @ExceptionHandler(DuplicatedException.class)
   @ResponseStatus(HttpStatus.CONFLICT)
   public ResponseEntity<ErrorDetails> handleRecordAlreadyExitsException(

--- a/src/test/java/com/wcc/platform/configuration/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/wcc/platform/configuration/GlobalExceptionHandlerTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -75,6 +76,21 @@ class GlobalExceptionHandlerTest {
 
     var expectation = new ErrorDetails(FORBIDDEN.value(), "Error", DETAILS);
     assertEquals(FORBIDDEN, response.getStatusCode());
+    assertEquals(expectation, response.getBody());
+  }
+
+  @Test
+  @DisplayName(
+      "Given DataAccessException, when handling, then return CONFLICT with specific cause message")
+  void shouldReturnConflictForDataAccessException() {
+    var rootCause = new RuntimeException("duplicate key value violates unique constraint");
+    var exception =
+        new DuplicateKeyException("PreparedStatementCallback; SQL [INSERT...]", rootCause);
+
+    var response = globalExceptionHandler.handleDataAccessException(exception, webRequest);
+
+    var expectation = new ErrorDetails(CONFLICT.value(), rootCause.getMessage(), DETAILS);
+    assertEquals(CONFLICT, response.getStatusCode());
     assertEquals(expectation, response.getBody());
   }
 }


### PR DESCRIPTION
## Description

Database-level duplicate key and integrity violation exceptions were previously unhandled by the global exception handler, likely resulting in a 500 response for constraint conflicts. This adds a dedicated handler for DataIntegrityViolationException (which covers DuplicateKeyException as a subtype) that returns HTTP 409 CONFLICT, giving clients a clear and actionable signal when a record already exists. The handler is intentionally scoped to avoid misclassifying unrelated database errors such as connection failures as conflicts.

## Related Issue

Closes #564 

## Change Type

- [x] Bug Fix

## Screenshots

<!--  Please include screenshots from the Swagger API. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->