### PR TITLE
feat: add mentorship recommendation API with skill-based scoring + UI

### DIFF
--- a/admin-wcc-app/__tests__/services/mentorshipService.test.ts
+++ b/admin-wcc-app/__tests__/services/mentorshipService.test.ts
@@ -1,0 +1,59 @@
+import { createManualMatch, getMentorshipRecommendations } from '../../services/mentorshipService';
+import { apiFetch } from '../../lib/api';
+
+jest.mock('../../lib/api', () => ({
+  apiFetch: jest.fn(),
+}));
+
+describe('mentorshipService', () => {
+  const token = 'fake-token';
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getMentorshipRecommendations', () => {
+    it('should fetch mentorship recommendations for a program', async () => {
+      const mockResponse = {
+        matchedMentors: [],
+        notMatchedMentors: [],
+        notMatchedMentees: [],
+      };
+      (apiFetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await getMentorshipRecommendations(1, token);
+
+      expect(apiFetch).toHaveBeenCalledWith(
+        '/api/platform/v1/admin/mentorship/matches/recommendations/1',
+        { token }
+      );
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('createManualMatch', () => {
+    it('should send a POST request to assign a mentor to a mentee', async () => {
+      (apiFetch as jest.Mock).mockResolvedValue(undefined);
+
+      await createManualMatch(20, 5, 10, token);
+
+      expect(apiFetch).toHaveBeenCalledWith('/api/platform/v1/mentees/20/cycles/5/assign-mentor', {
+        method: 'POST',
+        body: { mentorId: 10, notes: undefined },
+        token,
+      });
+    });
+
+    it('should include notes in the request body when provided', async () => {
+      (apiFetch as jest.Mock).mockResolvedValue(undefined);
+
+      await createManualMatch(20, 5, 10, token, 'Good match for React skills');
+
+      expect(apiFetch).toHaveBeenCalledWith('/api/platform/v1/mentees/20/cycles/5/assign-mentor', {
+        method: 'POST',
+        body: { mentorId: 10, notes: 'Good match for React skills' },
+        token,
+      });
+    });
+  });
+});

--- a/admin-wcc-app/__tests__/services/mentorshipService.test.ts
+++ b/admin-wcc-app/__tests__/services/mentorshipService.test.ts
@@ -21,7 +21,7 @@ describe('mentorshipService', () => {
       };
       (apiFetch as jest.Mock).mockResolvedValue(mockResponse);
 
-      const result = await getMentorshipRecommendations(1, token);
+      const result = await getMentorshipRecommendations(1);
 
       expect(apiFetch).toHaveBeenCalledWith(
         '/api/platform/v1/admin/mentorship/matches/recommendations/1',

--- a/admin-wcc-app/__tests__/services/mentorshipService.test.ts
+++ b/admin-wcc-app/__tests__/services/mentorshipService.test.ts
@@ -21,7 +21,7 @@ describe('mentorshipService', () => {
       };
       (apiFetch as jest.Mock).mockResolvedValue(mockResponse);
 
-      const result = await getMentorshipRecommendations(1);
+      const result = await getMentorshipRecommendations(token);
 
       expect(apiFetch).toHaveBeenCalledWith(
         '/api/platform/v1/admin/mentorship/matches/recommendations/1',

--- a/admin-wcc-app/components/AdminLayout.tsx
+++ b/admin-wcc-app/components/AdminLayout.tsx
@@ -42,6 +42,11 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                 Mentees
               </Button>
             )}
+            {(isAdmin || isMentorshipAdmin) && (
+              <Button component={Link} href="/admin/mentorship" color="inherit">
+                Mentorship
+              </Button>
+            )}
             {(isAdmin || isLeader) && (
               <Button component={Link} href="/admin/users" color="inherit">
                 Users

--- a/admin-wcc-app/components/mentors/SkillsSection.tsx
+++ b/admin-wcc-app/components/mentors/SkillsSection.tsx
@@ -33,21 +33,6 @@ export default function SkillsSection({ skills }: SkillsSectionProps) {
           {skills.yearsExperience} years experience
         </Typography>
       )}
-      {skills.areas && skills.areas.length > 0 && (
-        <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-          {skills.areas.map((a) => (
-            <Chip
-              key={a.technicalArea}
-              label={
-                a.proficiencyLevel
-                  ? `${areaLabel(a.technicalArea)} · ${profLabel(a.proficiencyLevel)}`
-                  : areaLabel(a.technicalArea)
-              }
-              size="small"
-            />
-          ))}
-        </Box>
-      )}
       {skills.languages && skills.languages.length > 0 && (
         <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
           {skills.languages.map((l) => (
@@ -60,6 +45,21 @@ export default function SkillsSection({ skills }: SkillsSectionProps) {
               }
               size="small"
               color="secondary"
+            />
+          ))}
+        </Box>
+      )}
+      {skills.areas && skills.areas.length > 0 && (
+        <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+          {skills.areas.map((a) => (
+            <Chip
+              key={a.technicalArea}
+              label={
+                a.proficiencyLevel
+                  ? `${areaLabel(a.technicalArea)} · ${profLabel(a.proficiencyLevel)}`
+                  : areaLabel(a.technicalArea)
+              }
+              size="small"
             />
           ))}
         </Box>

--- a/admin-wcc-app/components/mentorship/MatchCard.tsx
+++ b/admin-wcc-app/components/mentorship/MatchCard.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Box, Button, Card, CardContent, Grid, Typography } from '@mui/material';
+import { MentorMatches } from '@/types/mentorship';
+import MentorInfoCard from './MentorInfoCard';
+import MenteeCard from './MenteeCard';
+
+interface MatchCardProps {
+  match: MentorMatches;
+}
+
+export default function MatchCard({ match }: MatchCardProps) {
+  return (
+    <Card sx={{ mb: 4, borderLeft: 6, borderColor: 'primary.main' }}>
+      <CardContent>
+        <Grid container spacing={4}>
+          <Grid item xs={12} md={5}>
+            <Typography variant="h6" gutterBottom color="primary">
+              Mentor #{match.mentor.id}
+            </Typography>
+            <MentorInfoCard mentor={match.mentor} />
+            <Box sx={{ mt: 2 }}>
+              <Typography variant="body2" color="text.secondary">
+                Review mentor profile and availability before matching.
+              </Typography>
+            </Box>
+          </Grid>
+
+          <Grid item xs={12} md={7}>
+            <Typography variant="h6" gutterBottom color="secondary">
+              Recommended {match.mentees.length || 0} mentees
+            </Typography>
+            {match.mentees.length > 0 ? (
+              match.mentees.map((suggestion) => (
+                <Box key={suggestion.mentee.id} sx={{ mb: 2 }}>
+                  <MenteeCard mentee={suggestion.mentee} score={suggestion.score} />
+
+                  <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: -1, mb: 1 }}>
+                    <Button size="small" variant="contained" color="primary">
+                      Match with {suggestion.mentee.fullName.split(' ')[0]}
+                    </Button>
+                  </Box>
+                </Box>
+              ))
+            ) : (
+              <Typography color="text.secondary">
+                No recommended mentees for this mentor.
+              </Typography>
+            )}
+          </Grid>
+        </Grid>
+      </CardContent>
+    </Card>
+  );
+}

--- a/admin-wcc-app/components/mentorship/MenteeCard.tsx
+++ b/admin-wcc-app/components/mentorship/MenteeCard.tsx
@@ -1,0 +1,165 @@
+import React, { useState } from 'react';
+import {
+  Avatar,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Collapse,
+  Divider,
+  Grid,
+  Grid2,
+  IconButton,
+  Link,
+  Stack,
+  Typography,
+} from '@mui/material';
+import {
+  Business as BusinessIcon,
+  ExpandLess as ExpandLessIcon,
+  ExpandMore as ExpandMoreIcon,
+  Language as LanguageIcon,
+  Public as PublicIcon,
+  Work as WorkIcon,
+} from '@mui/icons-material';
+import { MenteeItem } from '@/types/mentorship';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+
+interface MenteeCardProps {
+  mentee: MenteeItem;
+  score?: number;
+}
+
+export default function MenteeCard({ mentee, score }: MenteeCardProps) {
+  const [expanded, setExpand] = useState(false);
+
+  const location = [mentee.city, mentee.country?.countryName].filter(Boolean).join(', ');
+
+  return (
+    <Card variant="outlined" sx={{ mb: 2, position: 'relative' }}>
+      {score !== undefined && (
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 10,
+            right: 10,
+            bgcolor: 'primary.main',
+            color: 'white',
+            borderRadius: '50%',
+            width: 40,
+            height: 40,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontWeight: 'bold',
+            zIndex: 1,
+          }}
+        >
+          {score}
+        </Box>
+      )}
+      <CardContent>
+        <Stack direction="row" spacing={2}>
+          <Avatar
+            src={mentee.images?.[0]?.path}
+            alt={mentee.fullName}
+            sx={{ width: 56, height: 56 }}
+          >
+            {mentee.fullName.charAt(0)}
+          </Avatar>
+          <Box sx={{ flex: 1 }}>
+            <Typography variant="h6">{mentee.fullName}</Typography>
+            <Stack direction="row" spacing={1} alignItems="center" color="text.secondary">
+              <Typography variant="body2">Mentee Id: {mentee.id}</Typography>
+              {mentee.network && mentee.network.length > 0 && (
+                <Stack direction="row" spacing={2}>
+                  {mentee.network.map((n) => (
+                    <Link key={n.link} href={n.link} target="_blank" rel="noopener">
+                      <LinkedInIcon fontSize="small" sx={{ color: '#0077b5' }} />
+                    </Link>
+                  ))}
+                </Stack>
+              )}
+            </Stack>
+            <Stack direction="row" spacing={1} alignItems="center" color="text.secondary">
+              <WorkIcon fontSize="small" />
+              <Typography variant="body2">{mentee.position || 'N/A'}</Typography>
+            </Stack>
+            <Stack direction="row" spacing={1} alignItems="center" color="text.secondary">
+              <BusinessIcon fontSize="small" />
+              <Typography variant="body2">{mentee.companyName || 'N/A'}</Typography>
+            </Stack>
+            <Stack direction="row" spacing={1} alignItems="center" color="text.secondary">
+              <PublicIcon fontSize="small" />
+              <Typography variant="body2">{location || 'N/A'}</Typography>
+            </Stack>
+          </Box>
+          <IconButton onClick={() => setExpand(!expanded)}>
+            {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+          </IconButton>
+        </Stack>
+
+        <Collapse in={expanded} timeout="auto" unmountOnExit>
+          <Box sx={{ mt: 2 }}>
+            <Divider sx={{ mb: 2 }} />
+
+            <Typography variant="subtitle2" gutterBottom>
+              Bio
+            </Typography>
+            <Typography variant="body2" color="text.secondary" paragraph>
+              {mentee.bio || 'No bio provided.'}
+            </Typography>
+
+            <Grid2 container spacing={2}>
+              <Grid item xs={12} md={6}>
+                <Typography variant="subtitle2" gutterBottom>
+                  Skills & Proficiency
+                </Typography>
+                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                  {mentee.skills?.areas?.map((a) => (
+                    <Chip
+                      key={a.technicalArea}
+                      label={`${a.technicalArea.replace(/_/g, ' ')} (${a.proficiencyLevel})`}
+                      size="small"
+                    />
+                  ))}
+                </Stack>
+              </Grid>
+
+              <Box sx={{ mt: 1 }}>
+                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                  {mentee.skills?.mentorshipFocus?.map((f) => (
+                    <Chip
+                      key={f}
+                      label={f.replace(/_/g, ' ')}
+                      size="small"
+                      color="info"
+                      variant="outlined"
+                    />
+                  ))}
+                </Stack>
+              </Box>
+
+              <Grid item xs={12} md={6}>
+                <Typography variant="subtitle2" gutterBottom>
+                  Languages
+                </Typography>
+                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                  {mentee.spokenLanguages?.map((l) => (
+                    <Chip key={l} label={l} size="small" icon={<LanguageIcon />} />
+                  ))}
+                </Stack>
+              </Grid>
+
+              <Box sx={{ mt: 2 }}>
+                <Typography variant="body2">
+                  <strong>Available hours/month:</strong> {mentee.availableHsMonth || 'N/A'}
+                </Typography>
+              </Box>
+            </Grid2>
+          </Box>
+        </Collapse>
+      </CardContent>
+    </Card>
+  );
+}

--- a/admin-wcc-app/components/mentorship/MentorInfoCard.tsx
+++ b/admin-wcc-app/components/mentorship/MentorInfoCard.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Avatar, Box, Card, CardContent, Stack, Typography } from '@mui/material';
+import {
+  Business as BusinessIcon,
+  Public as PublicIcon,
+  Work as WorkIcon,
+} from '@mui/icons-material';
+import { MentorItem } from '@/types/mentor';
+import SkillsSection from '@/components/mentors/SkillsSection';
+import BioSection from '@/components/mentors/BioSection';
+
+interface MentorInfoCardProps {
+  mentor: MentorItem;
+}
+
+export default function MentorInfoCard({ mentor }: MentorInfoCardProps) {
+  const location = [mentor.city, mentor.country?.countryName].filter(Boolean).join(', ');
+
+  return (
+    <Card variant="outlined" sx={{ mb: 2, bgcolor: 'grey.50' }}>
+      <CardContent>
+        <Stack direction="row" spacing={2}>
+          <Avatar
+            src={
+              typeof mentor.images?.[0] === 'string'
+                ? mentor.images[0]
+                : (mentor.images?.[0] as any)?.path
+            }
+            alt={mentor.fullName}
+            sx={{ width: 64, height: 64 }}
+          >
+            {mentor.fullName.charAt(0)}
+          </Avatar>
+          <Box sx={{ flex: 1 }}>
+            <Typography variant="h6">{mentor.fullName}</Typography>
+            <Stack direction="row" spacing={1} alignItems="center" color="text.secondary">
+              <WorkIcon fontSize="small" />
+              <Typography variant="body2">{mentor.position || 'N/A'}</Typography>
+            </Stack>
+            <Stack direction="row" spacing={1} alignItems="center" color="text.secondary">
+              <BusinessIcon fontSize="small" />
+              <Typography variant="body2">{mentor.companyName || 'N/A'}</Typography>
+            </Stack>
+            <Stack direction="row" spacing={1} alignItems="center" color="text.secondary">
+              <PublicIcon fontSize="small" />
+              <Typography variant="body2">{location || 'N/A'}</Typography>
+            </Stack>
+          </Box>
+        </Stack>
+
+        <Box sx={{ mt: 1 }}>{mentor.bio && <BioSection bio={mentor.bio} />}</Box>
+        <Box sx={{ mt: 1 }}>{mentor.skills && <SkillsSection skills={mentor.skills} />}</Box>
+        <Box sx={{ mt: 2 }}>
+          <Stack direction="row" spacing={2}>
+            <Typography variant="body2">
+              <strong>Availability Long Term: </strong>
+              {mentor.menteeSection?.longTerm?.numMentee || 0} mentees,{' '}
+              {mentor.menteeSection?.longTerm?.hours || 0} hours
+            </Typography>
+          </Stack>
+        </Box>
+        <Box sx={{ mt: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            Ideal Mentee
+          </Typography>
+          <Stack direction="row" spacing={2}>
+            <Typography variant="body2">{mentor.menteeSection?.idealMentee}</Typography>
+          </Stack>
+        </Box>
+        <Box sx={{ mt: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            Additional
+          </Typography>
+          <Stack direction="row" spacing={2}>
+            <Typography variant="body2">{mentor.menteeSection?.additional}</Typography>
+          </Stack>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}

--- a/admin-wcc-app/pages/admin/mentorship/index.tsx
+++ b/admin-wcc-app/pages/admin/mentorship/index.tsx
@@ -1,0 +1,152 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  Container,
+  Paper,
+  Tab,
+  Tabs,
+  Typography,
+} from '@mui/material';
+import AdminLayout from '@/components/AdminLayout';
+import { getMentorshipRecommendations } from '@/services/mentorshipService';
+import { MentorshipRecommendationResponse } from '@/types/mentorship';
+import { getStoredToken, isTokenExpired } from '@/lib/auth';
+import { useRouter } from 'next/router';
+import MatchCard from '@/components/mentorship/MatchCard';
+import MenteeCard from '@/components/mentorship/MenteeCard';
+import MentorInfoCard from '@/components/mentorship/MentorInfoCard';
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function CustomTabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box sx={{ py: 3 }}>{children}</Box>}
+    </div>
+  );
+}
+
+export default function MentorshipAdminPage() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<MentorshipRecommendationResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [tabValue, setTabValue] = useState(0);
+
+  useEffect(() => {
+    const token = getStoredToken();
+    if (!token || isTokenExpired(token)) {
+      router.replace('/login');
+      return;
+    }
+
+    getMentorshipRecommendations(token)
+      .then((res) => {
+        setData(respToRecommendationResponse(res));
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err.message || 'Failed to fetch recommendations');
+        setLoading(false);
+      });
+  }, [router]);
+
+  const respToRecommendationResponse = (resp: any): MentorshipRecommendationResponse => {
+    return {
+      matchedMentors: resp.matchedMentors || [],
+      notMatchedMentors: resp.notMatchedMentors || [],
+      notMatchedMentees: resp.notMatchedMentees || [],
+    };
+  };
+
+  const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
+    setTabValue(newValue);
+  };
+
+  if (loading) {
+    return (
+      <AdminLayout>
+        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8 }}>
+          <CircularProgress />
+        </Box>
+      </AdminLayout>
+    );
+  }
+
+  return (
+    <AdminLayout>
+      <Container maxWidth="xl">
+        <Typography variant="h4" gutterBottom sx={{ mt: 2, mb: 4 }}>
+          Mentorship - Manual Matching
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 4 }}>
+            {error}
+          </Alert>
+        )}
+
+        <Paper sx={{ width: '100%', mb: 4 }}>
+          <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+            <Tabs value={tabValue} onChange={handleTabChange} aria-label="mentorship tabs">
+              <Tab label={`Recommendations (${data?.matchedMentors.length || 0})`} />
+              <Tab label={`Unmatched Mentors (${data?.notMatchedMentors.length || 0})`} />
+              <Tab label={`Unmatched Mentees (${data?.notMatchedMentees.length || 0})`} />
+            </Tabs>
+          </Box>
+
+          <CustomTabPanel value={tabValue} index={0}>
+            {data?.matchedMentors.map((match, idx) => (
+              <MatchCard key={match.mentor.id || idx} match={match} />
+            ))}
+            {data?.matchedMentors.length === 0 && (
+              <Typography color="text.secondary" align="center">
+                No matches found.
+              </Typography>
+            )}
+          </CustomTabPanel>
+
+          <CustomTabPanel value={tabValue} index={1}>
+            <Box sx={{ maxWidth: 800, mx: 'auto' }}>
+              {data?.notMatchedMentors.map((mentor) => (
+                <MentorInfoCard key={mentor.id} mentor={mentor} />
+              ))}
+              {data?.notMatchedMentors.length === 0 && (
+                <Typography color="text.secondary" align="center">
+                  All mentors have recommendations.
+                </Typography>
+              )}
+            </Box>
+          </CustomTabPanel>
+
+          <CustomTabPanel value={tabValue} index={2}>
+            <Box sx={{ maxWidth: 800, mx: 'auto' }}>
+              {data?.notMatchedMentees.map((mentee) => (
+                <MenteeCard key={mentee.id} mentee={mentee} />
+              ))}
+              {data?.notMatchedMentees.length === 0 && (
+                <Typography color="text.secondary" align="center">
+                  All mentees have recommendations.
+                </Typography>
+              )}
+            </Box>
+          </CustomTabPanel>
+        </Paper>
+      </Container>
+    </AdminLayout>
+  );
+}

