### PR TITLE
Fix: expose Bearer token auth in Swagger UI for token-protected endpoints

### DIFF
--- a/src/main/java/com/wcc/platform/configuration/OpenApiConfig.java
+++ b/src/main/java/com/wcc/platform/configuration/OpenApiConfig.java
@@ -2,6 +2,7 @@ package com.wcc.platform.configuration;
 
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.security.SecuritySchemes;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.servers.Server;
@@ -19,11 +20,18 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /** Custom configuration for open api. */
 @Configuration
-@SecurityScheme(
-    name = "apiKey",
-    type = SecuritySchemeType.APIKEY,
-    paramName = "X-API-KEY",
-    in = io.swagger.v3.oas.annotations.enums.SecuritySchemeIn.HEADER)
+@SecuritySchemes({
+  @SecurityScheme(
+      name = "apiKey",
+      type = SecuritySchemeType.APIKEY,
+      paramName = "X-API-KEY",
+      in = io.swagger.v3.oas.annotations.enums.SecuritySchemeIn.HEADER),
+  @SecurityScheme(
+      name = "bearerAuth",
+      type = SecuritySchemeType.HTTP,
+      scheme = "bearer",
+      bearerFormat = "JWT")
+})
 public class OpenApiConfig implements WebMvcConfigurer {
 
   private static final String ACTUATOR = "actuator";

--- a/src/main/java/com/wcc/platform/controller/MenteeApplicationController.java
+++ b/src/main/java/com/wcc/platform/controller/MenteeApplicationController.java
@@ -92,7 +92,12 @@ public class MenteeApplicationController {
   @RequiresPermission(
       value = {Permission.MENTOR_APPL_READ, Permission.MENTOR_APPROVE},
       operator = LogicalOperator.OR)
-  @Operation(summary = "Get applications received by a mentor")
+  @Operation(
+      summary = "Get applications received by a mentor",
+      security = {
+        @SecurityRequirement(name = "apiKey"),
+        @SecurityRequirement(name = "bearerAuth")
+      })
   @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<List<MenteeApplication>> getMentorApplications(
       @Parameter(description = "ID of the mentor") @PathVariable final Long mentorId,

--- a/src/main/java/com/wcc/platform/controller/platform/AuthController.java
+++ b/src/main/java/com/wcc/platform/controller/platform/AuthController.java
@@ -106,8 +106,12 @@ public class AuthController {
    * @return List of all members.
    */
   @GetMapping("/users")
-  @SecurityRequirement(name = "apiKey")
-  @Operation(summary = "API to retrieve users with access to restrict area")
+  @Operation(
+      summary = "API to retrieve users with access to restrict area",
+      security = {
+        @SecurityRequirement(name = "apiKey"),
+        @SecurityRequirement(name = "bearerAuth")
+      })
   @RequiresRole({RoleType.ADMIN, RoleType.LEADER})
   @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<List<UserAccount>> getUsers() {


### PR DESCRIPTION
## Problem

Endpoints protected by `@RequiresPermission` or `@RequiresRole` require a Bearer token
(`Authorization: Bearer <token>`), but Swagger UI had no way to provide one — only the
`X-API-KEY` scheme was defined. This made it impossible to test token-protected endpoints
directly from the Swagger UI, always resulting in 403.

**Affected endpoints:**
- `GET /api/platform/v1/mentors/{mentorId}/applications`
- `GET /api/auth/users`

## Fix

- Registered a `bearerAuth` (HTTP Bearer / JWT) security scheme alongside the existing `apiKey`
  scheme in `OpenApiConfig`
- Added `security = {@SecurityRequirement(name = "apiKey"), @SecurityRequirement(name = "bearerAuth")}`
  inside `@Operation` on the two endpoints that enforce token-based authorization — no other
  endpoints are affected

## How to use

1. Call `POST /api/auth/login` with admin credentials to obtain a token
2. Click **Authorize** in Swagger UI → paste the token under **bearerAuth**
   (without the `Bearer ` prefix)
3. Token-protected endpoints can now be tested directly from the UI

## Change Type

- [x] Bug Fix
- [x] New Feature

This issue #561  can be closed after this fix. 