### PR TITLE
Replace unresolved teamEmailSignature placeholder in mentor rejection email

### DIFF
--- a/src/main/resources/email-templates/mentorship_profile_not_approved_mentor.yml
+++ b/src/main/resources/email-templates/mentorship_profile_not_approved_mentor.yml
@@ -33,5 +33,5 @@ MENTOR_PROFILE_REJECT:
     </p>
 
     <p>
-    {{teamEmailSignature}}
+    WCC Mentorship Team
     </p>


### PR DESCRIPTION
**Problem**
Calling PATCH `/api/platform/v1/mentors/{id}/reject` always returned 400 with:
"Missing required parameters: [teamEmailSignature]"

The rejection email template `mentorship_profile_not_approved_mentor.yml` contained a `{{teamEmailSignature}}` placeholder that was never backed by a config property or passed as a template parameter in `MentorshipNotificationService.sendMentorRejectionEmail()`. As a result, template rendering failed on every rejection attempt, making the endpoint completely unusable.

**Fix**
Replaced `{{teamEmailSignature}}` with the same static WCC Mentorship Team signature already used in the approval email template (`mentorship_profile_approved_mentor.yml`).

## Change Type

- [x] Bug Fix