### PR TITLE
fix: allow any authenticated user to access GET /api/auth/me

### DIFF
--- a/src/main/java/com/wcc/platform/controller/platform/AuthController.java
+++ b/src/main/java/com/wcc/platform/controller/platform/AuthController.java
@@ -90,7 +90,6 @@ public class AuthController {
       summary = "Get current authenticated user and member info",
       security = {@SecurityRequirement(name = "apiKey"), @SecurityRequirement(name = "bearerAuth")})
   @ResponseStatus(HttpStatus.OK)
-  @RequiresRole({RoleType.ADMIN, RoleType.LEADER})
   public ResponseEntity<LoginResponse> currentUser() {
     final var auth = SecurityContextHolder.getContext().getAuthentication();
     if (auth == null || !auth.isAuthenticated()) {


### PR DESCRIPTION
## Summary
`GET /api/auth/me` was incorrectly restricted to ADMIN and LEADER roles via @RequiresRole, causing a 403 for users with other roles (e.g. Mentor In Community)

Removed the role check, the endpoint already validates that the caller is authenticated via the SecurityContext, so unauthenticated requests still return 401

Test plan
- Log in as a Mentor and call GET /api/auth/me — expect 200 with roles and member info
- Log in as an Admin/Leader and call GET /api/auth/me — expect 200 (no regression)
- Call GET /api/auth/me without a token — expect 401

Closes #610 