### PR TITLE
Reset password UI

### DIFF
--- a/admin-wcc-app/pages/admin/members/index.tsx
+++ b/admin-wcc-app/pages/admin/members/index.tsx
@@ -1,5 +1,22 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Alert, Avatar, Box, Button, Chip, Link, Paper, Stack, Typography } from '@mui/material';
+import {
+  Alert,
+  Avatar,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Link,
+  Paper,
+  Snackbar,
+  Stack,
+  Typography,
+} from '@mui/material';
 import AdminLayout from '@/components/AdminLayout';
 import { apiFetch, getErrorMessage } from '@/lib/api';
 import { getStoredToken, isTokenExpired } from '@/lib/auth';
@@ -38,11 +55,29 @@ type MembersResponse =
     };
 
 const MEMBERS_PATH = '/api/platform/v1/members';
+const RESET_PASSWORD_PATH = '/api/auth/reset-password/request';
+
+interface ResetDialogState {
+  open: boolean;
+  member: MemberItem | null;
+}
 
 export default function MembersPage() {
   const router = useRouter();
   const [items, setItems] = useState<MemberItem[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [resetDialog, setResetDialog] = useState<ResetDialogState>({ open: false, member: null });
+  const [resetLoading, setResetLoading] = useState(false);
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    severity: 'success' | 'error';
+  }>({
+    open: false,
+    message: '',
+    severity: 'success',
+  });
 
   const normalize = useCallback((resp: MembersResponse): MemberItem[] => {
     if (Array.isArray(resp)) return resp;
@@ -65,12 +100,49 @@ export default function MembersPage() {
   );
 
   useEffect(() => {
-    const token = getStoredToken();
-    if (!token || isTokenExpired(token)) router.replace('/login');
+    const storedToken = getStoredToken();
+    if (!storedToken || isTokenExpired(storedToken)) router.replace('/login');
     else {
-      load(token);
+      setToken(storedToken);
+      load(storedToken);
     }
   }, [load, router]);
+
+  const openResetDialog = (member: MemberItem) => {
+    setResetDialog({ open: true, member });
+  };
+
+  const closeResetDialog = () => {
+    setResetDialog({ open: false, member: null });
+  };
+
+  const handleSendResetEmail = async () => {
+    const member = resetDialog.member;
+    if (!member?.email || !token) return;
+
+    setResetLoading(true);
+    try {
+      await apiFetch(RESET_PASSWORD_PATH, {
+        method: 'POST',
+        token,
+        body: { email: member.email, recipientName: member.fullName },
+      });
+      setSnackbar({
+        open: true,
+        message: `Reset password email sent to ${member.email}`,
+        severity: 'success',
+      });
+    } catch (err: unknown) {
+      setSnackbar({
+        open: true,
+        message: getErrorMessage(err, 'Failed to send reset email'),
+        severity: 'error',
+      });
+    } finally {
+      setResetLoading(false);
+      closeResetDialog();
+    }
+  };
 
   const prettyLocation = (m: MemberItem) => {
     const parts = [m.city, m.country?.countryName || m.country?.countryCode].filter(Boolean);
@@ -155,6 +227,20 @@ export default function MembersPage() {
                     </Stack>
                   )}
                 </Box>
+
+                {/* Actions */}
+                {m.email && (
+                  <Box sx={{ display: 'flex', alignItems: 'flex-start', pt: 0.5 }}>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      color="warning"
+                      onClick={() => openResetDialog(m)}
+                    >
+                      Reset Password
+                    </Button>
+                  </Box>
+                )}
               </Stack>
             </Paper>
           ))}
@@ -163,6 +249,49 @@ export default function MembersPage() {
           )}
         </Box>
       </Paper>
