### PR TITLE
fix: Serialize skill enums as constant names for admin portal dropdowns

### DIFF
--- a/admin-wcc-app/components/mentors/MentorCard.tsx
+++ b/admin-wcc-app/components/mentors/MentorCard.tsx
@@ -2,6 +2,7 @@ import { Avatar, Box, Chip, Link, Paper, Stack, Typography } from '@mui/material
 import BioSection from '@/components/mentors/BioSection';
 import SkillsSection from '@/components/mentors/SkillsSection';
 import { MentorItem } from '@/types/mentor';
+import { MENTORSHIP_TYPES } from '@/lib/mentorshipTypes';
 
 interface MentorCardProps {
   mentor: MentorItem;
@@ -50,7 +51,12 @@ export default function MentorCard({ mentor }: MentorCardProps) {
             return types.length > 0 ? (
               <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                 {types.map((t) => (
-                  <Chip key={`type-${t}`} label={t} size="small" color="success" />
+                  <Chip
+                    key={`type-${t}`}
+                    label={MENTORSHIP_TYPES.find((m) => m.value === t)?.label ?? t}
+                    size="small"
+                    color="success"
+                  />
                 ))}
               </Box>
             ) : null;

--- a/admin-wcc-app/components/mentors/SkillsSection.tsx
+++ b/admin-wcc-app/components/mentors/SkillsSection.tsx
@@ -1,8 +1,28 @@
 import { Box, Chip, Typography } from '@mui/material';
 import { MentorSkills } from '@/types/mentor';
+import { TECHNICAL_AREAS } from '@/lib/technicalAreas';
+import { PROGRAMMING_LANGUAGES } from '@/lib/programmingLanguages';
+import { MENTORSHIP_FOCUS_AREAS } from '@/lib/mentorshipFocusAreas';
+import { PROFICIENCY_LEVELS } from '@/lib/proficiencyLevels';
 
 interface SkillsSectionProps {
   skills: MentorSkills;
+}
+
+function areaLabel(value: string): string {
+  return TECHNICAL_AREAS.find((a) => a.value === value)?.label ?? value;
+}
+
+function langLabel(value: string): string {
+  return PROGRAMMING_LANGUAGES.find((l) => l.value === value)?.label ?? value;
+}
+
+function profLabel(value: string): string {
+  return PROFICIENCY_LEVELS.find((p) => p.value === value)?.label ?? value;
+}
+
+function focusLabel(value: string): string {
+  return MENTORSHIP_FOCUS_AREAS.find((f) => f.value === value)?.label ?? value;
 }
 
 export default function SkillsSection({ skills }: SkillsSectionProps) {
@@ -19,7 +39,9 @@ export default function SkillsSection({ skills }: SkillsSectionProps) {
             <Chip
               key={a.technicalArea}
               label={
-                a.proficiencyLevel ? `${a.technicalArea} · ${a.proficiencyLevel}` : a.technicalArea
+                a.proficiencyLevel
+                  ? `${areaLabel(a.technicalArea)} · ${profLabel(a.proficiencyLevel)}`
+                  : areaLabel(a.technicalArea)
               }
               size="small"
             />
@@ -31,7 +53,11 @@ export default function SkillsSection({ skills }: SkillsSectionProps) {
           {skills.languages.map((l) => (
             <Chip
               key={l.language}
-              label={l.proficiencyLevel ? `${l.language} · ${l.proficiencyLevel}` : l.language}
+              label={
+                l.proficiencyLevel
+                  ? `${langLabel(l.language)} · ${profLabel(l.proficiencyLevel)}`
+                  : langLabel(l.language)
+              }
               size="small"
               color="secondary"
             />
@@ -41,7 +67,7 @@ export default function SkillsSection({ skills }: SkillsSectionProps) {
       {skills.mentorshipFocus && skills.mentorshipFocus.length > 0 && (
         <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
           {skills.mentorshipFocus.map((f) => (
-            <Chip key={f} label={f} size="small" color="info" />
+            <Chip key={f} label={focusLabel(f)} size="small" color="info" />
           ))}
         </Box>
       )}

--- a/src/main/java/com/wcc/platform/domain/cms/attributes/CodeLanguage.java
+++ b/src/main/java/com/wcc/platform/domain/cms/attributes/CodeLanguage.java
@@ -1,5 +1,6 @@
 package com.wcc.platform.domain.cms.attributes;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -54,7 +55,8 @@ public enum CodeLanguage {
   }
 
   @Override
+  @JsonValue
   public String toString() {
-    return name;
+    return name();
   }
 }

--- a/src/main/java/com/wcc/platform/domain/cms/attributes/MentorshipFocusArea.java
+++ b/src/main/java/com/wcc/platform/domain/cms/attributes/MentorshipFocusArea.java
@@ -1,5 +1,6 @@
 package com.wcc.platform.domain.cms.attributes;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -38,7 +39,8 @@ public enum MentorshipFocusArea {
   }
 
   @Override
+  @JsonValue
   public String toString() {
-    return description;
+    return name();
   }
 }

--- a/src/main/java/com/wcc/platform/domain/cms/attributes/ProficiencyLevel.java
+++ b/src/main/java/com/wcc/platform/domain/cms/attributes/ProficiencyLevel.java
@@ -1,5 +1,6 @@
 package com.wcc.platform.domain.cms.attributes;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -13,7 +14,8 @@ import lombok.Getter;
  */
 @Schema(
     description =
-        "Proficiency level can be populated using the enum NAME (e.g., BEGINNER), description (e.g., Beginner), or id (e.g., 1).",
+        "Proficiency level can be populated using the enum NAME (e.g., BEGINNER),"
+            + " description (e.g., Beginner), or id (e.g., 1).",
     example = "ADVANCED")
 @Getter
 @AllArgsConstructor
@@ -41,7 +43,8 @@ public enum ProficiencyLevel {
   }
 
   @Override
+  @JsonValue
   public String toString() {
-    return description;
+    return name();
   }
 }

--- a/src/main/java/com/wcc/platform/domain/cms/attributes/TechnicalArea.java
+++ b/src/main/java/com/wcc/platform/domain/cms/attributes/TechnicalArea.java
@@ -1,5 +1,6 @@
 package com.wcc.platform.domain.cms.attributes;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -52,7 +53,8 @@ public enum TechnicalArea {
   }
 
   @Override
+  @JsonValue
   public String toString() {
-    return description;
+    return name();
   }
 }

--- a/src/test/java/com/wcc/platform/domain/cms/attributes/ProficiencyLevelTest.java
+++ b/src/test/java/com/wcc/platform/domain/cms/attributes/ProficiencyLevelTest.java
@@ -35,10 +35,10 @@ class ProficiencyLevelTest {
 
   @Test
   void testToString() {
-    assertEquals("Beginner", ProficiencyLevel.BEGINNER.toString());
-    assertEquals("Intermediate", ProficiencyLevel.INTERMEDIATE.toString());
-    assertEquals("Advanced", ProficiencyLevel.ADVANCED.toString());
-    assertEquals("Expert", ProficiencyLevel.EXPERT.toString());
+    assertEquals("BEGINNER", ProficiencyLevel.BEGINNER.toString());
+    assertEquals("INTERMEDIATE", ProficiencyLevel.INTERMEDIATE.toString());
+    assertEquals("ADVANCED", ProficiencyLevel.ADVANCED.toString());
+    assertEquals("EXPERT", ProficiencyLevel.EXPERT.toString());
   }
 
   @Test

--- a/src/test/java/com/wcc/platform/domain/platform/MentorTest.java
+++ b/src/test/java/com/wcc/platform/domain/platform/MentorTest.java
@@ -42,8 +42,8 @@ class MentorTest {
   @Test
   void testToString() {
     final var expected =
-        "Mentor(profileStatus=PENDING, skills=Skills[yearsExperience=2, areas=[TechnicalAreaProficiency[technicalArea=Backend, proficiencyLevel=Beginner], TechnicalAreaProficiency[technicalArea=Frontend, proficiencyLevel=Beginner]], "
-            + "languages=[LanguageProficiency[language=Javascript, proficiencyLevel=Beginner]], mentorshipFocus=[Grow from beginner to mid-level]], "
+        "Mentor(profileStatus=PENDING, skills=Skills[yearsExperience=2, areas=[TechnicalAreaProficiency[technicalArea=BACKEND, proficiencyLevel=BEGINNER], TechnicalAreaProficiency[technicalArea=FRONTEND, proficiencyLevel=BEGINNER]], "
+            + "languages=[LanguageProficiency[language=JAVASCRIPT, proficiencyLevel=BEGINNER]], mentorshipFocus=[GROW_BEGINNER_TO_MID]], "
             + "spokenLanguages=[English, Spanish, German], bio=Mentor bio, "
             + "menteeSection=MenteeSection[idealMentee=ideal mentee description, "
             + "additional=additional, longTerm=LongTermMentorship[numMentee=1, hours=4], "


### PR DESCRIPTION
## Description

### Problem
In Admin portal, on Mentor page (where mentor can edit profile) some skills are not displayed (selected) in the dropdown menus, although all data is stored in the database (GET is returning complete profile with all skills).

### Solution

CodeLanguage, TechnicalArea, ProficiencyLevel, MentorshipFocusArea — added @JsonValue on toString() returning name() as a consistent, annotation-driven contract; toString() now returns the constant name (e.g. "BACKEND").

Frontend (admin-wcc-app)

components/mentors/SkillsSection.tsx — the members list display component now resolves constant names to human-readable labels via the existing option lookup tables (TECHNICAL_AREAS, PROGRAMMING_LANGUAGES, PROFICIENCY_LEVELS, MENTORSHIP_FOCUS_AREAS) so chips still show "Backend", "Java" etc.
components/mentors/MentorCard.tsx — mentorship type chips (AD_HOC, LONG_TERM) resolved to "Ad Hoc" / "Long Term" via MENTORSHIP_TYPES lookup.


## Related Issue



## Change Type

- [X] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Test
- [ ] Other

## Screenshots

### Mentor's page

<img width="1035" height="1230" alt="Screenshot 2026-04-23 145925" src="https://github.com/user-attachments/assets/fb2e6ac2-f157-4da1-ac26-631d99876e86" />

### Mentor's page

<img width="1010" height="1262" alt="Screenshot 2026-04-23 145940" src="https://github.com/user-attachments/assets/985cfd8e-9f8a-409b-8367-56f71db59d49" />

### All mentors
<img width="1387" height="1151" alt="Screenshot 2026-04-23 145904" src="https://github.com/user-attachments/assets/e6b00619-f72e-4ff3-ae84-ee90abca3182" />

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [X] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->