### PR TITLE
feat: Add MENTORSHIP_ADMIN role with mentor list access

### DIFF
--- a/src/main/java/com/wcc/platform/controller/MentorController.java
+++ b/src/main/java/com/wcc/platform/controller/MentorController.java
@@ -47,7 +47,7 @@ public class MentorController {
   @Operation(
       summary = "API to retrieve a list of all mentors with access to restricted area",
       security = {@SecurityRequirement(name = "apiKey"), @SecurityRequirement(name = "bearerAuth")})
-  @RequiresRole({RoleType.ADMIN, RoleType.LEADER})
+  @RequiresRole({RoleType.ADMIN, RoleType.LEADER, RoleType.MENTORSHIP_ADMIN})
   @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<List<MentorDto>> getAllMentors() {
     final List<MentorDto> mentors = mentorshipService.getAllMentors();

--- a/src/main/java/com/wcc/platform/domain/auth/MemberTypeRoleMapper.java
+++ b/src/main/java/com/wcc/platform/domain/auth/MemberTypeRoleMapper.java
@@ -27,6 +27,7 @@ public final class MemberTypeRoleMapper {
   private static final Map<RoleType, Integer> ROLE_HIERARCHY =
       Map.of(
           RoleType.ADMIN, 100,
+          RoleType.MENTORSHIP_ADMIN, 90,
           RoleType.LEADER, 80,
           RoleType.MENTOR, 60,
           RoleType.CONTRIBUTOR, 50,

--- a/src/main/java/com/wcc/platform/domain/auth/Permission.java
+++ b/src/main/java/com/wcc/platform/domain/auth/Permission.java
@@ -2,6 +2,7 @@ package com.wcc.platform.domain.auth;
 
 import lombok.AllArgsConstructor;
 
+/** Enum representing permissions for different actions within the platform. */
 @AllArgsConstructor
 public enum Permission {
   // User Management

--- a/src/main/java/com/wcc/platform/domain/platform/type/RoleType.java
+++ b/src/main/java/com/wcc/platform/domain/platform/type/RoleType.java
@@ -10,9 +10,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum RoleType {
   ADMIN(1, "Platform Administrator", Set.of(Permission.values())),
-  LEADER(
-      4,
-      "Platform Leader",
+  MENTORSHIP_ADMIN(
+      20,
+      "Mentorship Administrator",
       Set.of(
           Permission.USER_READ,
           Permission.MENTOR_APPROVE,
@@ -20,6 +20,14 @@ public enum RoleType {
           Permission.CYCLE_EMAIL_SEND,
           Permission.MATCH_MANAGE,
           Permission.MENTOR_APPL_READ)),
+  LEADER(
+      4,
+      "Platform Leader",
+      Set.of(
+          Permission.USER_READ,
+          Permission.USER_WRITE,
+          Permission.MENTOR_APPL_READ,
+          Permission.MENTOR_PROFILE_UPDATE)),
   MENTEE(
       5, "Mentee In Community", Set.of(Permission.MENTEE_APPL_SUBMIT, Permission.MENTEE_APPL_READ)),
   MENTOR(

--- a/src/test/java/com/wcc/platform/controller/MentorControllerTest.java
+++ b/src/test/java/com/wcc/platform/controller/MentorControllerTest.java
@@ -474,8 +474,7 @@ class MentorControllerTest {
   @DisplayName(
       "Given getAllMentors method, when inspecting its annotations,"
           + " then it should require ADMIN, LEADER or MENTORSHIP_ADMIN role")
-  void shouldRequireAdminLeaderOrMentorshipAdminRoleOnGetAllMentors()
-      throws NoSuchMethodException {
+  void shouldRequireAdminLeaderOrMentorshipAdminRoleOnGetAllMentors() throws NoSuchMethodException {
     var method = MentorController.class.getDeclaredMethod("getAllMentors");
     var annotation = method.getAnnotation(RequiresRole.class);
 

--- a/src/test/java/com/wcc/platform/controller/MentorControllerTest.java
+++ b/src/test/java/com/wcc/platform/controller/MentorControllerTest.java
@@ -5,6 +5,7 @@ import static com.wcc.platform.factories.MockMvcRequestFactory.postRequest;
 import static com.wcc.platform.factories.SetupMentorFactories.createMentorDtoTest;
 import static com.wcc.platform.factories.SetupMentorFactories.createMentorTest;
 import static com.wcc.platform.factories.SetupMentorFactories.createUpdatedMentorTest;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -17,12 +18,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wcc.platform.configuration.SecurityConfig;
 import com.wcc.platform.configuration.TestConfig;
+import com.wcc.platform.configuration.security.RequiresRole;
 import com.wcc.platform.domain.exceptions.MemberNotFoundException;
 import com.wcc.platform.domain.exceptions.MentorStatusException;
 import com.wcc.platform.domain.platform.member.ProfileStatus;
 import com.wcc.platform.domain.platform.mentorship.Mentor;
 import com.wcc.platform.domain.platform.mentorship.MentorDto;
 import com.wcc.platform.domain.platform.type.MemberType;
+import com.wcc.platform.domain.platform.type.RoleType;
 import com.wcc.platform.service.MentorshipService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -465,5 +468,19 @@ class MentorControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].isWomen", is(true)))
         .andExpect(jsonPath("$[1].isWomen", is(false)));
+  }
+
+  @Test
+  @DisplayName(
+      "Given getAllMentors method, when inspecting its annotations,"
+          + " then it should require ADMIN, LEADER or MENTORSHIP_ADMIN role")
+  void shouldRequireAdminLeaderOrMentorshipAdminRoleOnGetAllMentors()
+      throws NoSuchMethodException {
+    var method = MentorController.class.getDeclaredMethod("getAllMentors");
+    var annotation = method.getAnnotation(RequiresRole.class);
+
+    assertThat(annotation).isNotNull();
+    assertThat(annotation.value())
+        .containsExactlyInAnyOrder(RoleType.ADMIN, RoleType.LEADER, RoleType.MENTORSHIP_ADMIN);
   }
 }


### PR DESCRIPTION
## Description

  - Introduces a new `MENTORSHIP_ADMIN` role (id=20) with permissions scoped                                      
    to mentorship operations: reviewing applications, managing matches, and                                     
    sending cycle emails.                                                  
  - Updates `LEADER` role permissions to focus on user management and mentor                                      
    profile updates.                                                                                              
  - Grants `MENTORSHIP_ADMIN` access to `GET /api/platform/v1/mentors`                                            
    alongside `ADMIN` and `LEADER`.      

## Change Type

- [x] Bug Fix
- [x] Code Refactor
