### PR TITLE
docs: document Codex skill discovery

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -5,15 +5,32 @@ They are written in plain markdown with no tool-specific syntax so they can be
 consumed by Claude Code, OpenAI Codex, GitHub Copilot, Cursor, Windsurf, or
 any agent that reads repository context.
 
+For OpenAI Codex in this repository, `AGENTS.md` is the main adapter. It is
+expected to enumerate the available skills and point back to these canonical
+runbooks under `.ai/skills/`.
+
 ## Structure
 
 ```
 .ai/
   skills/
-    commit.md       ← safe commit workflow (any agent)
-    pr-review.md    ← PR review workflow (any agent)
+    commit.md             ← safe commit workflow
+    open-pr.md            ← PR title/description workflow
+    pr-review.md          ← PR review workflow
+    pre-commit-review.md  ← local diff review workflow
+    pull-request.md       ← pull request preparation workflow
+    split-commits.md      ← atomic commit grouping workflow
   README.md         ← this file
 ```
+
+## Available canonical skills
+
+- `commit` — safe commit with secret scanning and conventional commits
+- `pr-review` — inline GitHub PR review with repository-specific checks
+- `pre-commit-review` — local diff review before committing
+- `open-pr` — generate a PR title and description from the current branch diff
+- `pull-request` — broader PR preparation workflow
+- `split-commits` — group local changes into atomic commits
 
 ## How each agent uses these skills
 
@@ -27,6 +44,18 @@ any agent that reads repository context.
 
 The canonical source of truth lives here in `.ai/skills/`.
 Each agent wrapper is a thin adapter — no duplication of logic.
+
+## Codex usage notes
+
+Codex should discover repository skills through `AGENTS.md`, then read the
+canonical runbook from `.ai/skills/<name>.md` before executing the workflow.
+
+Recommended pattern:
+
+1. Match the user's request to one of the documented skills
+2. Open the corresponding `.ai/skills/<name>.md` file
+3. Follow the runbook steps exactly, while still respecting repository safety
+   rules and any active user constraints
 
 ## Adding a new skill
 

--- a/.ai/skills/commit.md
+++ b/.ai/skills/commit.md
@@ -4,7 +4,8 @@ Safe commit workflow with sensitive-data detection and conventional commit messa
 
 ## When to apply
 
-Run this workflow when the user asks you to commit, stage and commit, or `/commit`.
+Run this workflow when the user asks you to commit or stage and commit, or
+uses an agent-specific shortcut such as `/commit` in Claude Code.
 
 ## Step 1 — Gather context
 

--- a/.ai/skills/open-pr.md
+++ b/.ai/skills/open-pr.md
@@ -5,7 +5,8 @@ GitHub URL so the user can open the PR in the browser.
 
 ## When to apply
 
-Run this workflow when the user asks to open a PR, create a pull request, or `/open-pr`.
+Run this workflow when the user asks to open a PR or create a pull request, or
+uses an agent-specific shortcut such as `/open-pr` in Claude Code.
 
 ## Step 1 — Gather context
 

--- a/.ai/skills/pr-review.md
+++ b/.ai/skills/pr-review.md
@@ -4,7 +4,9 @@ Code review workflow that posts inline comments on a pull request using the GitH
 
 ## When to apply
 
-Run this workflow when the user asks you to review a PR, check a pull request, or `/pr-review`.
+Run this workflow when the user asks you to review a PR or check a pull
+request, or uses an agent-specific shortcut such as `/pr-review` in Claude
+Code.
 
 ## Step 1 — Fetch PR data
 

--- a/.ai/skills/pre-commit-review.md
+++ b/.ai/skills/pre-commit-review.md
@@ -4,7 +4,9 @@ Local code review workflow that analyses staged and unstaged changes before a co
 
 ## When to apply
 
-Run this workflow when the user asks to review local changes, check code before committing, or `/pre-commit-review`.
+Run this workflow when the user asks to review local changes or check code
+before committing, or uses an agent-specific shortcut such as
+`/pre-commit-review` in Claude Code.
 
 ## Step 1 — Gather local diff
 

--- a/.ai/skills/split-commits.md
+++ b/.ai/skills/split-commits.md
@@ -7,7 +7,8 @@ groups warrant separate pull requests.
 ## When to apply
 
 Run this workflow when the user asks to split changes into separate commits,
-wants help organising a large diff before committing, or invokes `/split-commits`.
+wants help organising a large diff before committing, or uses an
+agent-specific shortcut such as `/split-commits` in Claude Code.
 
 ---
 
@@ -170,7 +171,7 @@ After all groups are committed, output:
 
 PR suggestions:
   • <description of which commits to bundle into each PR and why>
