### PR TITLE
Fix mentor profile url link 

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,7 +42,7 @@ mentorship:
 
 notification:
   mentorship-email: mentorship@womencodingcommunity.com
-  mentor-profile-url: https://www.womencodingcommunity.com/mentors?keywords=
+  mentor-profile-url: https://mentorship.womencodingcommunity.com/mentorship/mentors?keyword=
   volunteer-url: https://www.womencodingcommunity.com/volunteer
 
 logging:


### PR DESCRIPTION
## Description

This fixes the email template with correct url for the mentor's profile.


## Related Issue

Closes [Issue](#662)

## Change Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Test
- [ ] Other

## Screenshots

Before 

<img width="676" height="261" alt="image" src="https://github.com/user-attachments/assets/5831ba65-056e-47a1-a550-104796187086" />

After
<img width="794" height="274" alt="image" src="https://github.com/user-attachments/assets/26b642fc-6197-46a4-9362-a9de1d586d36" />


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->