--- a/admin-wcc-app/services/mentorshipService.ts
+++ b/admin-wcc-app/services/mentorshipService.ts
@@ -1,0 +1,30 @@
+import { apiFetch } from '@/lib/api';
+import { MentorshipRecommendationResponse } from '@/types/mentorship';
+
+const MENTORSHIP_ADMIN_PATH = '/api/platform/v1/admin/mentorship';
+const MENTEES_PATH = '/api/platform/v1/mentees';
+
+export async function getMentorshipRecommendations(
+  token: string
+): Promise<MentorshipRecommendationResponse> {
+  const CYCLE_ID = 1; // TODO - Change to pickup the current cycle
+
+  return apiFetch<MentorshipRecommendationResponse>(
+    `${MENTORSHIP_ADMIN_PATH}/matches/recommendations/${CYCLE_ID}`,
+    { token }
+  );
+}
+
+export async function createManualMatch(
+  menteeId: number | string,
+  cycleId: number | string,
+  mentorId: number | string,
+  token: string,
+  notes?: string
+): Promise<void> {
+  return apiFetch<void>(`${MENTEES_PATH}/${menteeId}/cycles/${cycleId}/assign-mentor`, {
+    method: 'POST',
+    body: { mentorId, notes },
+    token,
+  });
+}

