### PR TITLE
feat: add mentorship email notifications for applications and matches

### DIFF
--- a/.ai/skills/open-pr.md
+++ b/.ai/skills/open-pr.md
@@ -147,3 +147,28 @@ Tell the user to:
 - Never include change type checkboxes for types not present in the diff
 - Never include the Screenshots section for pure test/docs/chore/ci changes
 - Never include "I have tested my changes locally" for pure docs/chore/ci changes
+
+### Prose formatting — NO line wrapping
+
+Every prose paragraph (Description, Related Issue, any explanatory text) **must be a single unbroken line**. Do NOT wrap text at 72, 80, or any other column width. The only newlines allowed inside prose sections are **blank lines** that separate paragraphs.
+
+**Why:** When the user pastes the description into the GitHub PR text area, any mid-sentence newline is preserved literally. GitHub's markdown preview converts single newlines to spaces, but the raw editor shows them as broken lines and some renderers (email notifications, API consumers) do not reflow the text, making the description look fragmented.
+
+✅ Correct — each paragraph is one long line:
+```
+## Description
+
+This PR introduces email notifications for the mentorship workflow and fixes profile picture loading. Notifications are sent to both mentor and mentee with a copy to the mentorship team whenever an application status changes or a match is created.
+
+Supporting fixes include narrowing the email catch block and adding per-element @Email validation to recipient lists.
+```
+
+❌ Wrong — lines wrapped at ~72 chars:
+```
+## Description
+
+This PR introduces email notifications for the mentorship workflow
+and fixes profile picture loading. Notifications are sent to both
+mentor and mentee with a copy to the mentorship team whenever an
+application status changes or a match is created.
+```

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -37,7 +37,7 @@ allowed-tools: Bash, Read, Glob
 
 3. Suggest a PR title using Conventional Commits format: `<type>: <short imperative description>` (50–72 chars). When multiple types apply, use the most significant: `feat` > `fix` > `refactor` > `test` > `docs` > `chore`.
 
-4. Generate the filled-in PR description. Pre-check only the applicable change type boxes; remove the inapplicable ones entirely. Write all prose sections (Description, Related Issue) as flowing paragraphs — do NOT wrap lines at any character limit. Each sentence or logical thought should continue on the same line so that GitHub renders the text correctly without unwanted line breaks.
+4. Generate the filled-in PR description. Pre-check only the applicable change type boxes; remove the inapplicable ones entirely. Write all prose sections (Description, Related Issue) as flowing paragraphs where **each paragraph is a single unbroken line** — do NOT insert newlines within a paragraph for any reason. Blank lines between paragraphs are fine; newlines inside a paragraph are not. When the user pastes the description into GitHub, mid-sentence newlines are preserved literally in the text area and break the visual layout.
 
 5. **Screenshots section** — decide based on changed files:
    - Frontend changes (`admin-wcc-app/**`, `*.tsx`, `*.css`, components, pages): include the section and list the specific screenshots needed (before/after UI, error states, label/title changes, GIF for interactions). Emphasise that screenshots are required for the reviewer to assess visual changes.
@@ -61,7 +61,11 @@ allowed-tools: Bash, Read, Glob
 
 ## Rules
 
-- **Never hard-wrap prose** — description text must not have forced line breaks mid-sentence or mid-paragraph; let GitHub reflow the text naturally
+- **Each prose paragraph must be a single unbroken line** — never wrap text at 72, 80, or any column width. The only newlines inside prose sections must be blank lines separating paragraphs. Mid-sentence newlines paste literally into the GitHub text area and break the rendered layout.
+
+  ✅ Correct: `This PR adds email notifications. Notifications are sent to both mentor and mentee when an application changes.`
+
+  ❌ Wrong: `This PR adds email notifications.\nNotifications are sent to both mentor\nand mentee when an application changes.`
 
 - Always target `main` on `Women-Coding-Community/wcc-backend` (upstream)
 - Never use `gh pr create` — fork permissions require the user to open the PR through the browser

--- a/src/main/java/com/wcc/platform/configuration/NotificationConfig.java
+++ b/src/main/java/com/wcc/platform/configuration/NotificationConfig.java
@@ -5,6 +5,11 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Configuration properties for notification-related settings.
+ *
+ * <p>Binds to the {@code notification} prefix in application configuration.
+ */
 @Configuration
 @ConfigurationProperties(prefix = "notification")
 @Getter
@@ -12,4 +17,5 @@ import org.springframework.context.annotation.Configuration;
 public class NotificationConfig {
   private String mentorProfileUrl;
   private String volunteerUrl;
+  private String mentorshipEmail;
 }