-  • Use /open-pr to generate the PR description for each branch.
+  • Use the `open-pr` workflow to generate the PR description for each branch.
 ```
 
 If groups with `depends on` relationships exist, suggest the order in which to
@@ -186,4 +187,5 @@ open PRs and whether to stack them or wait for the dependency to merge first.
 - Stop immediately if sensitive data is detected
 - Never force-push
 - Do not create commits until the user confirms the grouping in Step 4
-- If only one logical group exists, tell the user and suggest `/commit` instead
+- If only one logical group exists, tell the user and suggest the `commit`
+  workflow instead

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,29 +9,96 @@ WCC (Women Coding Community) Backend — Spring Boot 3.2.5, Java 21, PostgreSQL.
 
 See `CLAUDE.md` for full architecture, build commands, and conventions.
 
+## Skill Access
+
+Repository-specific AI workflows live under `.ai/skills/` as canonical
+markdown runbooks. When a user request matches one of the skills below, read
+the corresponding file in `.ai/skills/` and follow that runbook.
+
+Discovery pattern for Codex:
+
+- Match the request to a skill name or workflow intent
+- Open `.ai/skills/<skill-name>.md`
+- Execute the runbook while still respecting this file's repository rules
+
 ## Skills
 
 ### commit
+
 Safe commit with sensitive-data detection and conventional commit messages.
 
 Full runbook: [`.ai/skills/commit.md`](.ai/skills/commit.md)
 
 **Quick reference:**
+
 - Scan diff for secrets before staging anything
 - Conventional Commits format: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
 - Always write a body explaining *why*, not just what
 - Stage by file name, never `git add .`
 
 ### pr-review
+
 Inline code review posted via GitHub CLI.
 
 Full runbook: [`.ai/skills/pr-review.md`](.ai/skills/pr-review.md)
 
 **Quick reference:**
+
 - Use `gh pr diff` and `gh api` for inline comments
 - Prioritise: regressions → security → data integrity → conventions → tests
 - Post comments on exact changed lines, not just a summary
 - Java 21 idioms, Spring Boot conventions, Given-When-Then test names
+
+### pre-commit-review
+
+Local review of staged and unstaged changes before committing.
+
+Full runbook: [`.ai/skills/pre-commit-review.md`](.ai/skills/pre-commit-review.md)
+
+**Quick reference:**
+
+- Review local diff before commit with regression-first mindset
+- Auto-fix style issues in changed files where the runbook allows it
+- Report only findings that require human judgement
+- Enforce Java test naming and `@DisplayName` conventions
+
+### open-pr
+
+Prepare a pull request title and description from the current branch diff.
+
+Full runbook: [`.ai/skills/open-pr.md`](.ai/skills/open-pr.md)
+
+**Quick reference:**
+
+- Derive PR title from the dominant conventional-commit change type
+- Fill the repo PR template with only applicable sections
+- Include Swagger screenshots for backend API changes
+- Print the resulting GitHub PR URL for the user
+
+### pull-request
+
+Pull request workflow runbook for repository PR creation and description.
+
+Full runbook: [`.ai/skills/pull-request.md`](.ai/skills/pull-request.md)
+
+**Quick reference:**
+
+- Use when the user asks for pull request preparation workflows
+- Follow the canonical markdown runbook under `.ai/skills/`
+- Keep PR output aligned with repository templates and conventions
+
+### split-commits
+
+Split local changes into atomic commits grouped by logical concern.
+
+Full runbook: [`.ai/skills/split-commits.md`](.ai/skills/split-commits.md)
+
+**Quick reference:**
+
+- Analyse the full uncommitted diff and group files by concern
+- Keep feature, refactor, test, and chore changes separate where possible
+- Re-scan each proposed commit for sensitive data before committing
+- Suggest which commit groups should become separate PRs
 
 ## Build commands
 

--- a/docs/claude-code-skills.md
+++ b/docs/claude-code-skills.md
@@ -11,7 +11,7 @@ The canonical skills live in **`.ai/skills/`** and are written without any tool-
 | Agent | Adapter location | Invoke with |
 |-------|-----------------|-------------|
 | **Claude Code** | `.claude/skills/<name>/SKILL.md` | `/commit`, `/pr-review` |
-| **OpenAI Codex** | `AGENTS.md` (repo root) | Natural language or slash commands |
+| **OpenAI Codex** | `AGENTS.md` (repo root) | Natural language requests |
 | **GitHub Copilot** | `.github/copilot-instructions.md` | Natural language in chat |
 | **Cursor** | `.cursor/rules/*.mdc` | Natural language or `@commit` rules |
 | **Windsurf** | `.windsurf/rules/` | Natural language |
@@ -21,6 +21,10 @@ The workflow logic is defined **once** in `.ai/skills/`. Agent adapters are thin
 ---
 
 ## Available Skills
+
+The canonical runbooks are the same for every supported agent. Claude may
+invoke them through `.claude/skills/...`, while Codex should discover them
+through `AGENTS.md` and open the matching file from `.ai/skills/`.
 
 ### `/commit`
 
@@ -40,6 +44,9 @@ Safely stages and commits your changes with a well-structured commit message.
 ```bash
 # Make your changes, then in Claude Code:
 /commit
+
+# Or ask Codex naturally:
+"commit the current changes using the repo commit skill"
 ```
 
 **Why this matters:**
@@ -73,7 +80,24 @@ Reviews a pull request using the GitHub CLI and posts inline comments directly o
 
 # Or with a full URL:
 /pr-review https://github.com/Women-Coding-Community/wcc-backend/pull/541
+
+# Or ask Codex naturally:
+"review PR 541 using the repo pr-review skill"
 ```
+
+---
+
+## How Codex should access skills
+
+Codex uses `AGENTS.md` as the repository entry point. That file should list the
+available skills and point back to the canonical runbooks under `.ai/skills/`.
+
+When a task matches a workflow:
+
+1. Read `AGENTS.md` to discover the available skill names
+2. Open the matching `.ai/skills/<name>.md` runbook
+3. Execute the runbook steps, adapting only where repository safety rules or
+   explicit user instructions require it
 
 **Why this matters:**
 - Gives you a second pair of eyes before requesting human review


### PR DESCRIPTION
## Description

This PR documents how OpenAI Codex should discover and use the repository's  canonical AI workflows. 

It adds an explicit Codex entry point in `AGENTS.md`,   expands the `.ai` documentation to list the available runbooks, and clarifies that slash-command examples are Claude-specific while Codex should use natural   language requests. 
This keeps agent guidance consistent across the repository  and makes the `.ai/skills/` runbooks easier to reuse.


 ## Change Type

  - [x] Documentation

  ## Pull request checklist

  - [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)

  Notes:

  - No screenshots section needed.
  - No “tested locally” checkbox needed because this is docs-only.