+
+      {/* Confirm reset password dialog */}
+      <Dialog open={resetDialog.open} onClose={closeResetDialog}>
+        <DialogTitle>Send Password Reset Email</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Send a password reset link to <strong>{resetDialog.member?.email}</strong> for{' '}
+            <strong>{resetDialog.member?.fullName}</strong>?
+            <br />
+            The link will expire in 60 minutes.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeResetDialog} disabled={resetLoading}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSendResetEmail}
+            variant="contained"
+            color="warning"
+            disabled={resetLoading}
+            startIcon={resetLoading ? <CircularProgress size={16} color="inherit" /> : null}
+          >
+            {resetLoading ? 'Sending…' : 'Send Reset Email'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Success / error snackbar */}
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={5000}
+        onClose={() => setSnackbar((s) => ({ ...s, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity={snackbar.severity}
+          onClose={() => setSnackbar((s) => ({ ...s, open: false }))}
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
     </AdminLayout>
   );
 }

--- a/admin-wcc-app/pages/reset-password.tsx
+++ b/admin-wcc-app/pages/reset-password.tsx
@@ -26,12 +26,19 @@ export default function ResetPasswordPage() {
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const isPasswordStrong = (pwd: string) => /[0-9]/.test(pwd) && /[!@#$%]/.test(pwd);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
 
     if (newPassword !== confirmPassword) {
       setError('Passwords do not match');
+      return;
+    }
+
+    if (!isPasswordStrong(newPassword)) {
+      setError('Password must contain at least one digit and one special character (!@#$%).');
       return;
     }
 
@@ -94,7 +101,7 @@ export default function ResetPasswordPage() {
                 required
                 margin="normal"
                 inputProps={{ minLength: 8, maxLength: 128 }}
-                helperText="Must be 8–128 characters"
+                helperText="Must be 8–128 characters, include at least one digit and one special character (!@#$%)"
                 disabled={isInvalidToken || loading}
               />
               <TextField

--- a/admin-wcc-app/pages/reset-password.tsx
+++ b/admin-wcc-app/pages/reset-password.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  Paper,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { apiFetch, getErrorMessage } from '@/lib/api';
+
+interface PasswordResetResponse {
+  message: string;
+}
+
+export default function ResetPasswordPage() {
+  const router = useRouter();
+  const { token } = router.query;
+
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (newPassword !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    if (!token || typeof token !== 'string') {
+      setError('Reset token is missing or invalid. Please request a new password reset link.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await apiFetch<PasswordResetResponse>('/api/auth/reset-password/confirm', {
+        method: 'POST',
+        body: { token, newPassword },
+      });
+      setSuccess(true);
+      setTimeout(() => router.push('/login'), 3000);
+    } catch (err: unknown) {
+      setError(getErrorMessage(err, 'Failed to reset password. The link may have expired.'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const isInvalidToken = router.isReady && !token;
+
+  return (
+    <Container maxWidth="sm" sx={{ mt: 12 }}>
+      <Paper elevation={3} sx={{ p: 4 }}>
+        <Typography variant="h4" color="primary" fontWeight={700} gutterBottom>
+          Women Coding Community
+        </Typography>
+        <Typography variant="h6" gutterBottom>
+          Reset Your Password
+        </Typography>
+
+        {isInvalidToken && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            No reset token found. Please use the link from your reset email or request a new one.
+          </Alert>
+        )}
+
+        {success ? (
+          <Alert severity="success" sx={{ mb: 2 }}>
+            Your password has been reset successfully. Redirecting to login…
+          </Alert>
+        ) : (
+          <>
+            {error && (
+              <Alert severity="error" sx={{ mb: 2 }}>
+                {error}
+              </Alert>
+            )}
+            <Box component="form" onSubmit={handleSubmit}>
+              <TextField
+                label="New Password"
+                type="password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                fullWidth
+                required
+                margin="normal"
+                inputProps={{ minLength: 8, maxLength: 128 }}
+                helperText="Must be 8–128 characters"
+                disabled={isInvalidToken || loading}
+              />
+              <TextField
+                label="Confirm New Password"
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                fullWidth
+                required
+                margin="normal"
+                disabled={isInvalidToken || loading}
+              />
+              <Button
+                type="submit"
+                variant="contained"
+                color="primary"
+                fullWidth
+                disabled={isInvalidToken || loading}
+                sx={{ mt: 2 }}
+                startIcon={loading ? <CircularProgress size={18} color="inherit" /> : null}
+              >
+                {loading ? 'Resetting…' : 'Reset Password'}
+              </Button>
+            </Box>
+          </>
+        )}
+      </Paper>
+    </Container>
+  );
+}

--- a/fly-dev.toml
+++ b/fly-dev.toml
@@ -10,6 +10,8 @@ primary_region = 'lhr'
 
 [env]
 SPRING_PROFILES_ACTIVE = "flyio"
+# Required secrets (set via `fly secrets set -a wcc-backend-dev`):
+#   APP_RESET_PASSWORD_BASE_URL=https://dev-wcc-admin.vercel.app
 
 [http_service]
 internal_port = 8080

--- a/fly-prod.toml
+++ b/fly-prod.toml
@@ -10,6 +10,8 @@ primary_region = 'lhr'
 
 [env]
 SPRING_PROFILES_ACTIVE = "flyio"
+# Required secrets (set via `fly secrets set -a wcc-backend-prod`):
+#   APP_RESET_PASSWORD_BASE_URL=https://prod-wcc-admin.vercel.app
 
 [http_service]
 internal_port = 8080

--- a/src/main/java/com/wcc/platform/configuration/PasswordResetConfig.java
+++ b/src/main/java/com/wcc/platform/configuration/PasswordResetConfig.java
@@ -17,7 +17,7 @@ import org.springframework.context.annotation.Configuration;
 public class PasswordResetConfig {
 
   /** Base URL of the frontend application. Used to construct the reset link sent by email. */
-  private String baseUrl = "http://localhost:3000";
+  private String baseUrl;
 
   /** Time-to-live for a password reset token, in minutes. Defaults to 60. */
   private int ttlMinutes = 60;

--- a/src/main/java/com/wcc/platform/controller/platform/AuthController.java
+++ b/src/main/java/com/wcc/platform/controller/platform/AuthController.java
@@ -2,6 +2,7 @@ package com.wcc.platform.controller.platform;
 
 import com.wcc.platform.configuration.security.RequiresRole;
 import com.wcc.platform.domain.auth.LoginResponse;
+import com.wcc.platform.domain.auth.UpdateUserRolesRequest;
 import com.wcc.platform.domain.auth.UserAccount;
 import com.wcc.platform.domain.platform.type.RoleType;
 import com.wcc.platform.service.AuthService;
@@ -10,11 +11,11 @@ import com.wcc.platform.service.PasswordResetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import com.wcc.platform.domain.auth.UpdateUserRolesRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import java.util.Optional;
@@ -41,6 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 @Tag(name = "Platform: Authentication")
 @RequiredArgsConstructor
+@SuppressWarnings("PMD.ExcessiveImports")
 public class AuthController {
   private static final ResponseEntity<LoginResponse> UNAUTHORIZED =
       ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new LoginResponse("Invalid credentials"));
@@ -188,7 +190,11 @@ public class AuthController {
   /** Request DTO for the password reset confirmation endpoint. */
   public record ConfirmPasswordResetRequest(
       @NotBlank String token,
-      @NotBlank @Size(min = 8, max = 128, message = "Password must be between 8 and 128 characters")
+      @NotBlank
+          @Size(min = 8, max = 128, message = "Password must be between 8 and 128 characters")
+          @Pattern(
+              regexp = "^(?=.*[0-9])(?=.*[!@#$%]).*$",
+              message = "Password must contain at least one digit and one special character (!@#$%)")
           String newPassword) {}
 
   /** Response DTO returned from both password reset endpoints. */

--- a/src/main/java/com/wcc/platform/service/PasswordResetService.java
+++ b/src/main/java/com/wcc/platform/service/PasswordResetService.java
@@ -18,7 +18,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -33,6 +32,7 @@ public class PasswordResetService {
 
   private static final SecureRandom RANDOM = new SecureRandom();
 
+  private final PasswordResetTokenPersistenceService tokenService;
   private final PasswordResetTokenRepository resetTokenRepository;
   private final UserAccountRepository userAccountRepository;
   private final UserTokenRepository userTokenRepository;
@@ -44,8 +44,8 @@ public class PasswordResetService {
    * Initiates the password reset flow for the given email address. Generates a single-use reset
    * token, persists it in its own committed transaction, then sends the reset link by email.
    *
-   * <p>The token is committed before the email is sent so that a transient email failure (e.g.
-   * SMTP misconfiguration) does not silently discard the token. If the email send fails the caller
+   * <p>The token is committed before the email is sent so that a transient email failure (e.g. SMTP
+   * misconfiguration) does not silently discard the token. If the email send fails the caller
    * receives a 500 and can retry; the token remains valid until it expires.
    *
    * @param email the email address of the user whose password should be reset
@@ -64,7 +64,7 @@ public class PasswordResetService {
     final OffsetDateTime expiresAt = now.plusMinutes(passwordResetConfig.getTtlMinutes());
     final String rawToken = generateToken();
 
-    persistToken(
+    tokenService.persistToken(
         PasswordResetToken.builder()
             .token(rawToken)
             .userId(user.getId())
@@ -91,17 +91,6 @@ public class PasswordResetService {
             .build());
 
     return "Password reset email sent";
-  }
-
-  /**
-   * Persists the reset token in its own transaction so it is immediately committed and visible to
-   * the confirm endpoint, independent of any outer transaction or subsequent email failure.
-   *
-   * @param token the token to persist
-   */
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public void persistToken(final PasswordResetToken token) {
-    resetTokenRepository.create(token);
   }
 
   /**
@@ -136,5 +125,4 @@ public class PasswordResetService {
     RANDOM.nextBytes(bytes);
     return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
   }
-
 }

--- a/src/main/java/com/wcc/platform/service/PasswordResetService.java
+++ b/src/main/java/com/wcc/platform/service/PasswordResetService.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -41,17 +42,16 @@ public class PasswordResetService {
 
   /**
    * Initiates the password reset flow for the given email address. Generates a single-use reset
-   * token, stores it, and emails the reset link to the user.
+   * token, persists it in its own committed transaction, then sends the reset link by email.
    *
-   * <p>Transactional to roll back the token insert if the email send fails. Trade-off: the email is
-   * sent before the transaction commits, so there is a negligible window where the token is not yet
-   * visible. A future improvement is to extract token creation to a separate service.
+   * <p>The token is committed before the email is sent so that a transient email failure (e.g.
+   * SMTP misconfiguration) does not silently discard the token. If the email send fails the caller
+   * receives a 500 and can retry; the token remains valid until it expires.
    *
    * @param email the email address of the user whose password should be reset
    * @param recipientName the display name to include in the email greeting
    * @return a message indicating whether the reset email was sent or the user was not found
    */
-  @Transactional
   public String requestReset(final String email, final String recipientName) {
     final Optional<UserAccount> userOpt = userAccountRepository.findByEmail(email);
     if (userOpt.isEmpty()) {
@@ -64,7 +64,7 @@ public class PasswordResetService {
     final OffsetDateTime expiresAt = now.plusMinutes(passwordResetConfig.getTtlMinutes());
     final String rawToken = generateToken();
 
-    resetTokenRepository.create(
+    persistToken(
         PasswordResetToken.builder()
             .token(rawToken)
             .userId(user.getId())
@@ -91,6 +91,17 @@ public class PasswordResetService {
             .build());
 
     return "Password reset email sent";
+  }
+
+  /**
+   * Persists the reset token in its own transaction so it is immediately committed and visible to
+   * the confirm endpoint, independent of any outer transaction or subsequent email failure.
+   *
+   * @param token the token to persist
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void persistToken(final PasswordResetToken token) {
+    resetTokenRepository.create(token);
   }
 
   /**

--- a/src/main/java/com/wcc/platform/service/PasswordResetTokenPersistenceService.java
+++ b/src/main/java/com/wcc/platform/service/PasswordResetTokenPersistenceService.java
@@ -1,0 +1,31 @@
+package com.wcc.platform.service;
+
+import com.wcc.platform.domain.auth.PasswordResetToken;
+import com.wcc.platform.repository.PasswordResetTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Handles persistence of password reset tokens in an isolated transaction. By living in its own
+ * Spring bean the {@code REQUIRES_NEW} propagation is honoured via the AOP proxy, ensuring the
+ * token is committed to the database before the calling service proceeds to send the reset email.
+ */
+@Service
+@RequiredArgsConstructor
+public class PasswordResetTokenPersistenceService {
+
+  private final PasswordResetTokenRepository resetTokenRepository;
+
+  /**
+   * Persists the reset token in its own transaction so it is immediately committed and visible to
+   * the confirm endpoint, independent of any outer transaction or subsequent email failure.
+   *
+   * @param token the token to persist
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void persistToken(final PasswordResetToken token) {
+    resetTokenRepository.create(token);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,7 +69,7 @@ app:
     team-signature: "WCC Mentorship Team"
   reset-password:
     base-url: ${APP_RESET_PASSWORD_BASE_URL:http://localhost:3000}
-    ttl-minutes: 60
+    ttl-minutes: 7200
     reset-path: /reset-password
   seed:
     admin:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,7 +68,7 @@ app:
   email:
     team-signature: "WCC Mentorship Team"
   reset-password:
-    base-url: http://localhost:3000
+    base-url: ${APP_RESET_PASSWORD_BASE_URL:http://localhost:3000}
     ttl-minutes: 60
     reset-path: /reset-password
   seed:

--- a/src/test/java/com/wcc/platform/service/PasswordResetServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/PasswordResetServiceTest.java
@@ -37,6 +37,7 @@ class PasswordResetServiceTest {
   private static final String NEW_PASSWORD = "NewP@ssword1";
   private static final String HASHED_PASSWORD = "hashed-new-password";
 
+  @Mock private PasswordResetTokenPersistenceService tokenPersistenceService;
   @Mock private PasswordResetTokenRepository resetTokenRepository;
   @Mock private UserAccountRepository userAccountRepository;
   @Mock private UserTokenRepository userTokenRepository;
@@ -53,6 +54,7 @@ class PasswordResetServiceTest {
 
     passwordResetService =
         new PasswordResetService(
+            tokenPersistenceService,
             resetTokenRepository,
             userAccountRepository,
             userTokenRepository,
@@ -67,11 +69,10 @@ class PasswordResetServiceTest {
   void shouldCreateTokenAndSendEmailForValidEmail() {
     var user = new UserAccount(1, null, EMAIL, "hash", List.of(RoleType.MENTOR), true);
     when(userAccountRepository.findByEmail(EMAIL)).thenReturn(Optional.of(user));
-    when(resetTokenRepository.create(any())).thenAnswer(inv -> inv.getArgument(0));
 
     passwordResetService.requestReset(EMAIL, RECIPIENT_NAME);
 
-    verify(resetTokenRepository).create(any(PasswordResetToken.class));
+    verify(tokenPersistenceService).persistToken(any(PasswordResetToken.class));
     verify(emailService).sendTemplateEmail(any(TemplateEmailRequest.class));
   }
 
@@ -83,7 +84,7 @@ class PasswordResetServiceTest {
 
     passwordResetService.requestReset(EMAIL, RECIPIENT_NAME);
 
-    verify(resetTokenRepository, never()).create(any());
+    verify(tokenPersistenceService, never()).persistToken(any());
     verify(emailService, never()).sendTemplateEmail(any());
   }
 


### PR DESCRIPTION
## Description

Created new reset form on wcc-admin app, and added a "Reset password" button to the members tab.
And
Updated application.yml to use the application url from the secrets.

## Related Issue

Closes [Issue](#605) 

## Change Type

- [ ] Bug Fix
- [x] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Test
- [ ] Other

## Screenshots

New Reset Button on the Member's Tab

<img width="707" height="514" alt="image" src="https://github.com/user-attachments/assets/fca7ae6e-ebdd-4fba-9775-497a0db5549d" />

Reset password Form 
<img width="609" height="464" alt="reset-wcc-admin-ui" src="https://github.com/user-attachments/assets/0e148904-7c8d-4fa6-845e-cff0c7183efa" />


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->