### PR TITLE
feat: Add automatic review decision to pr-review skill

### DIFF
--- a/.ai/skills/pr-review.md
+++ b/.ai/skills/pr-review.md
@@ -75,7 +75,31 @@ gh api repos/<owner>/<repo>/pulls/<number>/comments \
 
 Prefer line-level comments over top-level summary comments.
 
-## Step 5 — Comment quality bar
+## Step 5 — Submit review decision
+
+After posting all inline comments, submit a formal review decision:
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<number>/reviews \
+  -X POST \
+  -f commit_id='<sha>' \
+  -f body='<summary>' \
+  -f event='<event>'
+```
+
+**Decision rules:**
+
+| Condition | `event` value |
+|---|---|
+| No `[CRITICAL]` findings | `APPROVE` |
+| Any `[CRITICAL]` finding | `REQUEST_CHANGES` |
+| Uncertain / needs author input | `COMMENT` |
+
+When approving, write a short encouraging body (2–3 sentences) summarising what looks good and calling out any `[WARNING]` or `[INFO]` items the author may want to address as a follow-up.
+
+When requesting changes, clearly list the `[CRITICAL]` items that must be resolved before merge.
+
+## Step 6 — Comment quality bar
 
 Every comment must:
 - State the **concrete risk** (what could go wrong)

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -34,6 +34,12 @@ description: Review pull requests using GitHub CLI. Use when asked to check a PR
 - Do not leave only general/top-level comments when line-level comments are possible.
 - If a comment was posted in the wrong place, repost at the correct line and remove the incorrect one.
 
+1. Submit a formal review decision after posting inline comments:
+- Use `gh api repos/<owner>/<repo>/pulls/<number>/reviews -X POST -f commit_id='<sha>' -f body='<summary>' -f event='<event>'`
+- **APPROVE** when no `[CRITICAL]` findings are present — write a short encouraging summary (2–3 sentences) noting what looks good and listing any `[WARNING]`/`[INFO]` items as optional follow-ups.
+- **REQUEST_CHANGES** when any `[CRITICAL]` finding exists — clearly list what must be resolved before merge.
+- **COMMENT** only when genuinely uncertain or when author input is needed before a decision can be made.
+
 1. Respect user review preferences from this repo context:
 - Use the context into the repo from the PR URL for the PR operations.
 - Avoid rerunning local tests when the user says they already tested, unless they ask for test execution.

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ node_modules
 .DS_Store
 /fly.toml
 docs/presentation-claude-code-skills.md
+/src/main/resources/application-dev.yml


### PR DESCRIPTION
## Description

The pr-review skill previously ended after posting inline comments, requiring a manual approval or change-request to be submitted separately. 

This adds a new Step 5 that automatically submits a formal GitHub review decision 
APPROVE when no [CRITICAL] findings are present, 
REQUEST_CHANGES when any [CRITICAL] exists, and 
COMMENT only when genuinely uncertain. 

The decision table and guidance for writing the approval body are included so the review closes the loop without extra prompting. 
Both the canonical skill file and the SKILL.md adapter are updated in sync. application-dev.yml is added to .gitignore to keep local dev config out of version control.

## Change Type

- [x] Documentation
- [x] AI Automation

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)

<!--  Thanks for sending a pull request! -->