--- a/src/main/java/com/wcc/platform/domain/email/EmailRequest.java
+++ b/src/main/java/com/wcc/platform/domain/email/EmailRequest.java
@@ -1,8 +1,8 @@
 package com.wcc.platform.domain.email;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -21,16 +21,9 @@ import lombok.NoArgsConstructor;
 @Schema(description = "Request object for sending emails")
 public class EmailRequest {
 
-  @NotBlank(message = "Recipient email is required")
-  @Email(message = "Recipient email must be valid")
-  @Schema(description = "Recipient email address", example = "recipient@example.com")
-  private String to;
-
-  @Schema(description = "CC recipients", example = "[\"cc1@example.com\", \"cc2@example.com\"]")
-  private List<String> cc;
-
   @Schema(description = "BCC recipients", example = "[\"bcc@example.com\"]")
-  private List<String> bcc;
+  @NotEmpty(message = "Recipient emails are required")
+  private List<String> recipients = List.of();
 
   @NotBlank(message = "Subject is required")
   @Size(max = 255, message = "Subject must not exceed 255 characters")
@@ -46,8 +39,8 @@ public class EmailRequest {
   @Schema(
       description = "Whether the email body contains HTML content",
       example = "false",
-      defaultValue = "false")
-  private boolean html;
+      defaultValue = "true")
+  private boolean html = true;
 
   @Schema(description = "Reply-to email address", example = "noreply@womencodingcommunity.com")
   private String replyTo;

--- a/src/main/java/com/wcc/platform/domain/email/EmailResponse.java
+++ b/src/main/java/com/wcc/platform/domain/email/EmailResponse.java
@@ -29,7 +29,9 @@ public class EmailResponse {
       example = "2025-11-16T10:48:50.992574288Z")
   private OffsetDateTime timestamp;
 
-  @Schema(description = "Email address of the recipient", example = "recipient@example.com")
+  @Schema(
+      description = "Emails address of the recipients",
+      example = "recipient@example.com;recipient2@example.com")
   private String recipient;
 
   @Schema(description = "Error details if the email failed to send", example = "SMTP server error")

--- a/src/main/java/com/wcc/platform/domain/email/TemplateEmailRequest.java
+++ b/src/main/java/com/wcc/platform/domain/email/TemplateEmailRequest.java
@@ -12,7 +12,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-
+/** Request object for sending an email using a template. */
 @Getter
 @Builder
 @NoArgsConstructor
@@ -20,23 +20,24 @@ import lombok.NoArgsConstructor;
 @Schema(description = "Request object for sending an email using template")
 public class TemplateEmailRequest {
 
-    @NotBlank(message = "Recipient email is required")
-    @Email(message = "Recipient email must be valid")
-    @Schema(description = "Recipient email address", example = "recipient@example.com")
-    private String to;
+  @NotBlank(message = "Recipient email is required")
+  @Email(message = "Recipient email must be valid")
+  @Schema(
+      description = "Recipient email address always send as BCC",
+      example = "recipient@example.com")
+  private String to;
 
-    @Schema(description = "CC recipients", example = "[\"cc1@example.com\", \"cc2@example.com\"]")
-    private List<String> cc;
+  @Schema(description = "BCC recipients", example = "[\"bcc@example.com\"]")
+  private List<String> bcc;
 
-    @Schema(description = "BCC recipients", example = "[\"bcc@example.com\"]")
-    private List<String> bcc;
+  @NotNull(message = "Template type is required")
+  private TemplateType templateType;
 
-    @NotNull(message = "Template type is required")
-    private TemplateType templateType;
-
-    @NotNull(message = "Template parameters are required")
-    @Schema(description = "Key-value pairs used to replace placeholders inside the email template",
-        example = """
+  @NotNull(message = "Template parameters are required")
+  @Schema(
+      description = "Key-value pairs used to replace placeholders inside the email template",
+      example =
+          """
             {
               "mentorName": "Mike",
               "program": "Ad-hoc mentorship",
@@ -44,14 +45,14 @@ public class TemplateEmailRequest {
               "deadline": "27/09/25"
             }
             """)
-    private Map<String, String> templateParameters;
+  private Map<String, Object> templateParameters;
 
-    @Schema(
-        description = "Whether the email body contains HTML content",
-        example = "false",
-        defaultValue = "false")
-    private boolean html;
+  @Schema(
+      description = "Whether the email body contains HTML content",
+      example = "false",
+      defaultValue = "false")
+  private boolean html;
 
-    @Schema(description = "Reply-to email address", example = "noreply@womencodingcommunity.com")
-    private String replyTo;
+  @Schema(description = "Reply-to email address", example = "noreply@womencodingcommunity.com")
+  private String replyTo;
 }

--- a/src/main/java/com/wcc/platform/domain/template/TemplateRequest.java
+++ b/src/main/java/com/wcc/platform/domain/template/TemplateRequest.java
@@ -8,4 +8,4 @@ import java.util.Map;
  * @param templateType
  * @param params
  */
-public record TemplateRequest(TemplateType templateType, Map<String, String> params) {}
+public record TemplateRequest(TemplateType templateType, Map<String, Object> params) {}

--- a/src/main/java/com/wcc/platform/domain/template/TemplateType.java
+++ b/src/main/java/com/wcc/platform/domain/template/TemplateType.java
@@ -2,12 +2,18 @@ package com.wcc.platform.domain.template;
 
 import lombok.Getter;
 
+/**
+ * Enum representing different types of email templates. Each enum constant corresponds to a
+ * specific template file used for generating email content.
+ */
 @Getter
 @SuppressWarnings("PMD.LongVariable")
 public enum TemplateType {
   FEEDBACK_MENTOR_ADHOC("feedback_mentor_adhoc.yml"),
   FEEDBACK_MENTOR_LONG("feedback_mentor_long_term.yml"),
   NEW_CYCLE_MENTOR_LONG("joining_new_mentorship_cycle_mentor_long_term.yml"),
+  MATCH_APPLICATIONS("match_applications.yml"),
+  MENTEE_APPLICATIONS("mentee_applications.yml"),
   WELCOME_LONG("welcome_mentorship_mentee_mentor_long_term.yml"),
   KICK_OFF_MEETING_LONG("kick_off_meeting_mentor_mentee_long_term.yml"),
   MENTEE_APP_LONG("long_term_mentorship_application_received_mentee.yml"),

--- a/src/main/java/com/wcc/platform/repository/MemberRepository.java
+++ b/src/main/java/com/wcc/platform/repository/MemberRepository.java
@@ -18,6 +18,16 @@ public interface MemberRepository extends CrudRepository<Member, Long> {
   Optional<Member> findByEmail(String email);
 
   /**
+   * Find member by email.
+   *
+   * @param memberIds list of member ids
+   * @return list of emails corresponding to the provided member ids
+   * @throws com.wcc.platform.domain.exceptions.MemberNotFoundException if any member id does not
+   *     exist in the database
+   */
+  List<String> findEmails(List<Long> memberIds);
+
+  /**
    * Return all saved members.
    *
    * @return list of members

--- a/src/main/java/com/wcc/platform/repository/file/FileMemberRepository.java
+++ b/src/main/java/com/wcc/platform/repository/file/FileMemberRepository.java
@@ -73,6 +73,20 @@ public class FileMemberRepository implements MemberRepository {
   }
 
   @Override
+  public List<String> findEmails(final List<Long> memberIds) {
+    final var members = getAll();
+
+    if (!members.isEmpty()) {
+      return members.stream()
+          .filter(member -> memberIds.contains(member.getId()))
+          .map(Member::getEmail)
+          .toList();
+    }
+
+    return List.of();
+  }
+
+  @Override
   public Member create(final Member member) {
     final var members = getAll();
     members.add(member);

--- a/src/main/java/com/wcc/platform/repository/postgres/PostgresMemberRepository.java
+++ b/src/main/java/com/wcc/platform/repository/postgres/PostgresMemberRepository.java
@@ -3,6 +3,7 @@ package com.wcc.platform.repository.postgres;
 import com.wcc.platform.domain.platform.member.Member;
 import com.wcc.platform.repository.MemberRepository;
 import com.wcc.platform.repository.postgres.component.MemberMapper;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -70,10 +71,9 @@ public class PostgresMemberRepository implements MemberRepository {
     if (memberIds == null || memberIds.isEmpty()) {
       return List.of();
     }
-    final String sql =
-        "SELECT email FROM members WHERE id IN (%s)"
-            .formatted(String.join(",", memberIds.stream().map(String::valueOf).toList()));
-    return jdbc.query(sql, (rs, rowNum) -> rs.getString("email"));
+    final String placeholders = String.join(",", Collections.nCopies(memberIds.size(), "?"));
+    final String sql = "SELECT email FROM members WHERE id IN (" + placeholders + ")";
+    return jdbc.query(sql, (rs, rowNum) -> rs.getString("email"), memberIds.toArray());
   }
 
   @Override

--- a/src/main/java/com/wcc/platform/repository/postgres/PostgresMemberRepository.java
+++ b/src/main/java/com/wcc/platform/repository/postgres/PostgresMemberRepository.java
@@ -65,6 +65,17 @@ public class PostgresMemberRepository implements MemberRepository {
   }
 
   @Override
+  public List<String> findEmails(final List<Long> memberIds) {
+    if (memberIds == null || memberIds.isEmpty()) {
+      return List.of();
+    }
+    final String sql =
+        "SELECT email FROM members WHERE id IN (%s)"
+            .formatted(String.join(",", memberIds.stream().map(String::valueOf).toList()));
+    return jdbc.query(sql, (rs, rowNum) -> rs.getString("email"));
+  }
+
+  @Override
   public Optional<Member> findById(final Long id) {
     return jdbc.query(
         SELECT_BY_ID,

--- a/src/main/java/com/wcc/platform/service/EmailService.java
+++ b/src/main/java/com/wcc/platform/service/EmailService.java
@@ -14,10 +14,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -33,6 +33,7 @@ public class EmailService {
   private final String fromEmail;
   private final EmailTemplateService emailTemplateService;
 
+  /** Constructor for EmailService. */
   @Autowired
   public EmailService(
       final JavaMailSender javaMailSender,
@@ -44,7 +45,7 @@ public class EmailService {
   }
 
   /**
-   * Sends an email based on the provided email request.
+   * Sends an email based on the provided email request always sending as BCC.
    *
    * @param emailRequest the email request containing recipient, subject, body, and other details
    * @return EmailResponse containing the status of the email sending operation
@@ -52,24 +53,17 @@ public class EmailService {
    */
   public EmailResponse sendEmail(final EmailRequest emailRequest) {
     try {
-      log.info("Attempting to send email to: {}", emailRequest.getTo());
+      log.info("Attempting to send email to: {}", emailRequest.getRecipients());
 
       final MimeMessage message = javaMailSender.createMimeMessage();
       final var mimeMessageHelper =
           new MimeMessageHelper(message, true, StandardCharsets.UTF_8.name());
 
       mimeMessageHelper.setFrom(fromEmail);
-      mimeMessageHelper.setTo(emailRequest.getTo());
       mimeMessageHelper.setSubject(emailRequest.getSubject());
       mimeMessageHelper.setText(emailRequest.getBody(), emailRequest.isHtml());
 
-      if (!ObjectUtils.isEmpty(emailRequest.getCc())) {
-        mimeMessageHelper.setCc(emailRequest.getCc().toArray(new String[0]));
-      }
-
-      if (!ObjectUtils.isEmpty(emailRequest.getBcc())) {
-        mimeMessageHelper.setBcc(emailRequest.getBcc().toArray(new String[0]));
-      }
+      mimeMessageHelper.setBcc(emailRequest.getRecipients().toArray(new String[0]));
 
       if (!ObjectUtils.isEmpty(emailRequest.getReplyTo())) {
         mimeMessageHelper.setReplyTo(emailRequest.getReplyTo());
@@ -77,18 +71,21 @@ public class EmailService {
 
       javaMailSender.send(message);
 
-      log.info("Email sent successfully to: {}", emailRequest.getTo());
+      log.info("Email sent successfully to: {}", emailRequest.getRecipients());
 
       return EmailResponse.builder()
           .success(true)
           .message("Email sent successfully")
           .timestamp(OffsetDateTime.now())
-          .recipient(emailRequest.getTo())
+          .recipient(String.join(";", emailRequest.getRecipients()))
           .build();
-
-    } catch (MessagingException | MailException e) {
-      log.error("Failed to send email to: {}. Error: {}", emailRequest.getTo(), e.getMessage(), e);
-      throw new EmailSendException("Failed to send email to: " + emailRequest.getTo(), e);
+    } catch (MessagingException e) {
+      log.error(
+          "Failed to send email to: {}. Error: {}",
+          emailRequest.getRecipients(),
+          e.getMessage(),
+          e);
+      throw new EmailSendException("Failed to send email to: " + emailRequest.getRecipients(), e);
     }
   }
 
@@ -104,19 +101,19 @@ public class EmailService {
         emailTemplateService.renderTemplate(
             request.getTemplateType(), request.getTemplateParameters());
 
-    final EmailRequest.EmailRequestBuilder emailBuilder =
+    final var emailBuilder =
         EmailRequest.builder()
-            .to(request.getTo())
             .subject(renderedTemplate.subject())
             .body(renderedTemplate.body())
             .html(request.isHtml());
 
-    if (request.getCc() != null && !request.getCc().isEmpty()) {
-      emailBuilder.cc(request.getCc());
-    }
-
-    if (request.getBcc() != null && !request.getBcc().isEmpty()) {
-      emailBuilder.bcc(request.getBcc());
+    if (CollectionUtils.isEmpty(request.getBcc())) {
+      emailBuilder.recipients(List.of(request.getTo()));
+    } else {
+      final var recipients = new java.util.ArrayList<String>();
+      recipients.add(request.getTo());
+      recipients.addAll(request.getBcc());
+      emailBuilder.recipients(recipients);
     }
 
     if (StringUtils.isNotBlank(request.getReplyTo())) {
@@ -141,12 +138,12 @@ public class EmailService {
               try {
                 return sendEmail(request);
               } catch (EmailSendException e) {
-                log.error("Failed to send bulk email to: {}", request.getTo(), e);
+                log.error("Failed to send bulk email to: {}", request.getRecipients(), e);
                 return EmailResponse.builder()
                     .success(false)
                     .message("Failed to send email")
                     .timestamp(OffsetDateTime.now())
-                    .recipient(request.getTo())
+                    .recipient(String.join(";", request.getRecipients()))
                     .error(e.getMessage())
                     .build();
               }

--- a/src/main/java/com/wcc/platform/service/EmailTemplateService.java
+++ b/src/main/java/com/wcc/platform/service/EmailTemplateService.java
@@ -8,6 +8,7 @@ import com.wcc.platform.domain.template.Template;
 import com.wcc.platform.domain.template.TemplateType;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -118,7 +119,6 @@ public class EmailTemplateService {
     if (paramValue == null) {
       return StringUtils.EMPTY;
     }
-
-    return paramValue instanceof String ? (String) paramValue : paramValue.toString();
+    return Objects.toString(paramValue);
   }
 }

--- a/src/main/java/com/wcc/platform/service/EmailTemplateService.java
+++ b/src/main/java/com/wcc/platform/service/EmailTemplateService.java
@@ -7,18 +7,20 @@ import com.wcc.platform.domain.template.RenderedTemplate;
 import com.wcc.platform.domain.template.Template;
 import com.wcc.platform.domain.template.TemplateType;
 import java.io.IOException;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 
+/** Service for rendering email templates with placeholders replaced by actual values. */
 @Slf4j
 @Service
 public class EmailTemplateService {
@@ -37,24 +39,25 @@ public class EmailTemplateService {
   }
 
   /**
-   * Renders an email template by replacing all placeholders with the actual values
-   * provided in the parameters map.
+   * Renders an email template by replacing all placeholders with the actual values provided in the
+   * parameters map.
    *
    * @param templateType the type of the email template to render
    * @param params a map of placeholder names to their replacement values
-   * @return a {@link RenderedTemplate} containing the subject and body with all placeholders replaced
+   * @return a {@link RenderedTemplate} containing the subject and body with all placeholders
+   *     replaced
    * @throws IllegalArgumentException if required placeholders are missing in {@code params}
    */
   public RenderedTemplate renderTemplate(
-      final TemplateType templateType, final Map<String, String> params) {
+      final TemplateType templateType, final Map<String, Object> params) {
     final Template template = loadTemplate(templateType);
-    final Map<String, String> mergedParams = mergeWithDefaults(params);
+    final Map<String, Object> mergedParams = mergeWithDefaults(params);
     validateTemplateParams(template, mergedParams);
     return RenderedTemplate.from(replacePlaceholders(template, mergedParams));
   }
 
-  private Map<String, String> mergeWithDefaults(final Map<String, String> params) {
-    final Map<String, String> merged = new ConcurrentHashMap<>();
+  private Map<String, Object> mergeWithDefaults(final Map<String, Object> params) {
+    final Map<String, Object> merged = new ConcurrentHashMap<>();
     merged.put(SIGNATURE_KEY, teamEmailSignature);
     merged.putAll(params);
     return merged;
@@ -74,7 +77,7 @@ public class EmailTemplateService {
     }
   }
 
-  private void validateTemplateParams(final Template template, final Map<String, String> params) {
+  private void validateTemplateParams(final Template template, final Map<String, Object> params) {
     final Set<String> requiredParams = extractPlaceholders(template);
     final Set<String> missingParams =
         requiredParams.stream()
@@ -97,17 +100,25 @@ public class EmailTemplateService {
     return matcher.results().map(result -> result.group(1)).collect(Collectors.toSet());
   }
 
-  private Template replacePlaceholders(final Template template, final Map<String, String> params) {
+  private Template replacePlaceholders(final Template template, final Map<String, Object> params) {
     return new Template(
         replacePlaceholdersInText(template.subject(), params),
         replacePlaceholdersInText(template.body(), params));
   }
 
-  private String replacePlaceholdersInText(final String text, final Map<String, String> params) {
+  private String replacePlaceholdersInText(final String text, final Map<String, Object> params) {
     String result = text;
-    for (final Map.Entry<String, String> entry : params.entrySet()) {
-      result = result.replace("{{" + entry.getKey() + "}}", entry.getValue());
+    for (final Map.Entry<String, Object> entry : params.entrySet()) {
+      result = result.replace("{{" + entry.getKey() + "}}", paramToValue(entry.getValue()));
     }
     return result;
+  }
+
+  private String paramToValue(final Object paramValue) {
+    if (paramValue == null) {
+      return StringUtils.EMPTY;
+    }
+
+    return paramValue instanceof String ? (String) paramValue : paramValue.toString();
   }
 }

--- a/src/main/java/com/wcc/platform/service/EmailTemplateService.java
+++ b/src/main/java/com/wcc/platform/service/EmailTemplateService.java
@@ -9,7 +9,6 @@ import com.wcc.platform.domain.template.TemplateType;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -57,7 +56,8 @@ public class EmailTemplateService {
   }
 
   private Map<String, Object> mergeWithDefaults(final Map<String, Object> params) {
-    final Map<String, Object> merged = new ConcurrentHashMap<>();
+    @SuppressWarnings("PMD.UseConcurrentHashMap") // HashMap is used to support null values
+    final Map<String, Object> merged = new java.util.HashMap<>();
     merged.put(SIGNATURE_KEY, teamEmailSignature);
     merged.putAll(params);
     return merged;

--- a/src/main/java/com/wcc/platform/service/MenteeWorkflowService.java
+++ b/src/main/java/com/wcc/platform/service/MenteeWorkflowService.java
@@ -13,11 +13,11 @@ import com.wcc.platform.domain.platform.mentorship.MenteeApplicationResponse;
 import com.wcc.platform.domain.platform.mentorship.MentorshipCycleEntity;
 import com.wcc.platform.repository.MenteeApplicationRepository;
 import com.wcc.platform.repository.MenteeRepository;
-import com.wcc.platform.repository.MentorRepository;
 import com.wcc.platform.repository.MentorshipCycleRepository;
 import com.wcc.platform.repository.MentorshipMatchRepository;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -35,10 +35,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class MenteeWorkflowService {
 
   private final MenteeApplicationRepository applicationRepository;
-  private final MentorRepository mentorRepository;
   private final MentorshipMatchRepository matchRepository;
   private final MentorshipCycleRepository cycleRepository;
   private final MenteeRepository menteeRepository;
+  private final MentorshipService mentorshipService;
 
   /**
    * Admin approves a mentee application.
@@ -63,6 +63,10 @@ public class MenteeWorkflowService {
         applicationId,
         application.getMenteeId(),
         application.getMentorId());
+
+    mentorshipService
+        .getNotificationService()
+        .sendApplicationUpdate(Optional.of(application), updated);
 
     return updated;
   }
@@ -91,6 +95,10 @@ public class MenteeWorkflowService {
         "Application {} from mentee {} rejected by the Mentorship Team",
         applicationId,
         application.getMenteeId());
+
+    mentorshipService
+        .getNotificationService()
+        .sendApplicationUpdate(Optional.of(application), updated);
 
     final boolean forwarded = forwardToNextPriorityMentor(application);
     if (!forwarded) {
@@ -128,6 +136,10 @@ public class MenteeWorkflowService {
         applicationId,
         application.getMenteeId());
 
+    mentorshipService
+        .getNotificationService()
+        .sendApplicationUpdate(Optional.of(application), updated);
+
     return updated;
   }
 
@@ -154,6 +166,10 @@ public class MenteeWorkflowService {
         application.getMentorId(),
         applicationId,
         application.getMenteeId());
+
+    mentorshipService
+        .getNotificationService()
+        .sendApplicationUpdate(Optional.of(application), updated);
 
     final boolean forwarded = forwardToNextPriorityMentor(application);
     if (!forwarded) {
@@ -260,7 +276,7 @@ public class MenteeWorkflowService {
   @Transactional
   public MenteeApplication assignMentor(
       final Long menteeId, final Long cycleId, final Long mentorId, final String notes) {
-    if (mentorRepository.findById(mentorId).isEmpty()) {
+    if (mentorshipService.getMentorRepository().findById(mentorId).isEmpty()) {
       throw new MentorNotFoundException(mentorId);
     }
 
@@ -288,9 +304,10 @@ public class MenteeWorkflowService {
                         String.format(
                             "No PENDING_MANUAL_MATCH application found for mentee %d in cycle %d",
                             menteeId, cycleId)));
+    final var reason = "Manual assignment by admin [" + notes + "]";
 
     applicationRepository.updateStatus(
-        manualMatchApp.getApplicationId(), ApplicationStatus.REJECTED, "Manually assigned mentor");
+        manualMatchApp.getApplicationId(), ApplicationStatus.REJECTED, reason);
 
     final MenteeApplication newApplication =
         MenteeApplication.builder()
@@ -299,12 +316,14 @@ public class MenteeWorkflowService {
             .cycleId(cycleId)
             .priorityOrder(null)
             .status(ApplicationStatus.PENDING)
-            .applicationMessage(notes)
+            .applicationMessage(reason)
             .build();
 
     final MenteeApplication created = applicationRepository.create(newApplication);
 
     log.info("Manually assigned mentor {} to mentee {} in cycle {}", mentorId, menteeId, cycleId);
+
+    mentorshipService.getNotificationService().sendApplicationUpdate(Optional.empty(), created);
 
     return created;
   }
@@ -347,6 +366,10 @@ public class MenteeWorkflowService {
         menteeId,
         cycleId,
         reason);
+
+    mentorshipService
+        .getNotificationService()
+        .sendApplicationUpdate(Optional.of(manualMatchApp), updated);
 
     return updated;
   }
@@ -401,14 +424,19 @@ public class MenteeWorkflowService {
 
     if (nextApplication.isPresent()) {
       final MenteeApplication nextApp = nextApplication.get();
-      applicationRepository.updateStatus(
-          nextApp.getApplicationId(), ApplicationStatus.MENTOR_REVIEWING, null);
+      final var nextAppUpdated =
+          applicationRepository.updateStatus(
+              nextApp.getApplicationId(), ApplicationStatus.MENTOR_REVIEWING, "[Next Priority]");
 
       log.info(
           "Forwarded application to next priority mentor {} for mentee {}",
           nextApp.getMentorId(),
           nextApp.getMenteeId());
-      // TODO: Send email notification to next priority mentor
+
+      mentorshipService
+          .getNotificationService()
+          .sendApplicationUpdate(Optional.of(nextApp), nextAppUpdated);
+
       return true;
     }
 
@@ -456,6 +484,10 @@ public class MenteeWorkflowService {
                 + "as all applications are non-forwardable",
             menteeId,
             cycleId);
+
+        mentorshipService
+            .getNotificationService()
+            .sendApplicationUpdate(Optional.empty(), manualMatchApp);
       }
     }
   }

--- a/src/main/java/com/wcc/platform/service/MentorshipMatchingService.java
+++ b/src/main/java/com/wcc/platform/service/MentorshipMatchingService.java
@@ -14,6 +14,7 @@ import com.wcc.platform.repository.MentorshipMatchRepository;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,6 +32,7 @@ public class MentorshipMatchingService {
   private final MentorshipMatchRepository matchRepository;
   private final MenteeApplicationRepository applicationRepository;
   private final MentorshipCycleRepository cycleRepository;
+  private final MentorshipService mentorshipService;
 
   /**
    * Confirm a match from an accepted application. This is typically done by mentorship team after
@@ -82,6 +84,8 @@ public class MentorshipMatchingService {
     applicationRepository.updateStatus(
         applicationId, ApplicationStatus.MATCHED, "Match confirmed by mentorship team");
 
+    mentorshipService.getNotificationService().sendMatchUpdate(Optional.empty(), created);
+
     // Reject all other pending applications for this mentee in this cycle
     rejectOtherApplications(application.getMenteeId(), application.getCycleId(), applicationId);
 
@@ -126,6 +130,8 @@ public class MentorshipMatchingService {
             .build();
 
     final MentorshipMatch result = matchRepository.update(matchId, updated);
+
+    mentorshipService.getNotificationService().sendMatchUpdate(Optional.of(match), updated);
 
     log.info(
         "Match {} completed between mentor {} and mentee {} {}",
@@ -177,6 +183,8 @@ public class MentorshipMatchingService {
     final MentorshipMatch result = matchRepository.update(matchId, updated);
 
     log.info("Match {} cancelled by {} - reason: {}", matchId, cancelledBy, reason);
+
+    mentorshipService.getNotificationService().sendMatchUpdate(Optional.of(match), updated);
 
     return result;
   }

--- a/src/main/java/com/wcc/platform/service/MentorshipNotificationService.java
+++ b/src/main/java/com/wcc/platform/service/MentorshipNotificationService.java
@@ -3,15 +3,26 @@ package com.wcc.platform.service;
 import com.wcc.platform.configuration.NotificationConfig;
 import com.wcc.platform.domain.email.EmailRequest;
 import com.wcc.platform.domain.exceptions.EmailSendException;
+import com.wcc.platform.domain.platform.mentorship.MenteeApplication;
 import com.wcc.platform.domain.platform.mentorship.Mentor;
+import com.wcc.platform.domain.platform.mentorship.MentorshipMatch;
 import com.wcc.platform.domain.template.TemplateType;
+import com.wcc.platform.repository.MemberRepository;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+/**
+ * Service responsible for sending mentorship-related notification emails. This service handles
+ * notifications for mentor approval and rejection, leveraging the email template rendering and
+ * email sending functionality.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -19,6 +30,7 @@ public class MentorshipNotificationService {
   private final EmailTemplateService emailTemplateService;
   private final EmailService emailService;
   private final NotificationConfig notificationConfig;
+  private final MemberRepository memberRepository;
 
   /**
    * Sends a mentor approval notification email to the specified mentor.
@@ -31,9 +43,9 @@ public class MentorshipNotificationService {
             + URLEncoder.encode(mentor.getFullName(), StandardCharsets.UTF_8);
 
     sendNotification(
-        mentor.getEmail(),
         TemplateType.MENTOR_APPROVED,
-        Map.of("mentorName", mentor.getFullName(), "mentorProfileUrl", mentorBaseUrl));
+        Map.of("mentorName", mentor.getFullName(), "mentorProfileUrl", mentorBaseUrl),
+        List.of(mentor.getEmail()));
   }
 
   /**
@@ -43,7 +55,6 @@ public class MentorshipNotificationService {
    */
   public void sendMentorRejectionEmail(final Mentor mentor, final String rejectionReason) {
     sendNotification(
-        mentor.getEmail(),
         TemplateType.MENTOR_PROFILE_REJECT,
         Map.of(
             "mentorshipApplicantName",
@@ -51,35 +62,119 @@ public class MentorshipNotificationService {
             "rejectionReason",
             rejectionReason,
             "volunteerUrl",
-            notificationConfig.getVolunteerUrl()));
+            notificationConfig.getVolunteerUrl()),
+        List.of(mentor.getEmail()));
+  }
+
+  /** Sends a notification email to the mentor regarding mentee applications updates. */
+  public void sendApplicationUpdate(
+      final Optional<MenteeApplication> application, final MenteeApplication updated) {
+
+    final Map<String, Object> params =
+        new java.util.concurrent.ConcurrentHashMap<>(
+            Map.of(
+                "applicationId", updated.getApplicationId(),
+                "menteeId", updated.getMenteeId(),
+                "mentorId", Optional.ofNullable(updated.getMentorId()).orElse(0L),
+                "cycleId", updated.getCycleId(),
+                "priorityOrder", Optional.ofNullable(updated.getPriorityOrder()).orElse(0),
+                "status", application.isPresent() ? application.get().getStatus() : "-",
+                "statusUpdated", updated.getStatus(),
+                "applicationMessage",
+                    Optional.ofNullable(updated.getApplicationMessage()).orElse(""),
+                "whyMentor", Optional.ofNullable(updated.getWhyMentor()).orElse(""),
+                "mentorResponse", Optional.ofNullable(updated.getMentorResponse()).orElse("")));
+
+    params.put("appliedAt", updated.getAppliedAt());
+    params.put("reviewedAt", updated.getReviewedAt());
+    params.put("matchedAt", updated.getMatchedAt());
+    params.put("createdAt", updated.getCreatedAt());
+    params.put("updatedAt", updated.getUpdatedAt());
+
+    sendNotificationByMemberId(
+        TemplateType.MENTEE_APPLICATIONS,
+        params,
+        List.of(updated.getMentorId(), updated.getMenteeId()));
   }
 
   /**
    * Renders an email template and sends a notification email to the specified recipient.
    *
-   * @param recipientEmail the recipient's email address
+   * @param recipientEmails the list of recipient's email address
    * @param templateType the type of template to render
    * @param templateParams the parameters to use for rendering the template
    */
-  private void sendNotification(
-      final String recipientEmail,
+  public void sendNotification(
       final TemplateType templateType,
-      final Map<String, String> templateParams) {
+      final Map<String, Object> templateParams,
+      final List<String> recipientEmails) {
     try {
       final var template = emailTemplateService.renderTemplate(templateType, templateParams);
 
       final var emailRequest =
           EmailRequest.builder()
-              .to(recipientEmail)
+              .recipients(recipientEmails)
               .subject(template.subject())
               .body(template.body())
-              .html(true)
               .build();
 
       emailService.sendEmail(emailRequest);
-      log.info("{} notification successfully sent to {}", templateType, recipientEmail);
+      log.info("{} notification successfully sent to {}", templateType, recipientEmails);
     } catch (EmailSendException e) {
-      log.error("Failed to send {} notification to {}", templateType, recipientEmail, e);
+      log.error("Failed to send {} notification to {}", templateType, recipientEmails, e);
     }
+  }
+
+  /**
+   * Renders an email template and sends a notification email to the specified recipient and always
+   * send copy to the mentorship team.
+   *
+   * @param memberIds the list of members ids to send notifications
+   * @param templateType the type of template to render
+   * @param templateParams the parameters to use for rendering the template
+   */
+  public void sendNotificationByMemberId(
+      final TemplateType templateType,
+      final Map<String, Object> templateParams,
+      final List<Long> memberIds) {
+
+    final var recipientEmails =
+        new java.util.ArrayList<>(
+            memberRepository.findEmails(memberIds).stream().filter(Objects::nonNull).toList());
+
+    recipientEmails.add(notificationConfig.getMentorshipEmail());
+
+    sendNotification(templateType, templateParams, recipientEmails);
+  }
+
+  /** Sends a notification email to the mentor regarding mentee applications updates. */
+  public void sendMatchUpdate(
+      final Optional<MentorshipMatch> previous, final MentorshipMatch updated) {
+
+    final Map<String, Object> params =
+        new java.util.concurrent.ConcurrentHashMap<>(
+            Map.of(
+                "matchId", Optional.ofNullable(updated.getMatchId()).orElse(0L),
+                "mentorId", updated.getMentorId(),
+                "menteeId", updated.getMenteeId(),
+                "cycleId", updated.getCycleId(),
+                "applicationId", Optional.ofNullable(updated.getApplicationId()).orElse(0L),
+                "status", previous.isPresent() ? previous.get().getStatus() : "-",
+                "statusUpdated", updated.getStatus(),
+                "sessionFrequency", Optional.ofNullable(updated.getSessionFrequency()).orElse(""),
+                "totalSessions", Optional.ofNullable(updated.getTotalSessions()).orElse(0),
+                "cancellationReason",
+                    Optional.ofNullable(updated.getCancellationReason()).orElse("")));
+
+    params.put("cancelledBy", updated.getCancelledBy());
+    params.put("startDate", updated.getStartDate());
+    params.put("endDate", updated.getEndDate());
+    params.put("expectedEndDate", updated.getExpectedEndDate());
+    params.put("cancelledAt", updated.getCancelledAt());
+    params.put("createdAt", updated.getCreatedAt());
+    params.put("updatedAt", updated.getUpdatedAt());
+
+    final var memberIds = List.of(updated.getMentorId(), updated.getMenteeId());
+    sendNotificationByMemberId(TemplateType.MATCH_APPLICATIONS, params, memberIds);
   }
 }

--- a/src/main/java/com/wcc/platform/service/MentorshipNotificationService.java
+++ b/src/main/java/com/wcc/platform/service/MentorshipNotificationService.java
@@ -10,12 +10,15 @@ import com.wcc.platform.domain.template.TemplateType;
 import com.wcc.platform.repository.MemberRepository;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 /**
@@ -74,7 +77,7 @@ public class MentorshipNotificationService {
         "PMD.UseConcurrentHashMap") // HashMap is used to support null values from domain model
     // fields
     final Map<String, Object> params =
-        new java.util.HashMap<>(
+        new HashMap<>(
             Map.of(
                 "applicationId", updated.getApplicationId(),
                 "menteeId", updated.getMenteeId(),
@@ -94,10 +97,12 @@ public class MentorshipNotificationService {
     params.put("createdAt", updated.getCreatedAt());
     params.put("updatedAt", updated.getUpdatedAt());
 
-    sendNotificationByMemberId(
-        TemplateType.MENTEE_APPLICATIONS,
-        params,
-        List.of(updated.getMentorId(), updated.getMenteeId()));
+    final var memberIds = new ArrayList<Long>();
+    if (updated.getMentorId() != null) {
+      memberIds.add(updated.getMentorId());
+    }
+    memberIds.add(updated.getMenteeId());
+    sendNotificationByMemberId(TemplateType.MENTEE_APPLICATIONS, params, memberIds);
   }
 
   /**
@@ -107,7 +112,7 @@ public class MentorshipNotificationService {
    * @param templateType the type of template to render
    * @param templateParams the parameters to use for rendering the template
    */
-  public void sendNotification(
+  /* default */ void sendNotification(
       final TemplateType templateType,
       final Map<String, Object> templateParams,
       final List<String> recipientEmails) {
@@ -119,6 +124,7 @@ public class MentorshipNotificationService {
               .recipients(recipientEmails)
               .subject(template.subject())
               .body(template.body())
+              .html(true)
               .build();
 
       emailService.sendEmail(emailRequest);
@@ -136,16 +142,19 @@ public class MentorshipNotificationService {
    * @param templateType the type of template to render
    * @param templateParams the parameters to use for rendering the template
    */
-  public void sendNotificationByMemberId(
+  /* default */ void sendNotificationByMemberId(
       final TemplateType templateType,
       final Map<String, Object> templateParams,
       final List<Long> memberIds) {
 
     final var recipientEmails =
-        new java.util.ArrayList<>(
+        new ArrayList<>(
             memberRepository.findEmails(memberIds).stream().filter(Objects::nonNull).toList());
 
-    recipientEmails.add(notificationConfig.getMentorshipEmail());
+    final String teamEmail = notificationConfig.getMentorshipEmail();
+    if (StringUtils.isNotBlank(teamEmail)) {
+      recipientEmails.add(teamEmail);
+    }
 
     sendNotification(templateType, templateParams, recipientEmails);
   }
@@ -158,7 +167,7 @@ public class MentorshipNotificationService {
         "PMD.UseConcurrentHashMap") // HashMap is used to support null values from domain model
     // fields
     final Map<String, Object> params =
-        new java.util.HashMap<>(
+        new HashMap<>(
             Map.of(
                 "matchId", Optional.ofNullable(updated.getMatchId()).orElse(0L),
                 "mentorId", updated.getMentorId(),

--- a/src/main/java/com/wcc/platform/service/MentorshipService.java
+++ b/src/main/java/com/wcc/platform/service/MentorshipService.java
@@ -23,6 +23,7 @@ import com.wcc.platform.utils.FiltersUtil;
 import java.util.List;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -40,12 +41,14 @@ public class MentorshipService {
       MentorshipCycleEntity.builder().status(CycleStatus.CLOSED).build();
 
   private static final int MINIMUM_HOURS = 2;
-  private final MentorRepository mentorRepository;
-  private final MemberRepository memberRepository;
+
+  @Getter private final MentorRepository mentorRepository;
+  @Getter private final MemberRepository memberRepository;
+
   private final MentorshipCycleRepository cycleRepository;
   private final UserProvisionService userProvisionService;
   private final MemberProfilePictureRepository profilePicRepo;
-  private final MentorshipNotificationService notificationService;
+  @Getter private final MentorshipNotificationService notificationService;
 
   /**
    * Create a mentor record.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,7 @@ mentorship:
 notification:
   mentor-profile-url: https://www.womencodingcommunity.com/mentors?keywords=
   volunteer-url: https://www.womencodingcommunity.com/volunteer
+  mentorship-email: mentorship@womencodingcommunity.com
 
 logging:
   level:

--- a/src/main/resources/email-templates/match_applications.yml
+++ b/src/main/resources/email-templates/match_applications.yml
@@ -27,4 +27,4 @@ MATCH_APPLICATIONS:
     {{teamEmailSignature}}
     </p>
 
-    <p>[Automatically Message]</p>
+    <p>[Automated Message]</p>

--- a/src/main/resources/email-templates/match_applications.yml
+++ b/src/main/resources/email-templates/match_applications.yml
@@ -1,0 +1,30 @@
+MATCH_APPLICATIONS:
+  subject: "[{{cycleId}}][match_applications]: {{applicationId}}-{{status}}"
+  body: |
+    <p>Dear Mentorship Team,</p>
+
+    <p>Check the mentorship match latest details.</p>
+    <ul>
+      <li><strong>Match ID:</strong> {{matchId}}</li>
+      <li><strong>Mentor ID:</strong> {{mentorId}}</li>
+      <li><strong>Mentee ID:</strong> {{menteeId}}</li>
+      <li><strong>Cycle ID:</strong> {{cycleId}}</li>
+      <li><strong>Application ID:</strong> {{applicationId}}</li>
+      <li><strong>Status:</strong> {{status}}</li>
+      <li><strong>Status Updated:</strong> {{statusUpdated}}</li>
+      <li><strong>Start Date:</strong> {{startDate}}</li>
+      <li><strong>End Date:</strong> {{endDate}}</li>
+      <li><strong>Expected End Date:</strong> {{expectedEndDate}}</li>
+      <li><strong>Session Frequency:</strong> {{sessionFrequency}}</li>
+      <li><strong>Total Sessions:</strong> {{totalSessions}}</li>
+      <li><strong>Cancellation Reason:</strong> {{cancellationReason}}</li>
+      <li><strong>Cancelled By:</strong> {{cancelledBy}}</li>
+      <li><strong>Cancelled At:</strong> {{cancelledAt}}</li>
+      <li><strong>Created At:</strong> {{createdAt}}</li>
+      <li><strong>Updated At:</strong> {{updatedAt}}</li>
+    </ul>
+    <p>
+    {{teamEmailSignature}}
+    </p>
+
+    <p>[Automatically Message]</p>

--- a/src/main/resources/email-templates/mentee_applications.yml
+++ b/src/main/resources/email-templates/mentee_applications.yml
@@ -25,4 +25,4 @@ MENTEE_APPLICATIONS:
     {{teamEmailSignature}}
     </p>
 
-    <p>[Automatically Message]</p>
+    <p>[Automated Message]</p>

--- a/src/main/resources/email-templates/mentee_applications.yml
+++ b/src/main/resources/email-templates/mentee_applications.yml
@@ -1,0 +1,28 @@
+MENTEE_APPLICATIONS:
+  subject: "[{{cycleId}}][mentee_applications]: {{applicationId}}-{{status}}"
+  body: |
+    <p>Dear Mentorship Team,</p>
+
+    <p>Check the mentee application latest details.</p>
+    <ul>
+      <li><strong>Application ID:</strong> {{applicationId}}</li>
+      <li><strong>Mentee ID:</strong> {{menteeId}}</li>
+      <li><strong>Mentor ID:</strong> {{mentorId}}</li>
+      <li><strong>Cycle ID:</strong> {{cycleId}}</li>
+      <li><strong>Priority Order:</strong> {{priorityOrder}}</li>
+      <li><strong>Status:</strong> {{status}}</li>
+      <li><strong>Status Updated:</strong> {{statusUpdated}}</li>
+      <li><strong>Application Message:</strong> {{applicationMessage}}</li>
+      <li><strong>Why Mentor:</strong> {{whyMentor}}</li>
+      <li><strong>Applied At:</strong> {{appliedAt}}</li>
+      <li><strong>Reviewed At:</strong> {{reviewedAt}}</li>
+      <li><strong>Matched At:</strong> {{matchedAt}}</li>
+      <li><strong>Mentor Response:</strong> {{mentorResponse}}</li>
+      <li><strong>Created At:</strong> {{createdAt}}</li>
+      <li><strong>Updated At:</strong> {{updatedAt}}</li>
+    </ul>
+    <p>
+    {{teamEmailSignature}}
+    </p>
+
+    <p>[Automatically Message]</p>

--- a/src/main/resources/email-templates/welcome_mentorship_mentee_mentor_long_term.yml
+++ b/src/main/resources/email-templates/welcome_mentorship_mentee_mentor_long_term.yml
@@ -1,10 +1,13 @@
 WELCOME_LONG:
-  subject: "Welcome to the {{year}} Mentorship Programme"
+  subject: "You are paired up in WCC Mentorship Program {{year}}"
   body: |
     <p>Dear {{mentorName}} and {{menteeName}},</p>
 
     <p>
-    We are excited to introduce you to our <strong>Mentorship Programme</strong>!
+    Welcome to the Women Coding Community Mentorship Programme. we're delighted to have you both on board!
+    </p>
+    <p>
+    Mentorship is a powerful tool for personal and professional growth, and we hope this relationship is a meaningful opportunity for you to learn, grow, and achieve your goals.
     </p>
 
     <p><strong>Contact information:</strong></p>
@@ -12,15 +15,11 @@ WELCOME_LONG:
     <ul>
       <li><strong>Mentor:</strong> {{mentorName}} (<a href="mailto:{{mentorEmail}}">{{mentorEmail}}</a>)</li>
       <li><strong>Mentee:</strong> {{menteeName}} (<a href="mailto:{{menteeEmail}}">{{menteeEmail}}</a>)</li>
+      <li><strong>Google Meet:</strong><a href="{{googleMeetLink}}">link</a></li>
     </ul>
-
+    
     <p>
-    We believe that mentorship is a powerful tool for personal and professional growth, and we are thrilled to have you as part of this program.
-    We hope that this mentorship relationship will be a valuable opportunity for you to learn, grow, and achieve your goals.
-    </p>
-
-    <p>
-    The mentorship program will run from <strong>April to September</strong>.
+    The mentorship program will run from <strong>May to October</strong>.
     The frequency and format of the meetings will be decided by you during your initial meeting.
     We recommend at least <strong>two mentoring sessions per month</strong> (45 minutes to 1 hour each) to ensure a meaningful relationship.
     </p>
@@ -33,6 +32,7 @@ WELCOME_LONG:
         The mentee is kindly asked to book the first session using the mentor’s scheduling link:
         <a href="{{mentorSchedulingLink}}">Schedule your first meeting</a>
       </li>
+      <li>Use</strong><a href="{{googleMeetLink}}">this Google Meetup</a>link and you both may choose whether to record, transcribe, or take notes during your calls.</li>
       <li>Define specific and measurable goals for the mentorship relationship.</li>
       <li>Develop an action plan to achieve those goals.</li>
       <li>Schedule regular check-ins to monitor progress and adjust the action plan as needed.</li>
@@ -47,25 +47,17 @@ WELCOME_LONG:
 
     <ul>
       <li>
-        <a href="{{attendanceTrackerUrl}}">Pair Mentorship Attendance Tracker</a> – for mentees to log session attendance.
-      </li>
-      <li>
-        <a href="{{notionTrackingTemplateUrl}}">Notion Tracking Template</a> – to track goals, progress, and stay organised.
-      </li>
-      <li>
         <a href="{{resourcesUrl}}">Mentorship Resources</a> – for mentors and mentees.
       </li>
       <li>
         <a href="{{codeOfConductUrl}}">Code of Conduct for Mentors and Mentees</a>
       </li>
     </ul>
-
-    <p>
-    We hope these resources help you make the most of this mentorship opportunity.
-    If you have any questions or concerns, please don’t hesitate to reach out to us via email or the
-    Slack channel <strong>#mentorship</strong>.
-    </p>
     
+    <p><strong>Note:</strong></p>
+    <p>You're welcome to use a personal or alternative communication method instead of provided Google Meetup Link. As a resource to you and your mentor, you may choose whether to record, transcribe, or take notes during your calls. Please be aware that if you choose to record or keep notes, WCC will automatically receive a copy. This information is fully confidential and will not be shared with anyone.</p>
+    <p>We hope these resources help you make the most of this mentorship opportunity. If you have any questions or concerns, please don’t hesitate to reach out to us via email or the Slack channel <strong>#mentorship</strong>.</p>
+    <p>Wishing you a rewarding mentorship journey!</p>
     <p>
     {{teamEmailSignature}}
     </p>

--- a/src/test/java/com/wcc/platform/controller/EmailControllerTest.java
+++ b/src/test/java/com/wcc/platform/controller/EmailControllerTest.java
@@ -55,18 +55,17 @@ class EmailControllerTest {
   @BeforeEach
   void setUp() {
 
-    Map<String, String> templateParams = Map.of(
-        "mentorName", "Mike",
-        "program", "Ad-hoc mentorship",
-        "menteeName", "Alice",
-        "deadline", "27/09/25",
-        "teamEmailSignature", "Best Regards"
-    );
-
+    Map<String, Object> templateParams =
+        Map.of(
+            "mentorName", "Mike",
+            "program", "Ad-hoc mentorship",
+            "menteeName", "Alice",
+            "deadline", "27/09/25",
+            "teamEmailSignature", "Best Regards");
 
     emailRequest =
         EmailRequest.builder()
-            .to("recipient@example.com")
+            .recipients(List.of("recipient@example.com"))
             .subject("Test Subject")
             .body("Test Body")
             .html(false)
@@ -119,7 +118,11 @@ class EmailControllerTest {
       "Given invalid email request without recipient, when sending email, then should return bad request")
   void shouldReturnBadRequestForInvalidEmail() throws Exception {
     EmailRequest invalidRequest =
-        EmailRequest.builder().to("").subject("Test Subject").body("Test Body").build();
+        EmailRequest.builder()
+            .recipients(List.of(""))
+            .subject("Test Subject")
+            .body("Test Body")
+            .build();
 
     mockMvc
         .perform(
@@ -135,7 +138,7 @@ class EmailControllerTest {
   void shouldReturnBadRequestForInvalidEmailFormat() throws Exception {
     EmailRequest invalidRequest =
         EmailRequest.builder()
-            .to("invalid-email")
+            .recipients(List.of("invalid-email"))
             .subject("Test Subject")
             .body("Test Body")
             .build();
@@ -171,14 +174,14 @@ class EmailControllerTest {
   void shouldSendBulkEmails() throws Exception {
     EmailRequest request1 =
         EmailRequest.builder()
-            .to("recipient1@example.com")
+            .recipients(List.of("recipient1@example.com"))
             .subject("Subject 1")
             .body("Body 1")
             .build();
 
     EmailRequest request2 =
         EmailRequest.builder()
-            .to("recipient2@example.com")
+            .recipients(List.of("recipient2@example.com"))
             .subject("Subject 2")
             .body("Body 2")
             .build();
@@ -220,7 +223,7 @@ class EmailControllerTest {
   void shouldSendHtmlEmail() throws Exception {
     EmailRequest htmlRequest =
         EmailRequest.builder()
-            .to("recipient@example.com")
+            .recipients(List.of("recipient@example.com"))
             .subject("Test Subject")
             .body("<h1>HTML Content</h1>")
             .html(true)
@@ -244,11 +247,9 @@ class EmailControllerTest {
   void shouldSendEmailWithCcAndBcc() throws Exception {
     EmailRequest ccBccRequest =
         EmailRequest.builder()
-            .to("recipient@example.com")
+            .recipients(List.of("recipient@example.com"))
             .subject("Test Subject")
             .body("Test Body")
-            .cc(List.of("cc@example.com"))
-            .bcc(List.of("bcc@example.com"))
             .build();
 
     when(emailService.sendEmail(any(EmailRequest.class))).thenReturn(emailResponse);
@@ -293,6 +294,4 @@ class EmailControllerTest {
                 .content(objectMapper.writeValueAsString(invalidTempEmailReq)))
         .andExpect(status().isBadRequest());
   }
-
-
 }

--- a/src/test/java/com/wcc/platform/factories/SetUpTemplateFactories.java
+++ b/src/test/java/com/wcc/platform/factories/SetUpTemplateFactories.java
@@ -17,7 +17,7 @@ public class SetUpTemplateFactories {
 
   /** Creates a template request.* */
   public static TemplateRequest createTemplateRequest(
-      final TemplateType type, final Map<String, String> parameters) {
+      final TemplateType type, final Map<String, Object> parameters) {
     return new TemplateRequest(type, parameters);
   }
 }

--- a/src/test/java/com/wcc/platform/service/EmailServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/EmailServiceTest.java
@@ -37,15 +37,11 @@ class EmailServiceTest {
 
   @Mock private MimeMessage mimeMessage;
 
-  @Mock
-  private EmailTemplateService emailTemplateService;
+  @Mock private EmailTemplateService emailTemplateService;
 
-  @Mock
-  private EmailResponse emailResponse;
+  @Mock private EmailResponse emailResponse;
 
-  @InjectMocks
-  @Spy
-  private EmailService emailService;
+  @InjectMocks @Spy private EmailService emailService;
 
   private EmailRequest emailRequest;
 
@@ -56,7 +52,7 @@ class EmailServiceTest {
 
     emailRequest =
         EmailRequest.builder()
-            .to("recipient@example.com")
+            .recipients(List.of("recipient@example.com"))
             .subject("Test Subject")
             .body("Test Body")
             .html(false)
@@ -85,7 +81,7 @@ class EmailServiceTest {
   void shouldSendHtmlEmail() {
     EmailRequest htmlRequest =
         EmailRequest.builder()
-            .to("recipient@example.com")
+            .recipients(List.of("recipient@example.com"))
             .subject("Test Subject")
             .body("<h1>Test HTML</h1>")
             .html(true)
@@ -106,10 +102,9 @@ class EmailServiceTest {
   void shouldSendEmailWithCc() {
     EmailRequest ccRequest =
         EmailRequest.builder()
-            .to("recipient@example.com")
+            .recipients(List.of("recipient@example.com"))
             .subject("Test Subject")
             .body("Test Body")
-            .cc(List.of("cc1@example.com", "cc2@example.com"))
             .build();
 
     when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
@@ -127,10 +122,9 @@ class EmailServiceTest {
   void shouldSendEmailWithBcc() {
     EmailRequest bccRequest =
         EmailRequest.builder()
-            .to("recipient@example.com")
+            .recipients(List.of("recipient@example.com"))
             .subject("Test Subject")
             .body("Test Body")
-            .bcc(List.of("bcc@example.com"))
             .build();
 
     when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
@@ -148,7 +142,7 @@ class EmailServiceTest {
   void shouldSendEmailWithReplyTo() {
     EmailRequest replyToRequest =
         EmailRequest.builder()
-            .to("recipient@example.com")
+            .recipients(List.of("recipient@example.com"))
             .subject("Test Subject")
             .body("Test Body")
             .replyTo("noreply@wcc.dev")
@@ -174,7 +168,7 @@ class EmailServiceTest {
 
     assertThatThrownBy(() -> emailService.sendEmail(emailRequest))
         .isInstanceOf(EmailSendException.class)
-        .hasMessageContaining("Failed to send email to: recipient@example.com");
+        .hasMessageContaining("Failed to send email to:");
   }
 
   @Test
@@ -183,14 +177,14 @@ class EmailServiceTest {
   void shouldSendBulkEmails() {
     EmailRequest request1 =
         EmailRequest.builder()
-            .to("recipient1@example.com")
+            .recipients(List.of("recipient1@example.com"))
             .subject("Subject 1")
             .body("Body 1")
             .build();
 
     EmailRequest request2 =
         EmailRequest.builder()
-            .to("recipient2@example.com")
+            .recipients(List.of("recipient2@example.com"))
             .subject("Subject 2")
             .body("Body 2")
             .build();
@@ -212,14 +206,14 @@ class EmailServiceTest {
   void shouldHandlePartialFailuresInBulkEmails() {
     EmailRequest request1 =
         EmailRequest.builder()
-            .to("recipient1@example.com")
+            .recipients(List.of("recipient1@example.com"))
             .subject("Subject 1")
             .body("Body 1")
             .build();
 
     EmailRequest request2 =
         EmailRequest.builder()
-            .to("recipient2@example.com")
+            .recipients(List.of("recipient2@example.com"))
             .subject("Subject 2")
             .body("Body 2")
             .build();
@@ -243,42 +237,36 @@ class EmailServiceTest {
       "Given a template email request with all optional fields, when sending template email, then should build and send email with all fields")
   void shouldSendTemplateEmailWithAllFields() {
 
-    TemplateEmailRequest request = TemplateEmailRequest.builder()
-        .to("recipient@example.com")
-        .templateType(TemplateType.FEEDBACK_MENTOR_ADHOC)
-        .templateParameters(Map.of("mentorName", "John"))
-        .cc(List.of("cc@example.com"))
-        .bcc(List.of("bcc@example.com"))
-        .replyTo("reply@example.com")
-        .html(true)
-        .build();
+    TemplateEmailRequest request =
+        TemplateEmailRequest.builder()
+            .to("recipient@example.com")
+            .templateType(TemplateType.FEEDBACK_MENTOR_ADHOC)
+            .templateParameters(Map.of("mentorName", "John"))
+            .bcc(List.of("bcc@example.com"))
+            .replyTo("reply@example.com")
+            .html(true)
+            .build();
 
-    RenderedTemplate renderedTemplate =
-        new RenderedTemplate("Subject", "Body");
+    RenderedTemplate renderedTemplate = new RenderedTemplate("Subject", "Body");
 
-    when(emailTemplateService.renderTemplate(any(), any()))
-        .thenReturn(renderedTemplate);
+    when(emailTemplateService.renderTemplate(any(), any())).thenReturn(renderedTemplate);
 
-    doReturn(emailResponse)
-        .when(emailService)
-        .sendEmail(any(EmailRequest.class));
+    doReturn(emailResponse).when(emailService).sendEmail(any(EmailRequest.class));
 
     EmailResponse result = emailService.sendTemplateEmail(request);
 
     assertThat(result).isEqualTo(emailResponse);
 
-    ArgumentCaptor<EmailRequest> captor =
-        ArgumentCaptor.forClass(EmailRequest.class);
+    ArgumentCaptor<EmailRequest> captor = ArgumentCaptor.forClass(EmailRequest.class);
 
     verify(emailService).sendEmail(captor.capture());
 
     EmailRequest sentRequest = captor.getValue();
 
-    assertThat(sentRequest.getTo()).isEqualTo("recipient@example.com");
+    assertThat(sentRequest.getRecipients()).contains("recipient@example.com");
     assertThat(sentRequest.getSubject()).isEqualTo("Subject");
     assertThat(sentRequest.getBody()).isEqualTo("Body");
-    assertThat(sentRequest.getCc()).contains("cc@example.com");
-    assertThat(sentRequest.getBcc()).contains("bcc@example.com");
+    assertThat(sentRequest.getRecipients()).contains("bcc@example.com");
     assertThat(sentRequest.getReplyTo()).isEqualTo("reply@example.com");
     assertThat(sentRequest.isHtml()).isTrue();
   }
@@ -288,38 +276,32 @@ class EmailServiceTest {
       "Given a template email request without optional fields, when sending template email, then should build and send email with only required fields")
   void shouldSendTemplateEmailWithoutOptionalFields() {
 
-    TemplateEmailRequest request = TemplateEmailRequest.builder()
-        .to("recipient@example.com")
-        .templateType(TemplateType.FEEDBACK_MENTOR_ADHOC)
-        .templateParameters(Map.of("mentorName", "John"))
-        .build();
+    TemplateEmailRequest request =
+        TemplateEmailRequest.builder()
+            .to("recipient@example.com")
+            .templateType(TemplateType.FEEDBACK_MENTOR_ADHOC)
+            .templateParameters(Map.of("mentorName", "John"))
+            .build();
 
-    RenderedTemplate renderedTemplate =
-        new RenderedTemplate("Subject", "Body");
+    RenderedTemplate renderedTemplate = new RenderedTemplate("Subject", "Body");
 
-    when(emailTemplateService.renderTemplate(any(), any()))
-        .thenReturn(renderedTemplate);
+    when(emailTemplateService.renderTemplate(any(), any())).thenReturn(renderedTemplate);
 
-    doReturn(emailResponse)
-        .when(emailService)
-        .sendEmail(any(EmailRequest.class));
+    doReturn(emailResponse).when(emailService).sendEmail(any(EmailRequest.class));
 
     EmailResponse result = emailService.sendTemplateEmail(request);
 
     assertThat(result).isEqualTo(emailResponse);
 
-    ArgumentCaptor<EmailRequest> captor =
-        ArgumentCaptor.forClass(EmailRequest.class);
+    ArgumentCaptor<EmailRequest> captor = ArgumentCaptor.forClass(EmailRequest.class);
 
     verify(emailService).sendEmail(captor.capture());
 
     EmailRequest sentRequest = captor.getValue();
 
-    assertThat(sentRequest.getTo()).isEqualTo("recipient@example.com");
+    assertThat(sentRequest.getRecipients()).contains("recipient@example.com");
     assertThat(sentRequest.getSubject()).isEqualTo("Subject");
     assertThat(sentRequest.getBody()).isEqualTo("Body");
-    assertThat(sentRequest.getCc()).isNull();
-    assertThat(sentRequest.getBcc()).isNull();
     assertThat(sentRequest.getReplyTo()).isNull();
     assertThat(sentRequest.isHtml()).isFalse();
   }
@@ -328,11 +310,12 @@ class EmailServiceTest {
   @DisplayName(
       "Given provided template type is not found, when sending template email, then should throw an Exception")
   void shouldThrowExceptionWhenTemplateEmailFails() {
-    TemplateEmailRequest request = TemplateEmailRequest.builder()
-        .to("test@example.com")
-        .templateType(TemplateType.FEEDBACK_MENTOR_ADHOC)
-        .templateParameters(Map.of("name", "John"))
-        .build();
+    TemplateEmailRequest request =
+        TemplateEmailRequest.builder()
+            .to("test@example.com")
+            .templateType(TemplateType.FEEDBACK_MENTOR_ADHOC)
+            .templateParameters(Map.of("name", "John"))
+            .build();
 
     when(emailTemplateService.renderTemplate(any(), any()))
         .thenThrow(new RuntimeException("Template not found."));
@@ -348,36 +331,30 @@ class EmailServiceTest {
   @DisplayName(
       "Given a template email request with empty optional fields, when sending template email, then should omit cc, bcc and replyTo from the built request")
   void shouldSendTemplateEmailWhenOptionalFieldsAreEmpty() {
-    TemplateEmailRequest request = TemplateEmailRequest.builder()
-        .to("test@example.com")
-        .templateType(TemplateType.FEEDBACK_MENTOR_ADHOC)
-        .templateParameters(Map.of("key", "value"))
-        .cc(null)
-        .bcc(Collections.emptyList())
-        .replyTo("")
-        .build();
+    TemplateEmailRequest request =
+        TemplateEmailRequest.builder()
+            .to("test@example.com")
+            .templateType(TemplateType.FEEDBACK_MENTOR_ADHOC)
+            .templateParameters(Map.of("key", "value"))
+            .bcc(Collections.emptyList())
+            .replyTo("")
+            .build();
 
-    RenderedTemplate renderedTemplate =
-        new RenderedTemplate("Subject", "Body");
+    RenderedTemplate renderedTemplate = new RenderedTemplate("Subject", "Body");
 
-    when(emailTemplateService.renderTemplate(any(), any()))
-        .thenReturn(renderedTemplate);
+    when(emailTemplateService.renderTemplate(any(), any())).thenReturn(renderedTemplate);
 
-    doReturn(EmailResponse.builder().success(true).build())
-        .when(emailService)
-        .sendEmail(any());
+    doReturn(EmailResponse.builder().success(true).build()).when(emailService).sendEmail(any());
 
     emailService.sendTemplateEmail(request);
 
-    ArgumentCaptor<EmailRequest> captor =
-        ArgumentCaptor.forClass(EmailRequest.class);
+    ArgumentCaptor<EmailRequest> captor = ArgumentCaptor.forClass(EmailRequest.class);
 
     verify(emailService).sendEmail(captor.capture());
 
     EmailRequest sentRequest = captor.getValue();
 
-    assertThat(sentRequest.getCc()).isNull();
-    assertThat(sentRequest.getBcc()).isNull();
+    assertThat(sentRequest.getRecipients()).contains("test@example.com");
     assertThat(sentRequest.getReplyTo()).isNull();
   }
 }

--- a/src/test/java/com/wcc/platform/service/EmailTemplateServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/EmailTemplateServiceTest.java
@@ -40,7 +40,7 @@ class EmailTemplateServiceTest {
 
   @Test
   void renderTemplateValidParametersSuccess() throws IOException {
-    Map<String, String> params = new HashMap<>();
+    Map<String, Object> params = new HashMap<>();
     params.put("mentorName", "Doe");
     params.put("menteeName", "Smith");
 
@@ -64,7 +64,7 @@ class EmailTemplateServiceTest {
   @Test
   void renderTemplateMissingParametersException() throws IOException {
     // Given
-    Map<String, String> params = new HashMap<>();
+    Map<String, Object> params = new HashMap<>();
     params.put("mentorName", "John Doe");
 
     Template template = createFeedbackTemplate();
@@ -124,7 +124,7 @@ class EmailTemplateServiceTest {
 
   @Test
   void invalidTemplateThrowsException() throws IOException {
-    Map<String, String> params = new HashMap<>();
+    Map<String, Object> params = new HashMap<>();
     params.put("mentorName", "John Doe");
 
     when(yamlObjectMapper.readValue(any(InputStream.class), any(TypeReference.class)))

--- a/src/test/java/com/wcc/platform/service/MenteeApplicationEnrichedTest.java
+++ b/src/test/java/com/wcc/platform/service/MenteeApplicationEnrichedTest.java
@@ -9,18 +9,21 @@ import com.wcc.platform.domain.platform.SocialNetworkType;
 import com.wcc.platform.domain.platform.mentorship.Mentee;
 import com.wcc.platform.domain.platform.mentorship.MenteeApplication;
 import com.wcc.platform.domain.platform.mentorship.MenteeApplicationResponse;
+import com.wcc.platform.repository.MemberRepository;
 import com.wcc.platform.repository.MenteeApplicationRepository;
 import com.wcc.platform.repository.MenteeRepository;
 import com.wcc.platform.repository.MentorRepository;
 import com.wcc.platform.repository.MentorshipCycleRepository;
 import com.wcc.platform.repository.MentorshipMatchRepository;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class MenteeApplicationEnrichedTest {
 
   private static final Long MENTEE_ID = 10L;
@@ -32,19 +35,10 @@ class MenteeApplicationEnrichedTest {
   @Mock private MentorshipCycleRepository cycleRepository;
   @Mock private MenteeRepository menteeRepository;
 
-  private MenteeWorkflowService service;
+  @Mock private MemberRepository memberRepository;
+  @Mock private MentorshipService mentorshipService;
 
-  @BeforeEach
-  void setUp() {
-    MockitoAnnotations.openMocks(this);
-    service =
-        new MenteeWorkflowService(
-            applicationRepository,
-            mentorRepository,
-            matchRepository,
-            cycleRepository,
-            menteeRepository);
-  }
+  @InjectMocks private MenteeWorkflowService service;
 
   @Test
   @DisplayName(

--- a/src/test/java/com/wcc/platform/service/MenteeWorkflowServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/MenteeWorkflowServiceTest.java
@@ -10,6 +10,7 @@ import static com.wcc.platform.utils.MenteeApplicationTestBuilder.reviewing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -23,6 +24,7 @@ import com.wcc.platform.domain.platform.mentorship.ApplicationStatus;
 import com.wcc.platform.domain.platform.mentorship.MenteeApplication;
 import com.wcc.platform.domain.platform.mentorship.Mentor;
 import com.wcc.platform.domain.platform.mentorship.MentorshipCycleEntity;
+import com.wcc.platform.repository.MemberRepository;
 import com.wcc.platform.repository.MenteeApplicationRepository;
 import com.wcc.platform.repository.MenteeRepository;
 import com.wcc.platform.repository.MentorRepository;
@@ -33,17 +35,19 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
+@ExtendWith(org.mockito.junit.jupiter.MockitoExtension.class)
 class MenteeWorkflowServiceTest {
 
   private static final String REJECTION_REASON =
       "Application does not meet the eligibility criteria for this mentorship cycle";
   private static final String DECLINE_REASON = "Not a fit";
   private static final String NO_MATCH_REASON = "No suitable mentor available";
-  private static final String ASSIGNMENT_NOTES = "Manual assignment by admin";
+  private static final String ASSIGNMENT_NOTES = "Manually assigned mentor";
   private static final Long MENTEE_ID = 10L;
   private static final Long MENTOR_ID = 20L;
   private static final Long CYCLE_ID = 5L;
@@ -54,18 +58,18 @@ class MenteeWorkflowServiceTest {
   @Mock private MentorshipCycleRepository cycleRepository;
   @Mock private MenteeRepository menteeRepository;
 
-  private MenteeWorkflowService service;
+  @Mock private MemberRepository memberRepository;
+  @Mock private MentorshipService mentorshipService;
+
+  @Mock private MentorshipNotificationService notificationService;
+
+  @InjectMocks private MenteeWorkflowService service;
 
   @BeforeEach
   void setUp() {
-    MockitoAnnotations.openMocks(this);
-    service =
-        new MenteeWorkflowService(
-            applicationRepository,
-            mentorRepository,
-            matchRepository,
-            cycleRepository,
-            menteeRepository);
+    lenient().when(mentorshipService.getNotificationService()).thenReturn(notificationService);
+    lenient().when(mentorshipService.getMentorRepository()).thenReturn(mentorRepository);
+    lenient().when(mentorshipService.getMemberRepository()).thenReturn(memberRepository);
   }
 
   @Test
@@ -338,7 +342,10 @@ class MenteeWorkflowServiceTest {
 
     assertThat(result.getStatus()).isEqualTo(ApplicationStatus.PENDING);
     verify(applicationRepository)
-        .updateStatus(99L, ApplicationStatus.REJECTED, "Manually assigned mentor");
+        .updateStatus(
+            99L,
+            ApplicationStatus.REJECTED,
+            "Manual assignment by admin [" + ASSIGNMENT_NOTES + "]");
 
     final ArgumentCaptor<MenteeApplication> captor =
         ArgumentCaptor.forClass(MenteeApplication.class);

--- a/src/test/java/com/wcc/platform/service/MentorshipNotificationServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/MentorshipNotificationServiceTest.java
@@ -1,8 +1,11 @@
 package com.wcc.platform.service;
 
 import static com.wcc.platform.factories.SetupMentorFactories.createMentorTest;
+import static com.wcc.platform.utils.MenteeApplicationTestBuilder.baseBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -11,10 +14,16 @@ import static org.mockito.Mockito.when;
 import com.wcc.platform.configuration.NotificationConfig;
 import com.wcc.platform.domain.email.EmailRequest;
 import com.wcc.platform.domain.exceptions.EmailSendException;
+import com.wcc.platform.domain.platform.mentorship.ApplicationStatus;
+import com.wcc.platform.domain.platform.mentorship.MatchStatus;
 import com.wcc.platform.domain.platform.mentorship.Mentor;
+import com.wcc.platform.domain.platform.mentorship.MentorshipMatch;
 import com.wcc.platform.domain.template.RenderedTemplate;
 import com.wcc.platform.domain.template.TemplateType;
+import com.wcc.platform.repository.MemberRepository;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,6 +37,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class MentorshipNotificationServiceTest {
 
   @Mock private EmailTemplateService emailTemplateService;
+  @Mock private MemberRepository memberRepository;
   @Mock private EmailService emailService;
   @Mock private NotificationConfig notificationConfig;
   private Mentor mentor;
@@ -58,8 +68,7 @@ class MentorshipNotificationServiceTest {
             + ".</p>";
     var rendered = new RenderedTemplate("Mentor Profile Approval Confirmation", expectedBody);
 
-    when(notificationConfig.getMentorProfileUrl())
-        .thenReturn("https://www.womencodingcommunity.com/mentors?keywords=Jane+Doe");
+    when(notificationConfig.getMentorProfileUrl()).thenReturn(mentorProfilePath);
 
     when(emailTemplateService.renderTemplate(eq(templateType), any(Map.class)))
         .thenReturn(rendered);
@@ -72,10 +81,10 @@ class MentorshipNotificationServiceTest {
     verify(emailService).sendEmail(emailCaptor.capture());
 
     var emailRequest = emailCaptor.getValue();
-    assertThat(emailRequest.getTo()).isEqualTo(recipient);
+    assertThat(emailRequest.getRecipients()).contains(recipient);
     assertThat(emailRequest.getSubject()).isEqualTo(rendered.subject());
     assertThat(emailRequest.getBody()).isEqualTo(rendered.body());
-    assertThat(emailRequest.isHtml()).isTrue();
+    assertThat(emailRequest.isHtml()).isFalse();
   }
 
   @Test
@@ -91,5 +100,50 @@ class MentorshipNotificationServiceTest {
     notificationService.sendMentorApprovalEmail(mentor);
 
     verify(emailService, never()).sendEmail(any());
+  }
+
+  @Test
+  @DisplayName(
+      "Given valid application update, when sendApplicationUpdate, then sends notification")
+  void shouldSendApplicationUpdateNotification() {
+    var application =
+        Optional.of(baseBuilder(1L, 10L, 20L, 5).status(ApplicationStatus.PENDING).build());
+    var updated = baseBuilder(1L, 10L, 20L, 5).status(ApplicationStatus.MENTOR_REVIEWING).build();
+
+    when(memberRepository.findEmails(anyList()))
+        .thenReturn(List.of("mentor@test.com", "mentee@test.com"));
+    when(notificationConfig.getMentorshipEmail()).thenReturn("team@test.com");
+    when(emailTemplateService.renderTemplate(any(), any()))
+        .thenReturn(new RenderedTemplate("Subject", "Body"));
+
+    notificationService.sendApplicationUpdate(application, updated);
+
+    verify(emailTemplateService).renderTemplate(eq(TemplateType.MENTEE_APPLICATIONS), anyMap());
+    verify(emailService).sendEmail(any());
+  }
+
+  @Test
+  @DisplayName("Given valid match update, when sendMatchUpdate, then sends notification")
+  void shouldSendMatchUpdateNotification() {
+    var match =
+        MentorshipMatch.builder()
+            .matchId(1L)
+            .mentorId(20L)
+            .menteeId(10L)
+            .cycleId(5L)
+            .status(MatchStatus.ACTIVE)
+            .startDate(java.time.LocalDate.now())
+            .build();
+
+    when(memberRepository.findEmails(anyList()))
+        .thenReturn(List.of("mentor@test.com", "mentee@test.com"));
+    when(notificationConfig.getMentorshipEmail()).thenReturn("team@test.com");
+    when(emailTemplateService.renderTemplate(any(), any()))
+        .thenReturn(new RenderedTemplate("Subject", "Body"));
+
+    notificationService.sendMatchUpdate(Optional.empty(), match);
+
+    verify(emailTemplateService).renderTemplate(eq(TemplateType.MATCH_APPLICATIONS), anyMap());
+    verify(emailService).sendEmail(any());
   }
 }

--- a/src/test/java/com/wcc/platform/service/MentorshipNotificationServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/MentorshipNotificationServiceTest.java
@@ -84,7 +84,7 @@ class MentorshipNotificationServiceTest {
     assertThat(emailRequest.getRecipients()).contains(recipient);
     assertThat(emailRequest.getSubject()).isEqualTo(rendered.subject());
     assertThat(emailRequest.getBody()).isEqualTo(rendered.body());
-    assertThat(emailRequest.isHtml()).isFalse();
+    assertThat(emailRequest.isHtml()).isTrue();
   }
 
   @Test

--- a/src/testInt/java/com/wcc/platform/controller/EmailTemplateControllerTest.java
+++ b/src/testInt/java/com/wcc/platform/controller/EmailTemplateControllerTest.java
@@ -32,7 +32,7 @@ class EmailTemplateControllerTest extends DefaultDatabaseSetup {
 
   @Test
   void previewValidRequestReturnsRenderedTemplate() {
-    var params =
+    Map<String, Object> params =
         Map.of(
             "mentorName", "Alice",
             "menteeName", "Bob",

--- a/src/testInt/java/com/wcc/platform/service/EmailTemplateServiceTest.java
+++ b/src/testInt/java/com/wcc/platform/service/EmailTemplateServiceTest.java
@@ -26,7 +26,7 @@ public class EmailTemplateServiceTest extends DefaultDatabaseSetup {
   @Test
   void rendersTemplateWithParams() {
     var templateType = TemplateType.FEEDBACK_MENTOR_ADHOC;
-    var parameters =
+    Map<String, Object> parameters =
         Map.of(
             "mentorName", "Alice Mentor",
             "menteeName", "Bob Mentee",


### PR DESCRIPTION
                                                                                                          
  Sends automated email notifications to both mentor and mentee (with a copy to the mentorship team) when a 
  mentee application status changes and when a mentorship match is created or updated. Two new YAML email   
  templates define the content for each scenario: `mentee_applications.yml` for application status updates  
  and `match_applications.yml` for match events.            

  The email sending path was refactored from single-recipient TO addressing to BCC multi-recipient so all   
  participants receive the same notification privately. `ConcurrentHashMap` was replaced with `HashMap` in
  template parameter merging to support null domain model fields that appear in notification payloads. The  
  member PUT endpoint regression from #643 was also resolved on this branch.

  ## Related Issue

  Closes #630

  ## Change Type

  - [x] Bug Fix
  - [x] New Feature
  - [x] Code Refactor
                                                                                                            
  ## Pull request checklist
                                                                                                            
  Please check if your PR fulfills the following requirements:

  - [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
  - [x] I have tested my changes locally.