### PR TITLE
fix: case-insensitive email lookup for authentication

### DIFF
--- a/src/main/java/com/wcc/platform/repository/postgres/PostgresUserAccountRepository.java
+++ b/src/main/java/com/wcc/platform/repository/postgres/PostgresUserAccountRepository.java
@@ -23,7 +23,8 @@ public class PostgresUserAccountRepository implements UserAccountRepository {
 
   private static final String SQL_SELECT_ALL = "SELECT * FROM user_accounts;";
   private static final String SQL_SELECT_BY_ID = "SELECT * FROM user_accounts WHERE id = ?";
-  private static final String SQL_SELECT_BY_MAIL = "SELECT * FROM user_accounts WHERE email = ?";
+  private static final String SQL_SELECT_BY_MAIL =
+      "SELECT * FROM user_accounts WHERE LOWER(email) = LOWER(?)";
   private static final String SQL_DELETE = "DELETE FROM user_accounts WHERE id = ?";
   private static final String SQL_INSERT =
       "INSERT INTO user_accounts (member_id, email, password_hash) VALUES (?,?,?)";

--- a/src/main/java/com/wcc/platform/repository/postgres/PostgresUserAccountRepository.java
+++ b/src/main/java/com/wcc/platform/repository/postgres/PostgresUserAccountRepository.java
@@ -6,6 +6,7 @@ import com.wcc.platform.repository.UserAccountRepository;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,7 +25,7 @@ public class PostgresUserAccountRepository implements UserAccountRepository {
   private static final String SQL_SELECT_ALL = "SELECT * FROM user_accounts;";
   private static final String SQL_SELECT_BY_ID = "SELECT * FROM user_accounts WHERE id = ?";
   private static final String SQL_SELECT_BY_MAIL =
-      "SELECT * FROM user_accounts WHERE LOWER(email) = LOWER(?)";
+      "SELECT * FROM user_accounts WHERE email = ?";
   private static final String SQL_DELETE = "DELETE FROM user_accounts WHERE id = ?";
   private static final String SQL_INSERT =
       "INSERT INTO user_accounts (member_id, email, password_hash) VALUES (?,?,?)";
@@ -88,7 +89,7 @@ public class PostgresUserAccountRepository implements UserAccountRepository {
   @Override
   public Optional<UserAccount> findByEmail(final String email) {
     final List<UserAccount> users =
-        jdbc.query(SQL_SELECT_BY_MAIL, (rs, rowNum) -> mapUser(rs), email);
+        jdbc.query(SQL_SELECT_BY_MAIL, (rs, rowNum) -> mapUser(rs), email.toLowerCase(Locale.ENGLISH));
     return users.stream().findFirst();
   }
 

--- a/src/main/java/com/wcc/platform/repository/postgres/component/MemberMapper.java
+++ b/src/main/java/com/wcc/platform/repository/postgres/component/MemberMapper.java
@@ -82,7 +82,8 @@ public class MemberMapper {
 
   /** Adds a new member to the database and returns the member ID. */
   public Long addMember(final Member member) {
-    final var existingMemberId = findMemberIdByEmail(member.getEmail());
+    final var email = member.getEmail().toLowerCase(Locale.ENGLISH);
+    final var existingMemberId = findMemberIdByEmail(email);
     if (existingMemberId != null) {
       updateMember(member, existingMemberId);
       return existingMemberId;
@@ -95,7 +96,7 @@ public class MemberMapper {
         member.getSlackDisplayName(),
         member.getPosition(),
         member.getCompanyName(),
-        member.getEmail(),
+        email,
         member.getCity(),
         getCountryId(member.getCountry()),
         defaultStatusPending,
@@ -112,10 +113,10 @@ public class MemberMapper {
               }
               return null;
             },
-            member.getEmail());
+            email);
 
     if (memberId == null) {
-      throw new IllegalStateException("Failed to retrieve member ID after insertion: " + member.getEmail());
+      throw new IllegalStateException("Failed to retrieve member ID after insertion: " + email);
     }
 
     addMemberTypes(memberId, member);

--- a/src/main/java/com/wcc/platform/service/AuthService.java
+++ b/src/main/java/com/wcc/platform/service/AuthService.java
@@ -11,6 +11,7 @@ import com.wcc.platform.repository.MemberRepository;
 import com.wcc.platform.repository.UserAccountRepository;
 import com.wcc.platform.repository.UserTokenRepository;
 import java.security.SecureRandom;
+import java.util.Locale;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Base64;
@@ -42,7 +43,7 @@ public class AuthService {
   private int tokenTtlMinutes;
 
   public Optional<UserAccount> findUserByEmail(final String email) {
-    return userAccountRepository.findByEmail(email);
+    return userAccountRepository.findByEmail(email.toLowerCase(Locale.ENGLISH));
   }
 
   /**
@@ -70,7 +71,7 @@ public class AuthService {
    *     successful, or an empty {@code Optional} if authentication fails
    */
   public Optional<UserToken> authenticateAndIssueToken(final String email, final String password) {
-    final Optional<UserAccount> userOpt = userAccountRepository.findByEmail(email);
+    final Optional<UserAccount> userOpt = userAccountRepository.findByEmail(email.toLowerCase(Locale.ENGLISH));
     if (userOpt.isEmpty()) {
       return Optional.empty();
     }

--- a/src/test/java/com/wcc/platform/service/AuthServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/AuthServiceTest.java
@@ -1,6 +1,7 @@
 package com.wcc.platform.service;
 
 import static com.wcc.platform.factories.SetupUserAccountFactories.createAdminUserTest;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -72,6 +73,19 @@ class AuthServiceTest {
     result = authService.findUserByEmail(email);
 
     assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void shouldNormalizeMixedCaseEmailToLowercaseWhenFindingUserByEmail() {
+    var mixedCaseEmail = "User@Example.COM";
+    var normalizedEmail = "user@example.com";
+    var userAccount = new UserAccount(1, 1L, normalizedEmail, "hash", List.of(RoleType.ADMIN), true);
+    when(userAccountRepository.findByEmail(normalizedEmail)).thenReturn(Optional.of(userAccount));
+
+    var result = authService.findUserByEmail(mixedCaseEmail);
+
+    assertThat(result).isPresent();
+    verify(userAccountRepository).findByEmail(normalizedEmail);
   }
 
   // ==================== authenticateAndIssueToken Tests ====================


### PR DESCRIPTION
## Problem
Login was case-sensitive — `admin@wcc.dev` and `Admin@wcc.dev` were treated as different accounts, causing 401 for users who registered or were seeded with a different email casing than what they typed at login.

## Change Type

- [x] Bug Fix