### PR TITLE
fix: externalize email credentials to environment variables

### DIFF
--- a/.github/workflows/fly-dev-deploy-backend.yml
+++ b/.github/workflows/fly-dev-deploy-backend.yml
@@ -45,6 +45,14 @@ jobs:
       - name: Deploy to Dev env
         uses: superfly/flyctl-actions/setup-flyctl@master
 
+      - name: Set Fly.io secrets
+        run: |
+          flyctl secrets set MAIL_USERNAME=${{ secrets.DEV_MAIL_USERNAME }} -a wcc-backend-dev
+          flyctl secrets set MAIL_PASSWORD=${{ secrets.DEV_MAIL_PASSWORD }} -a wcc-backend-dev
+          flyctl secrets set SECURITY_API_KEY=${{ secrets.API_KEY_DEV }} -a wcc-backend-dev
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
+
       - run: flyctl deploy --remote-only --config fly-dev.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}

--- a/.github/workflows/fly-prod-deploy-backend.yml
+++ b/.github/workflows/fly-prod-deploy-backend.yml
@@ -42,6 +42,13 @@ jobs:
       - name: Deploy to Prod env
         uses: superfly/flyctl-actions/setup-flyctl@master
 
+      - name: Set Fly.io secrets
+        run: |
+          flyctl secrets set MAIL_USERNAME=${{ secrets.PROD_MAIL_USERNAME }} -a wcc-backend-prod
+          flyctl secrets set MAIL_PASSWORD=${{ secrets.PROD_MAIL_PASSWORD }} -a wcc-backend-prod
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}
+
       - run: flyctl deploy --remote-only --config fly-prod.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,8 +19,8 @@ spring:
   mail:
     host: smtp.gmail.com
     port: 587
-    username: test@email.com
-    password: your-app-password
+    username: ${MAIL_USERNAME:test@email.com}
+    password: ${MAIL_PASSWORD:your-app-password}
     properties:
       mail:
         smtp:


### PR DESCRIPTION
## Description

- Describe your changes in detail.
Replace hardcoded SMTP username and password with environment variable placeholders (MAIL_USERNAME and MAIL_PASSWORD) while keeping the original values as defaults for local development.
- Why is this change required?
Emails were not working on dev env but fine on local.
- What problem does it solve?
Add new MAIL env var to fly io secrets
- Add Notes if anything is left unclear or not completed
Github secrets added to be picked by deployment to fly.io


<!--
Example PR: https://github.com/Women-Coding-Community/wcc-backend/pull/118
-->

## Related Issue

Please link to the issue here
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Change Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Test
- [ ] Other

## Screenshots

<!--  Please include screenshots from the Swagger API. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->