### PR TITLE
refactor: rename profile picture methods from Mentor to Member scope

### DIFF
--- a/src/main/java/com/wcc/platform/controller/ResourceController.java
+++ b/src/main/java/com/wcc/platform/controller/ResourceController.java
@@ -121,7 +121,7 @@ public class ResourceController {
       @Parameter(description = "Profile picture file") @RequestParam("file")
           final MultipartFile file) {
 
-    final var profilePicture = resourceService.uploadMentorProfilePicture(memberId, file);
+    final var profilePicture = resourceService.uploadMemberProfilePicture(memberId, file);
     return new ResponseEntity<>(profilePicture, HttpStatus.CREATED);
   }
 
@@ -129,7 +129,7 @@ public class ResourceController {
   @GetMapping("/member-profile-picture/{memberId}")
   @Operation(summary = "Get a member's profile picture")
   @ResponseStatus(HttpStatus.OK)
-  public ResponseEntity<MemberProfilePicture> getMentorProfilePicture(
+  public ResponseEntity<MemberProfilePicture> getMemberProfilePicture(
       @Parameter(description = "Id of the member") @PathVariable final Long memberId) {
 
     final var profilePicture = resourceService.getMemberProfilePicture(memberId);

--- a/src/main/java/com/wcc/platform/service/ResourceService.java
+++ b/src/main/java/com/wcc/platform/service/ResourceService.java
@@ -55,7 +55,7 @@ public class ResourceService {
 
   /** Uploads a mentor's profile picture. */
   @Transactional
-  public MemberProfilePicture uploadMentorProfilePicture(
+  public MemberProfilePicture uploadMemberProfilePicture(
       final Long memberId, final MultipartFile file) {
     memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException(memberId));
     return uploadProfile(memberId, file);

--- a/src/main/java/com/wcc/platform/service/ResourceService.java
+++ b/src/main/java/com/wcc/platform/service/ResourceService.java
@@ -53,7 +53,7 @@ public class ResourceService {
     deleteResourceBy(id);
   }
 
-  /** Uploads a mentor's profile picture. */
+  /** Uploads a member's profile picture. */
   @Transactional
   public MemberProfilePicture uploadMemberProfilePicture(
       final Long memberId, final MultipartFile file) {

--- a/src/test/java/com/wcc/platform/controller/ResourceControllerTest.java
+++ b/src/test/java/com/wcc/platform/controller/ResourceControllerTest.java
@@ -174,7 +174,7 @@ class ResourceControllerTest {
 
   @Test
   void uploadMemberProfilePictureShouldReturnCreatedProfilePicture() throws Exception {
-    when(resourceService.uploadMentorProfilePicture(eq(memberId), any(MultipartFile.class)))
+    when(resourceService.uploadMemberProfilePicture(eq(memberId), any(MultipartFile.class)))
         .thenReturn(profilePicture);
 
     mockMvc
@@ -190,7 +190,7 @@ class ResourceControllerTest {
   }
 
   @Test
-  void testGetMentorProfilePictureShouldReturnProfilePicture() throws Exception {
+  void testGetMemberProfilePictureShouldReturnProfilePicture() throws Exception {
     when(resourceService.getMemberProfilePicture(memberId)).thenReturn(profilePicture);
 
     mockMvc
@@ -237,8 +237,7 @@ class ResourceControllerTest {
   }
 
   @Test
-  @DisplayName(
-      "Given invalid URL, when saving external profile picture link, then returns 400")
+  @DisplayName("Given invalid URL, when saving external profile picture link, then returns 400")
   void shouldReturn400WhenExternalUrlIsInvalid() throws Exception {
     var request = new ExternalProfilePictureRequest(memberId, "not-a-valid-url");
 

--- a/src/test/java/com/wcc/platform/service/ResourceServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/ResourceServiceTest.java
@@ -195,7 +195,7 @@ class ResourceServiceTest {
     when(resourceRepository.create(any(Resource.class))).thenReturn(resource);
     when(repository.create(any(MemberProfilePicture.class))).thenReturn(profilePicture);
 
-    var result = resourceService.uploadMentorProfilePicture(memberId, multipartFile);
+    var result = resourceService.uploadMemberProfilePicture(memberId, multipartFile);
 
     assertNotNull(result);
     assertEquals(memberId, result.getMemberId());
@@ -350,7 +350,7 @@ class ResourceServiceTest {
   }
 
   @Test
-  void uploadMentorProfilePictureShouldReplaceExistingPicture() {
+  void uploadMemberProfilePictureShouldReplaceExistingPicture() {
     when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
     when(repository.findByMemberId(memberId)).thenReturn(Optional.of(profilePicture));
     when(resourceRepository.findById(resourceId)).thenReturn(Optional.of(resource));
@@ -362,7 +362,7 @@ class ResourceServiceTest {
     when(resourceRepository.create(any(Resource.class))).thenReturn(resource);
     when(repository.create(any(MemberProfilePicture.class))).thenReturn(profilePicture);
 
-    var result = resourceService.uploadMentorProfilePicture(memberId, multipartFile);
+    var result = resourceService.uploadMemberProfilePicture(memberId, multipartFile);
 
     assertNotNull(result);
     assertEquals(memberId, result.getMemberId());


### PR DESCRIPTION
## Description

the  profile picture functionality applies to all Members, not exclusively to those who are Mentors. The misleading "Mentor" prefix created confusion about the intended scope of the API and services                                                                                          
                  
- Renames both methods to use the correct `Member` terminology, aligning them with the existing endpoint path                
  (`/member-profile-picture`) and the `MemberProfilePicture` domain model. 

No behavior or API contract changes are included.

## Related

https://github.com/Women-Coding-Community/wcc-backend/pull/615

## Change Type

- [x] Code Refactor

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
