### PR TITLE
docs: update email templates (alerting long-term mentor of new applications + 

### DIFF
--- a/src/main/resources/email-templates/alert_new_mentees_applications_mentor_long.yml
+++ b/src/main/resources/email-templates/alert_new_mentees_applications_mentor_long.yml
@@ -1,32 +1,26 @@
 NEW_MENTEES_LONG:
-  subject: "[Action Required] New Mentee Applications for WCC Mentorship Programme"
+  subject: "[Action Required] Pending Mentee Application(s) for {{year}} WCC Mentorship Programme"
   body: |
     <p>Dear {{mentorName}},</p>
     <p>
-    Thank you for being part of the <strong>Women Coding Community</strong> <strong>{{year}}</strong>
-    Long-Term Mentorship Programme!
+    Thank you for being part of the <strong>Women Coding Community {{year}} Long-Term Mentorship Programme</strong>!
     </p>
 
     <p>
-    You’ve received new mentee applications. Please review the details in the spreadsheet below:
-    <a href="{{menteesSpreadsheetUrl}}">View mentee applications</a>
+    You have new mentee applications currently pending your review. 
+    Could you please log into your <a href="{{dashboardUrl}}"><strong>Mentor Dashboard</strong></a> today to check? 
     </p>
 
     <p>
-    Please take some time to review the profiles of these potential mentees.
-    If you are interested in mentoring any of the applicants, kindly reply to this email and let us know.
-    We will then connect you with them.
+    As an action point, please approve the mentee(s) you'd like to accept, or reject so that their application(s) can be forwarded to other mentors.
     </p>
 
     <p>
-    As the official kick-off for the mentorship programme is <strong>{{kickoffDate}}</strong>,
-    we kindly ask you to confirm your selected mentees by <strong>{{selectionDeadline}}</strong>
-    to ensure a smooth and timely pairing process.
+    If you do not see the application(s) or have any trouble accessing your account, please feel free to reply to this email.
     </p>
 
     <p>
-    If you have any questions or need further assistance, please don’t hesitate to reach out to us.
-    Your commitment to the mentorship programme is greatly appreciated, and we look forward to your continued support.
+    Thank you for your continued support of the mentorship programme, and we hope to get your response soon.
     </p>
 
     <p>

--- a/src/main/resources/email-templates/alert_new_mentees_applications_mentor_long.yml
+++ b/src/main/resources/email-templates/alert_new_mentees_applications_mentor_long.yml
@@ -8,7 +8,7 @@ NEW_MENTEES_LONG:
 
     <p>
     You have new mentee applications currently pending your review. 
-    Could you please log into your <a href="{{dashboardUrl}}"><strong>Mentor Dashboard</strong></a> today to check? 
+    Could you please log into your <a href="https://wcc-admin.vercel.app/"><strong>Mentor Dashboard</strong></a> today to check? 
     </p>
 
     <p>
@@ -16,7 +16,12 @@ NEW_MENTEES_LONG:
     </p>
 
     <p>
-    If you do not see the application(s) or have any trouble accessing your account, please feel free to reply to this email.
+    <strong>Please note:</strong> If you have not logged into the dashboard before, you should have received a password reset email from <strong>admin@womencodingcommunity.com</strong> prior to this email. 
+    If you cannot find it, please check your spam/junk folder first. If you still haven’t received it, please reply to this email and we’ll resend it for you.
+    </p>
+
+    <p>
+    If you do not see the application(s) or have any other trouble accessing your account, please feel free to reply to this email.
     </p>
 
     <p>

--- a/src/main/resources/email-templates/welcome_mentorship_mentee_mentor_long_term.yml
+++ b/src/main/resources/email-templates/welcome_mentorship_mentee_mentor_long_term.yml
@@ -1,59 +1,76 @@
 WELCOME_LONG:
-  subject: "You are paired up in WCC Mentorship Program {{year}}"
+  subject: "You are paired up in WCC Mentorship Programme {{year}}"
   body: |
     <p>Dear {{mentorName}} and {{menteeName}},</p>
 
-    <p>Welcome to the <strong>{{year}} Women Coding Community Mentorship Programme</strong>. we're delighted to have you both on board!</p>
+    <p>
+      Welcome to the Women Coding Community Mentorship Programme {{year}}. 
+      We're delighted to have you both on board!
+    </p>
 
-    <p>Mentorship is a powerful tool for personal and professional growth, and we hope this relationship is a meaningful opportunity for you to learn, grow, and achieve your goals.</p>
-    
-    <p><strong>Your Pairing</strong></p>
+    <p>
+      Mentorship is a powerful tool for personal and professional growth, and we hope this relationship 
+      is a meaningful opportunity for you to learn, grow, and achieve your goals.
+    </p>
+
+    <p><strong>Your Pairing:</strong></p>
 
     <ul>
       <li><strong>Mentor:</strong> {{mentorName}} (<a href="mailto:{{mentorEmail}}">{{mentorEmail}}</a>)</li>
       <li><strong>Mentee:</strong> {{menteeName}} (<a href="mailto:{{menteeEmail}}">{{menteeEmail}}</a>)</li>
+      <li><strong>Mentor's Scheduling Link:</strong> <a href="{{mentorSchedulingLink}}">{{mentorSchedulingLink}}</a></li>
       <li><strong>Google Meet Link:</strong> <a href="{{googleMeetLink}}">{{googleMeetLink}}</a></li>
     </ul>
 
     <p>
-    We've provided the Google Meet link above for your sessions (please ignore the corresponding calendar invite).
-    <strong>Note:</strong> You're welcome to use a personal meeting link or alternative communication method instead if you prefer. 
-    If you use the provided meeting link, you may choose whether to record, transcribe, or take notes during your calls. 
-    Please be aware that if you choose to record or keep notes, WCC will automatically receive a copy. 
-    This information is fully confidential and will not be shared with anyone.
-    </p>
-    
-    <p>
-    The programme will run from <strong>May to October</strong>.
-    The frequency and format of the meetings will be decided by you during your initial meeting.
-    We recommend at least <strong>two mentoring sessions per month</strong> (45 minutes to 1 hour each) to build a meaningful relationship.
+      We've provided the Google Meet link above for your sessions so you (please ignore the corresponding calendar invite). 
+      If you use the provided meeting link, you can choose whether to record, transcribe, or take notes during your calls. 
+      Please be aware that if you choose to record or keep notes, WCC will automatically receive a copy. This information 
+      is fully confidential and will not be shared with anyone. 
+      <strong>Note:</strong> You're welcome to use a personal meeting link or alternative communication method instead if you prefer.
     </p>
 
-    <p><strong>Getting Started</strong></p>
+    <p>
+      The programme will run from <strong>May to October</strong>. The frequency and format of the meetings will be decided by you 
+      during your initial meeting. We recommend at least <strong>two mentoring sessions per month</strong> (45 minutes to 1 hour each) 
+      to build a meaningful relationship.
+    </p>
+
+    <p><strong>Getting started:</strong></p>
+
     <ol>
       <li>
-        Schedule your initial meeting with your mentor. {{menteeName}}, please take the lead on booking this first session using the mentor’s scheduling link:
-        <a href="{{googleMeetLink}}">Schedule your first meeting</a>
-      </li>
+      Schedule your initial meeting with your mentor. {{menteeName}}, please take the lead on booking this first session 
+      using the mentor’s <a href="{{mentorSchedulingLink}}">scheduling link</a>.</li>
       <li>Define specific and measurable goals for the mentorship relationship.</li>
       <li>Develop an action plan to achieve those goals.</li>
       <li>Schedule regular check-ins to monitor progress and adjust the action plan as needed.</li>
     </ol>
-    <p>We also encourage you to stay in touch between sessions through your preferred channel (Slack or email) to get the most out of the programme.</p>
 
-    <p><strong>Resources</strong></p>
+    <p>
+      We also encourage you to stay in touch between sessions through your preferred channel (Slack or email) 
+      to get the most out of the programme.
+    </p>
+
+    <p><strong>Helpful Resources</strong></p>
     <p>To support you along the way:</p>
     <ul>
       <li>
         <a href="{{resourcesUrl}}">Mentorship Resources</a>
       </li>
       <li>
-        <a href="{{codeOfConductUrl}}">Code of Conduct</a>
+        <a href="{{codeOfConductUrl}}">Code of Conduct for Mentors and Mentees</a>
       </li>
     </ul>
+
+    <p>
+      We hope these resources help you make the most of this mentorship opportunity. If you have any questions 
+      or concerns, please don’t hesitate to reach out to us via email or the Slack channel <strong>#mentorship</strong>.
+    </p>
     
-    <p>We hope these resources help you make the most of this mentorship opportunity. If you have any questions or concerns, please don’t hesitate to reach out to us via email or the Slack channel <strong>#mentorship</strong>.</p>
-    <p>Wishing you a rewarding mentorship journey!</p>
+    <p>
+      Wishing you a rewarding mentorship journey!
+    </p>
     <p>
     {{teamEmailSignature}}
     </p>


### PR DESCRIPTION
## Description

- update existing email template to reuse for alerting long-term mentors that they have new mentee applications pending review (one of the templates that should be addressed with #649 )
- fix pairing email template (contents rendered from endpoint is different to current merge for some reason)

## Related Issue
[Request from mentorship team](https://docs.google.com/document/d/1EJrfPBAzZahlH5n4Gfz242E5OHZ2itL7/edit#heading=h.eyrf05dm48e6)
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Change Type

- [x] Email Templates

## Screenshots

<!--  Please include screenshots from the Swagger API. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [ ] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->