--- a/admin-wcc-app/types/mentorship.ts
+++ b/admin-wcc-app/types/mentorship.ts
@@ -1,0 +1,58 @@
+import { MentorItem } from './mentor';
+
+export interface MenteeItem {
+  id: number;
+  fullName: string;
+  position?: string;
+  email?: string;
+  slackDisplayName?: string;
+  country?: {
+    countryCode: string;
+    countryName: string;
+  };
+  city?: string;
+  companyName?: string;
+  memberTypes?: string[];
+  images?: {
+    path: string;
+    alt: string;
+    type: string;
+  }[];
+  network?: {
+    type: string;
+    link: string;
+  }[];
+  isWomen?: boolean;
+  profileStatus?: string;
+  skills?: {
+    yearsExperience?: number;
+    areas?: {
+      technicalArea: string;
+      proficiencyLevel: string;
+    }[];
+    languages?: {
+      language: string;
+      proficiencyLevel: string;
+    }[];
+    mentorshipFocus?: string[];
+  };
+  bio?: string;
+  spokenLanguages?: string[];
+  availableHsMonth?: number;
+}
+
+export interface MenteeMatchSuggestion {
+  mentee: MenteeItem;
+  score: number;
+}
+
+export interface MentorMatches {
+  mentor: MentorItem;
+  mentees: MenteeMatchSuggestion[];
+}
+
+export interface MentorshipRecommendationResponse {
+  matchedMentors: MentorMatches[];
+  notMatchedMentors: MentorItem[];
+  notMatchedMentees: MenteeItem[];
+}

