### PR TITLE
PR fix: add mentorship recommendation API with skill-based scoring

### DIFF
--- a/admin-wcc-app/__tests__/services/mentorshipService.test.ts
+++ b/admin-wcc-app/__tests__/services/mentorshipService.test.ts
@@ -21,7 +21,7 @@ describe('mentorshipService', () => {
       };
       (apiFetch as jest.Mock).mockResolvedValue(mockResponse);
 
-      const result = await getMentorshipRecommendations(1);
+      const result = await getMentorshipRecommendations(token);
 
       expect(apiFetch).toHaveBeenCalledWith(
         '/api/platform/v1/admin/mentorship/matches/recommendations/1',

--- a/src/main/java/com/wcc/platform/controller/MentorshipAdminMatchesController.java
+++ b/src/main/java/com/wcc/platform/controller/MentorshipAdminMatchesController.java
@@ -53,7 +53,7 @@ public class MentorshipAdminMatchesController {
    * @return Recommended matches
    */
   @GetMapping("/matches/recommendations/{cycleId}")
-  //  @RequiresRole({RoleType.ADMIN})
+  @RequiresPermission(Permission.MATCH_MANAGE)
   @Operation(summary = "Get suggested mentee matches for unmatched mentors")
   public ResponseEntity<MentorshipRecommendationResponse> getMatchRecommendations(
       @Parameter(description = "Cycle ID") @PathVariable final Long cycleId) {

--- a/src/testInt/java/com/wcc/platform/repository/postgres/PostgresMemberRepositoryIntegrationTest.java
+++ b/src/testInt/java/com/wcc/platform/repository/postgres/PostgresMemberRepositoryIntegrationTest.java
@@ -70,7 +70,7 @@ class PostgresMemberRepositoryIntegrationTest extends DefaultDatabaseSetup {
 
   @Test
   void createReturnEmptyForNotFoundMemberId() {
-    var optionalMember = repository.findById(7L);
+    var optionalMember = repository.findById(Long.MAX_VALUE);
 
     assertTrue(optionalMember.isEmpty(), "Should not find optionalMember with this id");
   }


### PR DESCRIPTION
## Description

fix(security): Added @RequiresPermission(Permission.MATCH_MANAGE) for api get getMatchRecommendations()
fix(test): Use token parameter
fix(integration test):  use Long.MAX_VALUE instead of hardcoded 7L in member repo integration test

## Related Issue
[PR link](https://github.com/Women-Coding-Community/wcc-backend/pull/670)

## Change Type

- [X] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Test
- [ ] Other

## Screenshots


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [X] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->