### PR TITLE
fix: route mentorship notifications to team email

### DIFF
--- a/src/main/java/com/wcc/platform/configuration/NotificationConfig.java
+++ b/src/main/java/com/wcc/platform/configuration/NotificationConfig.java
@@ -1,9 +1,11 @@
 package com.wcc.platform.configuration;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * Configuration properties for notification-related settings.
@@ -12,10 +14,11 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @ConfigurationProperties(prefix = "notification")
+@Validated
 @Getter
 @Setter
 public class NotificationConfig {
-  private String mentorProfileUrl;
-  private String volunteerUrl;
-  private String mentorshipEmail;
+  @NotBlank private String mentorProfileUrl;
+  @NotBlank private String volunteerUrl;
+  @NotBlank private String mentorshipEmail;
 }

--- a/src/main/java/com/wcc/platform/service/MentorshipNotificationService.java
+++ b/src/main/java/com/wcc/platform/service/MentorshipNotificationService.java
@@ -136,7 +136,7 @@ public class MentorshipNotificationService {
    * @param templateType the type of template to render
    * @param templateParams the parameters to use for rendering the template
    */
-  /* default */ void sendNotificationByMemberId(
+  public void sendNotificationByMemberId(
       final TemplateType templateType,
       final Map<String, Object> templateParams,
       final List<Long> memberIds) {

--- a/src/main/java/com/wcc/platform/service/MentorshipNotificationService.java
+++ b/src/main/java/com/wcc/platform/service/MentorshipNotificationService.java
@@ -48,7 +48,7 @@ public class MentorshipNotificationService {
     sendNotification(
         TemplateType.MENTOR_APPROVED,
         Map.of("mentorName", mentor.getFullName(), "mentorProfileUrl", mentorBaseUrl),
-        List.of(mentor.getEmail()));
+        List.of(mentor.getEmail(), notificationConfig.getMentorshipEmail()));
   }
 
   /**
@@ -70,12 +70,10 @@ public class MentorshipNotificationService {
   }
 
   /** Sends a notification email to the mentor regarding mentee applications updates. */
+  @SuppressWarnings("PMD.UseConcurrentHashMap") // HashMap is used to support null values
   public void sendApplicationUpdate(
       final Optional<MenteeApplication> application, final MenteeApplication updated) {
 
-    @SuppressWarnings(
-        "PMD.UseConcurrentHashMap") // HashMap is used to support null values from domain model
-    // fields
     final Map<String, Object> params =
         new HashMap<>(
             Map.of(
@@ -97,12 +95,8 @@ public class MentorshipNotificationService {
     params.put("createdAt", updated.getCreatedAt());
     params.put("updatedAt", updated.getUpdatedAt());
 
-    final var memberIds = new ArrayList<Long>();
-    if (updated.getMentorId() != null) {
-      memberIds.add(updated.getMentorId());
-    }
-    memberIds.add(updated.getMenteeId());
-    sendNotificationByMemberId(TemplateType.MENTEE_APPLICATIONS, params, memberIds);
+    sendNotification(
+        TemplateType.MENTEE_APPLICATIONS, params, List.of(notificationConfig.getMentorshipEmail()));
   }
 
   /**
@@ -160,12 +154,10 @@ public class MentorshipNotificationService {
   }
 
   /** Sends a notification email to the mentor regarding mentee applications updates. */
+  @SuppressWarnings("PMD.UseConcurrentHashMap") // HashMap is used to support null values
   public void sendMatchUpdate(
       final Optional<MentorshipMatch> previous, final MentorshipMatch updated) {
 
-    @SuppressWarnings(
-        "PMD.UseConcurrentHashMap") // HashMap is used to support null values from domain model
-    // fields
     final Map<String, Object> params =
         new HashMap<>(
             Map.of(
@@ -189,7 +181,7 @@ public class MentorshipNotificationService {
     params.put("createdAt", updated.getCreatedAt());
     params.put("updatedAt", updated.getUpdatedAt());
 
-    final var memberIds = List.of(updated.getMentorId(), updated.getMenteeId());
-    sendNotificationByMemberId(TemplateType.MATCH_APPLICATIONS, params, memberIds);
+    sendNotification(
+        TemplateType.MATCH_APPLICATIONS, params, List.of(notificationConfig.getMentorshipEmail()));
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,9 +41,9 @@ mentorship:
     enabled: false
 
 notification:
+  mentorship-email: mentorship@womencodingcommunity.com
   mentor-profile-url: https://www.womencodingcommunity.com/mentors?keywords=
   volunteer-url: https://www.womencodingcommunity.com/volunteer
-  mentorship-email: mentorship@womencodingcommunity.com
 
 logging:
   level:

--- a/src/test/java/com/wcc/platform/service/MentorshipNotificationServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/MentorshipNotificationServiceTest.java
@@ -4,7 +4,6 @@ import static com.wcc.platform.factories.SetupMentorFactories.createMentorTest;
 import static com.wcc.platform.utils.MenteeApplicationTestBuilder.baseBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -69,6 +68,7 @@ class MentorshipNotificationServiceTest {
     var rendered = new RenderedTemplate("Mentor Profile Approval Confirmation", expectedBody);
 
     when(notificationConfig.getMentorProfileUrl()).thenReturn(mentorProfilePath);
+    when(notificationConfig.getMentorshipEmail()).thenReturn("team@test.com");
 
     when(emailTemplateService.renderTemplate(eq(templateType), any(Map.class)))
         .thenReturn(rendered);
@@ -94,6 +94,7 @@ class MentorshipNotificationServiceTest {
   void sendNotificationWhenRenderFailsThenDoesNotSendEmail() {
     when(notificationConfig.getMentorProfileUrl())
         .thenReturn("https://www.womencodingcommunity.com/mentors?keywords=Jane+Doe");
+    when(notificationConfig.getMentorshipEmail()).thenReturn("team@test.com");
     when(emailTemplateService.renderTemplate(any(), any()))
         .thenThrow(new EmailSendException("Template not found"));
 
@@ -110,8 +111,6 @@ class MentorshipNotificationServiceTest {
         Optional.of(baseBuilder(1L, 10L, 20L, 5).status(ApplicationStatus.PENDING).build());
     var updated = baseBuilder(1L, 10L, 20L, 5).status(ApplicationStatus.MENTOR_REVIEWING).build();
 
-    when(memberRepository.findEmails(anyList()))
-        .thenReturn(List.of("mentor@test.com", "mentee@test.com"));
     when(notificationConfig.getMentorshipEmail()).thenReturn("team@test.com");
     when(emailTemplateService.renderTemplate(any(), any()))
         .thenReturn(new RenderedTemplate("Subject", "Body"));
@@ -135,8 +134,6 @@ class MentorshipNotificationServiceTest {
             .startDate(java.time.LocalDate.now())
             .build();
 
-    when(memberRepository.findEmails(anyList()))
-        .thenReturn(List.of("mentor@test.com", "mentee@test.com"));
     when(notificationConfig.getMentorshipEmail()).thenReturn("team@test.com");
     when(emailTemplateService.renderTemplate(any(), any()))
         .thenReturn(new RenderedTemplate("Subject", "Body"));
@@ -145,5 +142,64 @@ class MentorshipNotificationServiceTest {
 
     verify(emailTemplateService).renderTemplate(eq(TemplateType.MATCH_APPLICATIONS), anyMap());
     verify(emailService).sendEmail(any());
+  }
+
+  @Test
+  @DisplayName("Given mentor and reason, when sendMentorRejectionEmail, then sends notification")
+  void shouldSendMentorRejectionEmail() {
+    var reason = "Incomplete profile";
+    when(notificationConfig.getVolunteerUrl()).thenReturn("https://test.com/volunteer");
+    when(emailTemplateService.renderTemplate(any(), any()))
+        .thenReturn(new RenderedTemplate("Subject", "Body"));
+
+    notificationService.sendMentorRejectionEmail(mentor, reason);
+
+    verify(emailTemplateService).renderTemplate(eq(TemplateType.MENTOR_PROFILE_REJECT), anyMap());
+    verify(emailService).sendEmail(any());
+  }
+
+  @Test
+  @DisplayName(
+      "Given member IDs, when sendNotificationByMemberId, then fetches emails and sends notification")
+  void shouldSendNotificationByMemberId() {
+    var memberIds = List.of(1L, 2L);
+    var emails = List.of("user1@test.com", "user2@test.com");
+    when(memberRepository.findEmails(memberIds)).thenReturn(emails);
+    when(notificationConfig.getMentorshipEmail()).thenReturn("team@test.com");
+    when(emailTemplateService.renderTemplate(any(), any()))
+        .thenReturn(new RenderedTemplate("Subject", "Body"));
+
+    notificationService.sendNotificationByMemberId(
+        TemplateType.MENTOR_APPROVED, Map.of(), memberIds);
+
+    verify(memberRepository).findEmails(memberIds);
+    ArgumentCaptor<EmailRequest> emailCaptor = ArgumentCaptor.forClass(EmailRequest.class);
+    verify(emailService).sendEmail(emailCaptor.capture());
+
+    var emailRequest = emailCaptor.getValue();
+    assertThat(emailRequest.getRecipients()).containsAll(emails);
+    assertThat(emailRequest.getRecipients()).contains("team@test.com");
+  }
+
+  @Test
+  @DisplayName(
+      "Given member IDs and no team email, when sendNotificationByMemberId, then sends only to members")
+  void shouldSendNotificationByMemberIdWithoutTeamEmail() {
+    var memberIds = List.of(1L);
+    var emails = List.of("user1@test.com");
+    when(memberRepository.findEmails(memberIds)).thenReturn(emails);
+    when(notificationConfig.getMentorshipEmail()).thenReturn("");
+    when(emailTemplateService.renderTemplate(any(), any()))
+        .thenReturn(new RenderedTemplate("Subject", "Body"));
+
+    notificationService.sendNotificationByMemberId(
+        TemplateType.MENTOR_APPROVED, Map.of(), memberIds);
+
+    ArgumentCaptor<EmailRequest> emailCaptor = ArgumentCaptor.forClass(EmailRequest.class);
+    verify(emailService).sendEmail(emailCaptor.capture());
+
+    var emailRequest = emailCaptor.getValue();
+    assertThat(emailRequest.getRecipients()).hasSize(1);
+    assertThat(emailRequest.getRecipients()).containsExactly("user1@test.com");
   }
 }


### PR DESCRIPTION
## Description

Send notifications directly the mentorship team instead of mentor and mentee involved. 

## Related Issue

https://github.com/Women-Coding-Community/wcc-backend/issues/630 

## Change Type

- [x] Bug Fix