--- a/src/main/java/com/wcc/platform/configuration/security/RequiresRole.java
+++ b/src/main/java/com/wcc/platform/configuration/security/RequiresRole.java
@@ -6,10 +6,16 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/** Annotation to enforce role-based access control on methods or classes. */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 public @interface RequiresRole {
+
+  /** The roles required to access the annotated method or class. */
   RoleType[] value();
 
+  /**
+   * Defines the logical operator to apply when multiple roles are specified. By default, it uses OR
+   */
   LogicalOperator operator() default LogicalOperator.OR;
 }

--- a/src/main/java/com/wcc/platform/controller/MentorshipAdminMatchesController.java
+++ b/src/main/java/com/wcc/platform/controller/MentorshipAdminMatchesController.java
@@ -7,10 +7,11 @@ import com.wcc.platform.domain.platform.mentorship.CycleStatus;
 import com.wcc.platform.domain.platform.mentorship.MatchCancelRequest;
 import com.wcc.platform.domain.platform.mentorship.MentorshipCycleEntity;
 import com.wcc.platform.domain.platform.mentorship.MentorshipMatch;
+import com.wcc.platform.domain.platform.mentorship.recommendation.MentorshipRecommendationResponse;
 import com.wcc.platform.domain.platform.type.RoleType;
 import com.wcc.platform.repository.MentorshipCycleRepository;
-import com.wcc.platform.service.MenteeService;
 import com.wcc.platform.service.MentorshipMatchingService;
+import com.wcc.platform.service.MentorshipRecommendationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -27,7 +28,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -43,9 +43,23 @@ public class MentorshipAdminMatchesController {
 
   private final MentorshipMatchingService matchingService;
   private final MentorshipCycleRepository cycleRepository;
-  private final MenteeService menteeService;
+  private final MentorshipRecommendationService recommendationService;
 
   // ==================== Match Management ====================
+
+  /**
+   * API to get suggested mentee matches for unmatched mentors.
+   *
+   * @return Recommended matches
+   */
+  @GetMapping("/matches/recommendations/{cycleId}")
+  //  @RequiresRole({RoleType.ADMIN})
+  @Operation(summary = "Get suggested mentee matches for unmatched mentors")
+  public ResponseEntity<MentorshipRecommendationResponse> getMatchRecommendations(
+      @Parameter(description = "Cycle ID") @PathVariable final Long cycleId) {
+    final var recommendations = recommendationService.getRecommendations(cycleId);
+    return ResponseEntity.ok(recommendations);
+  }
 
   /**
    * API for admin to confirm a match from an accepted application. This creates the official
@@ -57,7 +71,6 @@ public class MentorshipAdminMatchesController {
   @PostMapping("/matches/confirm/{applicationId}")
   @RequiresPermission(Permission.MATCH_MANAGE)
   @Operation(summary = "Admin confirms a mentorship match from accepted application")
-  @ResponseStatus(HttpStatus.CREATED)
   public ResponseEntity<MentorshipMatch> confirmMatch(
       @Parameter(description = "Application ID to confirm as match") @PathVariable
           final Long applicationId) {
@@ -74,7 +87,6 @@ public class MentorshipAdminMatchesController {
   @GetMapping("/matches")
   @RequiresPermission(Permission.MATCH_MANAGE)
   @Operation(summary = "Get all matches for a cycle")
-  @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<List<MentorshipMatch>> getCycleMatches(
       @Parameter(description = "Cycle ID") @RequestParam final Long cycleId) {
     final List<MentorshipMatch> matches = matchingService.getCycleMatches(cycleId);
@@ -91,7 +103,6 @@ public class MentorshipAdminMatchesController {
   @PatchMapping("/matches/{matchId}/complete")
   @RequiresPermission(Permission.MATCH_MANAGE)
   @Operation(summary = "Complete a mentorship match")
-  @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<MentorshipMatch> completeMatch(
       @Parameter(description = "Match ID") @PathVariable final Long matchId,
       @Parameter(description = "Completion notes") @RequestParam(required = false)
@@ -110,7 +121,6 @@ public class MentorshipAdminMatchesController {
   @PatchMapping("/matches/{matchId}/cancel")
   @RequiresPermission(Permission.MATCH_MANAGE)
   @Operation(summary = "Cancel a mentorship match")
-  @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<MentorshipMatch> cancelMatch(
       @Parameter(description = "Match ID") @PathVariable final Long matchId,
       @Valid @RequestBody final MatchCancelRequest request) {
@@ -128,7 +138,6 @@ public class MentorshipAdminMatchesController {
   @PatchMapping("/matches/{matchId}/increment-session")
   @RequiresPermission(Permission.MATCH_MANAGE)
   @Operation(summary = "Increment session count for a match")
-  @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<MentorshipMatch> incrementSessionCount(
       @Parameter(description = "Match ID") @PathVariable final Long matchId) {
     final MentorshipMatch updated = matchingService.incrementSessionCount(matchId);
@@ -145,7 +154,6 @@ public class MentorshipAdminMatchesController {
   @GetMapping("/cycles/current")
   @RequiresRole({RoleType.ADMIN, RoleType.MENTORSHIP_ADMIN})
   @Operation(summary = "Get the currently open mentorship cycle")
-  @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<MentorshipCycleEntity> getCurrentCycle() {
     return cycleRepository
         .findOpenCycle()
@@ -162,7 +170,6 @@ public class MentorshipAdminMatchesController {
   @GetMapping("/cycles")
   @RequiresRole({RoleType.ADMIN, RoleType.MENTORSHIP_ADMIN})
   @Operation(summary = "Get cycles by status")
-  @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<List<MentorshipCycleEntity>> getCyclesByStatus(
       @Parameter(description = "Cycle status") @RequestParam final CycleStatus status) {
     final List<MentorshipCycleEntity> cycles = cycleRepository.findByStatus(status);
@@ -178,7 +185,6 @@ public class MentorshipAdminMatchesController {
   @GetMapping("/cycles/{cycleId}")
   @RequiresRole({RoleType.ADMIN, RoleType.MENTORSHIP_ADMIN})
   @Operation(summary = "Get a cycle by ID")
-  @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<MentorshipCycleEntity> getCycleById(
       @Parameter(description = "Cycle ID") @PathVariable final Long cycleId) {
     return cycleRepository
@@ -195,7 +201,6 @@ public class MentorshipAdminMatchesController {
   @GetMapping("/cycles/all")
   @RequiresRole({RoleType.ADMIN, RoleType.MENTORSHIP_ADMIN})
   @Operation(summary = "Get all mentorship cycles")
-  @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<List<MentorshipCycleEntity>> getAllCycles() {
     final List<MentorshipCycleEntity> cycles = cycleRepository.getAll();
     return ResponseEntity.ok(cycles);

--- a/src/main/java/com/wcc/platform/controller/MentorshipAdminMatchesController.java
+++ b/src/main/java/com/wcc/platform/controller/MentorshipAdminMatchesController.java
@@ -53,7 +53,7 @@ public class MentorshipAdminMatchesController {
    * @return Recommended matches
    */
   @GetMapping("/matches/recommendations/{cycleId}")
-  //  @RequiresRole({RoleType.ADMIN})
+  @RequiresPermission(Permission.MATCH_MANAGE)
   @Operation(summary = "Get suggested mentee matches for unmatched mentors")
   public ResponseEntity<MentorshipRecommendationResponse> getMatchRecommendations(
       @Parameter(description = "Cycle ID") @PathVariable final Long cycleId) {

--- a/src/main/java/com/wcc/platform/domain/platform/mentorship/Mentee.java
+++ b/src/main/java/com/wcc/platform/domain/platform/mentorship/Mentee.java
@@ -19,6 +19,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 
+/** Represents a mentee in the platform. */
 @Getter
 @NoArgsConstructor
 @ToString(callSuper = true)
@@ -34,6 +35,7 @@ public class Mentee extends Member {
   @Min(1)
   private Integer availableHsMonth;
 
+  /** Mentee Builder. */
   @Builder(builderMethodName = "menteeBuilder")
   public Mentee(
       final Long id,

--- a/src/main/java/com/wcc/platform/domain/platform/mentorship/recommendation/MenteeMatchSuggestion.java
+++ b/src/main/java/com/wcc/platform/domain/platform/mentorship/recommendation/MenteeMatchSuggestion.java
@@ -1,0 +1,11 @@
+package com.wcc.platform.domain.platform.mentorship.recommendation;
+
+import com.wcc.platform.domain.platform.mentorship.Mentee;
+
+/**
+ * DTO for a suggested mentee and their match score.
+ *
+ * @param mentee the mentee object
+ * @param score the match score
+ */
+public record MenteeMatchSuggestion(Mentee mentee, int score) {}

--- a/src/main/java/com/wcc/platform/domain/platform/mentorship/recommendation/MentorMatchSuggestion.java
+++ b/src/main/java/com/wcc/platform/domain/platform/mentorship/recommendation/MentorMatchSuggestion.java
@@ -1,0 +1,12 @@
+package com.wcc.platform.domain.platform.mentorship.recommendation;
+
+import com.wcc.platform.domain.platform.mentorship.Mentor;
+import java.util.List;
+
+/**
+ * DTO for a mentor and their suggested mentee matches with scores.
+ *
+ * @param mentor the mentor object
+ * @param mentees list of suggested mentee matches with scores
+ */
+public record MentorMatchSuggestion(Mentor mentor, List<MenteeMatchSuggestion> mentees) {}

--- a/src/main/java/com/wcc/platform/domain/platform/mentorship/recommendation/MentorshipRecommendationResponse.java
+++ b/src/main/java/com/wcc/platform/domain/platform/mentorship/recommendation/MentorshipRecommendationResponse.java
@@ -1,0 +1,17 @@
+package com.wcc.platform.domain.platform.mentorship.recommendation;
+
+import com.wcc.platform.domain.platform.mentorship.Mentee;
+import com.wcc.platform.domain.platform.mentorship.Mentor;
+import java.util.List;
+
+/**
+ * DTO for recommended matches response.
+ *
+ * @param matchedMentors list of mentors with their suggested mentee matches
+ * @param notMatchedMentors list of mentors who have no suggested matches
+ * @param notMatchedMentees list of mentees who are not suggested for any mentor
+ */
+public record MentorshipRecommendationResponse(
+    List<MentorMatchSuggestion> matchedMentors,
+    List<Mentor> notMatchedMentors,
+    List<Mentee> notMatchedMentees) {}

--- a/src/main/java/com/wcc/platform/repository/MentorRepository.java
+++ b/src/main/java/com/wcc/platform/repository/MentorRepository.java
@@ -36,6 +36,14 @@ public interface MentorRepository extends CrudRepository<Mentor, Long> {
   Mentor updateProfileStatus(Long mentorId, ProfileStatus profileStatus);
 
   /**
+   * Return all mentors with a specific profile status.
+   *
+   * @param status profile status
+   * @return list of mentors
+   */
+  List<Mentor> findAvailableMentors(ProfileStatus status);
+
+  /**
    * Reject a mentor by setting their profile status to REJECTED and recording the reason.
    *
    * @param mentorId the mentor's unique identifier

--- a/src/main/java/com/wcc/platform/repository/postgres/mentorship/PostgresMentorRepository.java
+++ b/src/main/java/com/wcc/platform/repository/postgres/mentorship/PostgresMentorRepository.java
@@ -59,6 +59,7 @@ public class PostgresMentorRepository implements MentorRepository {
       "SELECT mentors.* FROM mentors LEFT JOIN members ON mentors.mentor_id = members.id "
           + "WHERE members.email = ?";
   private static final String SQL_GET_ALL = "SELECT * FROM mentors";
+  private static final String SQL_GET_BY_STATUS = "SELECT * FROM mentors WHERE profile_status = ?";
   private static final String SQL_FIND_ID_BY_EMAIL =
       "SELECT mentors.mentor_id FROM mentors LEFT JOIN members ON mentors.mentor_id = members.id"
           + " WHERE members.email = ?";
@@ -98,6 +99,12 @@ public class PostgresMentorRepository implements MentorRepository {
           return null;
         },
         email);
+  }
+
+  @Override
+  public List<Mentor> findAvailableMentors(final ProfileStatus status) {
+    return jdbc.query(
+        SQL_GET_BY_STATUS, (rs, rowNum) -> mentorMapper.mapRowToMentor(rs), status.getStatusId());
   }
 
   @Override

--- a/src/main/java/com/wcc/platform/service/MentorshipRecommendationService.java
+++ b/src/main/java/com/wcc/platform/service/MentorshipRecommendationService.java
@@ -1,0 +1,160 @@
+package com.wcc.platform.service;
+
+import com.wcc.platform.domain.cms.attributes.MentorshipFocusArea;
+import com.wcc.platform.domain.cms.attributes.TechnicalArea;
+import com.wcc.platform.domain.platform.member.ProfileStatus;
+import com.wcc.platform.domain.platform.mentorship.LanguageProficiency;
+import com.wcc.platform.domain.platform.mentorship.Mentee;
+import com.wcc.platform.domain.platform.mentorship.Mentor;
+import com.wcc.platform.domain.platform.mentorship.MentorshipCycleEntity;
+import com.wcc.platform.domain.platform.mentorship.TechnicalAreaProficiency;
+import com.wcc.platform.domain.platform.mentorship.recommendation.MenteeMatchSuggestion;
+import com.wcc.platform.domain.platform.mentorship.recommendation.MentorMatchSuggestion;
+import com.wcc.platform.domain.platform.mentorship.recommendation.MentorshipRecommendationResponse;
+import com.wcc.platform.repository.MenteeRepository;
+import com.wcc.platform.repository.MentorRepository;
+import com.wcc.platform.repository.MentorshipCycleRepository;
+import com.wcc.platform.repository.MentorshipMatchRepository;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/** Service for generating mentorship recommendations based on mentor and mentee criteria. */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MentorshipRecommendationService {
+
+  private static final int LANGUAGE_SCORE = 50;
+  private static final int AREA_SCORE = 30;
+  private static final int FOCUS_SCORE = 10;
+
+  private final MentorRepository mentorRepository;
+  private final MenteeRepository menteeRepository;
+  private final MentorshipMatchRepository matchRepository;
+  private final MentorshipCycleRepository cycleRepository;
+
+  /**
+   * Get suggested mentee matches for each mentor who has availability.
+   *
+   * @param cycleId the ID of the mentorship cycle
+   * @return recommendation response
+   */
+  public MentorshipRecommendationResponse getRecommendations(final Long cycleId) {
+    final MentorshipCycleEntity cycle = cycleRepository.findById(cycleId).orElse(null);
+    if (cycle == null) {
+      log.warn("No open mentorship cycle found for recommendations");
+      return new MentorshipRecommendationResponse(List.of(), List.of(), List.of());
+    }
+
+    final var availableMentors =
+        mentorRepository.findAvailableMentors(ProfileStatus.ACTIVE).stream()
+            .filter(m -> m.getMenteeSection().longTerm() != null)
+            .filter(
+                m -> {
+                  final int currentMentees =
+                      matchRepository.countActiveMenteesByMentorAndCycle(m.getId(), cycleId);
+                  return currentMentees < m.getMenteeSection().longTerm().numMentee();
+                })
+            .toList();
+
+    final var unmatchedMentees =
+        menteeRepository.findByStatus(ProfileStatus.ACTIVE).stream()
+            .filter(m -> !matchRepository.isMenteeMatchedInCycle(m.getId(), cycleId))
+            .toList();
+
+    final List<MentorMatchSuggestion> matchedMentors =
+        availableMentors.stream()
+            .map(mentor -> buildMentorSuggestion(mentor, unmatchedMentees))
+            .filter(s -> !s.mentees().isEmpty())
+            .toList();
+
+    final Set<Long> suggestedMenteeIds =
+        matchedMentors.stream()
+            .flatMap(s -> s.mentees().stream())
+            .map(m -> m.mentee().getId())
+            .collect(Collectors.toSet());
+
+    final Set<Long> matchedMentorIds =
+        matchedMentors.stream().map(s -> s.mentor().getId()).collect(Collectors.toSet());
+
+    if (log.isDebugEnabled()) {
+      matchedMentors.forEach(
+          s -> log.debug("Mentor ID: {} Suggestions: {}", s.mentor().getId(), s.mentees()));
+    }
+
+    final var notMatchedMentors =
+        availableMentors.stream()
+            .filter(mentor -> !matchedMentorIds.contains(mentor.getId()))
+            .toList();
+
+    final var notMatchedMentees =
+        unmatchedMentees.stream()
+            .filter(mentee -> !suggestedMenteeIds.contains(mentee.getId()))
+            .toList();
+
+    return new MentorshipRecommendationResponse(
+        matchedMentors, notMatchedMentors, notMatchedMentees);
+  }
+
+  private MentorMatchSuggestion buildMentorSuggestion(
+      final Mentor mentor, final List<Mentee> unmatchedMentees) {
+    final List<MenteeMatchSuggestion> scoredMentees =
+        unmatchedMentees.stream()
+            .map(mentee -> new MenteeMatchSuggestion(mentee, calculateScore(mentor, mentee)))
+            .filter(s -> s.score() > 0)
+            .sorted(Comparator.comparingInt(MenteeMatchSuggestion::score).reversed())
+            .toList();
+    return new MentorMatchSuggestion(mentor, scoredMentees);
+  }
+
+  private int calculateScore(final Mentor mentor, final Mentee mentee) {
+    return scoreLanguages(mentor, mentee) + scoreAreas(mentor, mentee) + scoreFocus(mentor, mentee);
+  }
+
+  private int scoreLanguages(final Mentor mentor, final Mentee mentee) {
+    if (mentor.getSkills().languages().isEmpty()) {
+      return 0;
+    }
+    final var mentorLangs =
+        mentor.getSkills().languages().stream()
+            .map(LanguageProficiency::language)
+            .collect(Collectors.toSet());
+    return (int)
+            mentee.getSkills().languages().stream()
+                .map(LanguageProficiency::language)
+                .filter(mentorLangs::contains)
+                .count()
+        * LANGUAGE_SCORE;
+  }
+
+  private int scoreAreas(final Mentor mentor, final Mentee mentee) {
+    if (mentor.getSkills().areas().isEmpty()) {
+      return 0;
+    }
+    final Set<TechnicalArea> mentorAreas =
+        mentor.getSkills().areas().stream()
+            .map(TechnicalAreaProficiency::technicalArea)
+            .collect(Collectors.toSet());
+    return (int)
+            mentee.getSkills().areas().stream()
+                .map(TechnicalAreaProficiency::technicalArea)
+                .filter(mentorAreas::contains)
+                .count()
+        * AREA_SCORE;
+  }
+
+  private int scoreFocus(final Mentor mentor, final Mentee mentee) {
+    final var mentorFocus =
+        mentor.getSkills().mentorshipFocus().isEmpty()
+            ? EnumSet.noneOf(MentorshipFocusArea.class)
+            : EnumSet.copyOf(mentor.getSkills().mentorshipFocus());
+    return (int) mentee.getSkills().mentorshipFocus().stream().filter(mentorFocus::contains).count()
+        * FOCUS_SCORE;
+  }
+}

--- a/src/test/java/com/wcc/platform/service/MentorshipRecommendationServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/MentorshipRecommendationServiceTest.java
@@ -1,0 +1,224 @@
+package com.wcc.platform.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.wcc.platform.domain.cms.attributes.CodeLanguage;
+import com.wcc.platform.domain.cms.attributes.MentorshipFocusArea;
+import com.wcc.platform.domain.cms.attributes.ProficiencyLevel;
+import com.wcc.platform.domain.cms.attributes.TechnicalArea;
+import com.wcc.platform.domain.platform.member.ProfileStatus;
+import com.wcc.platform.domain.platform.mentorship.LanguageProficiency;
+import com.wcc.platform.domain.platform.mentorship.Mentee;
+import com.wcc.platform.domain.platform.mentorship.Mentor;
+import com.wcc.platform.domain.platform.mentorship.MentorshipCycleEntity;
+import com.wcc.platform.domain.platform.mentorship.Skills;
+import com.wcc.platform.domain.platform.mentorship.TechnicalAreaProficiency;
+import com.wcc.platform.domain.platform.mentorship.recommendation.MentorshipRecommendationResponse;
+import com.wcc.platform.factories.SetupMenteeFactories;
+import com.wcc.platform.factories.SetupMentorFactories;
+import com.wcc.platform.repository.MenteeRepository;
+import com.wcc.platform.repository.MentorRepository;
+import com.wcc.platform.repository.MentorshipCycleRepository;
+import com.wcc.platform.repository.MentorshipMatchRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MentorshipRecommendationServiceTest {
+
+  @Mock private MentorRepository mentorRepository;
+  @Mock private MenteeRepository menteeRepository;
+  @Mock private MentorshipMatchRepository matchRepository;
+  @Mock private MentorshipCycleRepository cycleRepository;
+
+  @InjectMocks private MentorshipRecommendationService service;
+
+  @BeforeEach
+  void setUp() {
+    final var cycle = MentorshipCycleEntity.builder().cycleId(1L).build();
+    when(cycleRepository.findById(1L)).thenReturn(Optional.of(cycle));
+  }
+
+  @Test
+  @DisplayName(
+      "Given active mentor and mentee with matching skills, when getRecommendations is called, then return suggestions with score")
+  void shouldReturnRecommendationsWhenSkillsMatch() {
+    // Mentor with Java and Backend
+    Mentor mentorBase = SetupMentorFactories.createMentorTest(1L, "Mentor Java", "mentor@test.com");
+    Mentor mentor =
+        Mentor.mentorBuilder()
+            .id(mentorBase.getId())
+            .fullName(mentorBase.getFullName())
+            .email(mentorBase.getEmail())
+            .profileStatus(ProfileStatus.ACTIVE)
+            .menteeSection(mentorBase.getMenteeSection())
+            .bio(mentorBase.getBio())
+            .skills(
+                new Skills(
+                    5,
+                    List.of(
+                        new TechnicalAreaProficiency(
+                            TechnicalArea.BACKEND, ProficiencyLevel.ADVANCED)),
+                    List.of(new LanguageProficiency(CodeLanguage.JAVA, ProficiencyLevel.ADVANCED)),
+                    List.of(MentorshipFocusArea.GROW_BEGINNER_TO_MID)))
+            .build();
+
+    // Mentee with Java and Backend
+    Mentee menteeBase =
+        SetupMenteeFactories.createMenteeTest(10L, "Mentee Java", "mentee@test.com");
+    Mentee mentee =
+        Mentee.menteeBuilder()
+            .id(menteeBase.getId())
+            .fullName(menteeBase.getFullName())
+            .email(menteeBase.getEmail())
+            .profileStatus(ProfileStatus.ACTIVE)
+            .bio(menteeBase.getBio())
+            .spokenLanguages(List.of("English"))
+            .availableHsMonth(menteeBase.getAvailableHsMonth())
+            .skills(
+                new Skills(
+                    1,
+                    List.of(
+                        new TechnicalAreaProficiency(
+                            TechnicalArea.BACKEND, ProficiencyLevel.BEGINNER)),
+                    List.of(new LanguageProficiency(CodeLanguage.JAVA, ProficiencyLevel.BEGINNER)),
+                    List.of(MentorshipFocusArea.GROW_BEGINNER_TO_MID)))
+            .build();
+
+    when(mentorRepository.findAvailableMentors(ProfileStatus.ACTIVE)).thenReturn(List.of(mentor));
+    when(menteeRepository.findByStatus(ProfileStatus.ACTIVE)).thenReturn(List.of(mentee));
+    when(matchRepository.countActiveMenteesByMentorAndCycle(anyLong(), anyLong())).thenReturn(0);
+    when(matchRepository.isMenteeMatchedInCycle(anyLong(), anyLong())).thenReturn(false);
+
+    MentorshipRecommendationResponse response = service.getRecommendations(1L);
+
+    assertThat(response.matchedMentors()).hasSize(1);
+    assertThat(response.matchedMentors().getFirst().mentor().getId()).isEqualTo(1L);
+    assertThat(response.matchedMentors().getFirst().mentees()).hasSize(1);
+    assertThat(response.matchedMentors().getFirst().mentees().getFirst().mentee().getId())
+        .isEqualTo(10L);
+    assertThat(response.matchedMentors().getFirst().mentees().getFirst().score()).isGreaterThan(0);
+    assertThat(response.notMatchedMentors()).isEmpty();
+    assertThat(response.notMatchedMentees()).isEmpty();
+  }
+
+  @Test
+  @DisplayName(
+      "Given mentor at capacity, when getRecommendations is called, then mentor is not included in suggestions")
+  void shouldNotRecommendWhenMentorAtCapacity() {
+    Mentor mentorBase = SetupMentorFactories.createMentorTest(1L, "Mentor Full", "mentor@test.com");
+    Mentor mentor =
+        Mentor.mentorBuilder()
+            .id(mentorBase.getId())
+            .fullName(mentorBase.getFullName())
+            .email(mentorBase.getEmail())
+            .profileStatus(ProfileStatus.ACTIVE)
+            .bio(mentorBase.getBio())
+            .skills(mentorBase.getSkills())
+            .menteeSection(mentorBase.getMenteeSection())
+            .build();
+
+    // Set capacity to 1
+    mentor
+        .getMenteeSection()
+        .longTerm()
+        .numMentee(); // this is record, so it might be final, let's see.
+
+    when(mentorRepository.findAvailableMentors(ProfileStatus.ACTIVE)).thenReturn(List.of(mentor));
+    when(menteeRepository.findByStatus(ProfileStatus.ACTIVE)).thenReturn(List.of());
+
+    // Assume capacity is 1 from SetupMentorFactories and it already has 1 match
+    int capacity = mentor.getMenteeSection().longTerm().numMentee();
+    when(matchRepository.countActiveMenteesByMentorAndCycle(1L, 1L)).thenReturn(capacity);
+
+    MentorshipRecommendationResponse response = service.getRecommendations(1L);
+
+    assertThat(response.matchedMentors()).isEmpty();
+    assertThat(response.notMatchedMentors()).isEmpty();
+  }
+
+  @Test
+  @DisplayName(
+      "Given mentee already matched, when getRecommendations is called, then mentee is not recommended")
+  void shouldNotRecommendWhenMenteeAlreadyMatched() {
+    Mentor mentor = SetupMentorFactories.createMentorTest(1L, "Mentor Java", "mentor@test.com");
+    Mentee mentee = SetupMenteeFactories.createMenteeTest(10L, "Mentee Java", "mentee@test.com");
+
+    when(mentorRepository.findAvailableMentors(ProfileStatus.ACTIVE)).thenReturn(List.of(mentor));
+    when(menteeRepository.findByStatus(ProfileStatus.ACTIVE)).thenReturn(List.of(mentee));
+    when(matchRepository.countActiveMenteesByMentorAndCycle(1L, 1L)).thenReturn(0);
+    when(matchRepository.isMenteeMatchedInCycle(10L, 1L)).thenReturn(true);
+
+    MentorshipRecommendationResponse response = service.getRecommendations(1L);
+
+    assertThat(response.matchedMentors()).isEmpty();
+    assertThat(response.notMatchedMentors()).extracting(Mentor::getId).containsExactly(1L);
+    assertThat(response.notMatchedMentees()).isEmpty();
+  }
+
+  @Test
+  @DisplayName(
+      "Given no skills match, when getRecommendations is called, then return empty matches")
+  void shouldReturnEmptyWhenNoSkillsMatch() {
+    Mentor mentorBase = SetupMentorFactories.createMentorTest(1L, "Mentor Java", "mentor@test.com");
+    Mentor mentor =
+        Mentor.mentorBuilder()
+            .id(mentorBase.getId())
+            .fullName(mentorBase.getFullName())
+            .email(mentorBase.getEmail())
+            .profileStatus(ProfileStatus.ACTIVE)
+            .menteeSection(mentorBase.getMenteeSection())
+            .bio(mentorBase.getBio())
+            .skills(
+                new Skills(
+                    5,
+                    List.of(
+                        new TechnicalAreaProficiency(
+                            TechnicalArea.BACKEND, ProficiencyLevel.ADVANCED)),
+                    List.of(new LanguageProficiency(CodeLanguage.JAVA, ProficiencyLevel.ADVANCED)),
+                    List.of(MentorshipFocusArea.GROW_BEGINNER_TO_MID)))
+            .build();
+
+    Mentee menteeBase =
+        SetupMenteeFactories.createMenteeTest(10L, "Mentee Python", "mentee@test.com");
+    Mentee mentee =
+        Mentee.menteeBuilder()
+            .id(menteeBase.getId())
+            .fullName(menteeBase.getFullName())
+            .email(menteeBase.getEmail())
+            .profileStatus(ProfileStatus.ACTIVE)
+            .bio(menteeBase.getBio())
+            .spokenLanguages(List.of("English"))
+            .availableHsMonth(menteeBase.getAvailableHsMonth())
+            .skills(
+                new Skills(
+                    1,
+                    List.of(
+                        new TechnicalAreaProficiency(
+                            TechnicalArea.FRONTEND, ProficiencyLevel.BEGINNER)),
+                    List.of(
+                        new LanguageProficiency(CodeLanguage.PYTHON, ProficiencyLevel.BEGINNER)),
+                    List.of(MentorshipFocusArea.SWITCH_TO_MANAGEMENT)))
+            .build();
+
+    when(mentorRepository.findAvailableMentors(ProfileStatus.ACTIVE)).thenReturn(List.of(mentor));
+    when(menteeRepository.findByStatus(ProfileStatus.ACTIVE)).thenReturn(List.of(mentee));
+    when(matchRepository.countActiveMenteesByMentorAndCycle(1L, 1L)).thenReturn(0);
+    when(matchRepository.isMenteeMatchedInCycle(10L, 1L)).thenReturn(false);
+
+    MentorshipRecommendationResponse response = service.getRecommendations(1L);
+
+    assertThat(response.matchedMentors()).isEmpty();
+    assertThat(response.notMatchedMentors()).extracting(Mentor::getId).containsExactly(1L);
+    assertThat(response.notMatchedMentees()).extracting(Mentee::getId).containsExactly(10L);
+  }
+}

--- a/src/testInt/java/com/wcc/platform/repository/postgres/PostgresMemberRepositoryIntegrationTest.java
+++ b/src/testInt/java/com/wcc/platform/repository/postgres/PostgresMemberRepositoryIntegrationTest.java
@@ -70,7 +70,7 @@ class PostgresMemberRepositoryIntegrationTest extends DefaultDatabaseSetup {
 
   @Test
   void createReturnEmptyForNotFoundMemberId() {
-    var optionalMember = repository.findById(7L);
+    var optionalMember = repository.findById(Long.MAX_VALUE);
 
     assertTrue(optionalMember.isEmpty(), "Should not find optionalMember with this id");
   }


### PR DESCRIPTION
## Description

Introduces GET /matches/recommendations/{cycleId} to suggest ranked mentee matches for available mentors based on language, technical area, and mentorship focus alignment. Scoring is split into dedicated private methods
(scoreLanguages, scoreAreas, scoreFocus) to stay within PMD cognitive complexity limits, and the matching loop uses streams throughout to satisfy AvoidInstantiatingObjectsInLoops. Adds findAvailableMentors by status to
MentorRepository, Javadoc to RequiresRole and Mentee, and full unit test coverage for the new service.

<!--
Example PR: https://github.com/Women-Coding-Community/wcc-backend/pull/118
-->

## Related Issue

#658 

## Change Type

- [x] New Feature

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->