### PR TITLE
feat: add recommendation with skill-based scoring API + UI

### DIFF
--- a/admin-wcc-app/__tests__/services/mentorshipService.test.ts
+++ b/admin-wcc-app/__tests__/services/mentorshipService.test.ts
@@ -1,5 +1,9 @@
-import { createManualMatch, getMentorshipRecommendations } from '../../services/mentorshipService';
-import { apiFetch } from '../../lib/api';
+import {
+  createManualMatch,
+  getMenteeApplications,
+  getMentorshipRecommendations,
+} from '@/services/mentorshipService';
+import { apiFetch } from '@/lib/api';
 
 jest.mock('../../lib/api', () => ({
   apiFetch: jest.fn(),
@@ -21,13 +25,39 @@ describe('mentorshipService', () => {
       };
       (apiFetch as jest.Mock).mockResolvedValue(mockResponse);
 
-      const result = await getMentorshipRecommendations(1, token);
+      const result = await getMentorshipRecommendations(token);
 
       expect(apiFetch).toHaveBeenCalledWith(
-        '/api/platform/v1/admin/mentorship/matches/recommendations/1',
+        '/api/platform/v1/admin/mentorship/matches/recommendations',
         { token }
       );
       expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('getMenteeApplications', () => {
+    it('should fetch mentee applications without mentor filter', async () => {
+      const mockApps = [{ menteeId: 1, status: 'PENDING' }];
+      (apiFetch as jest.Mock).mockResolvedValue(mockApps);
+
+      const result = await getMenteeApplications(5, ['PENDING', 'ACCEPTED'], token);
+
+      expect(apiFetch).toHaveBeenCalledWith(
+        '/api/platform/v1/admin/mentorship/cycles/5/applications?status=PENDING%2CACCEPTED',
+        { token }
+      );
+      expect(result).toEqual(mockApps);
+    });
+
+    it('should fetch mentee applications with mentor filter', async () => {
+      (apiFetch as jest.Mock).mockResolvedValue([]);
+
+      await getMenteeApplications(5, ['PENDING'], token, 10);
+
+      expect(apiFetch).toHaveBeenCalledWith(
+        '/api/platform/v1/admin/mentorship/cycles/5/applications?status=PENDING&mentorId=10',
+        { token }
+      );
     });
   });
 

--- a/admin-wcc-app/__tests__/services/mentorshipService.test.ts
+++ b/admin-wcc-app/__tests__/services/mentorshipService.test.ts
@@ -1,0 +1,59 @@
+import { createManualMatch, getMentorshipRecommendations } from '../../services/mentorshipService';
+import { apiFetch } from '../../lib/api';
+
+jest.mock('../../lib/api', () => ({
+  apiFetch: jest.fn(),
+}));
+
+describe('mentorshipService', () => {
+  const token = 'fake-token';
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getMentorshipRecommendations', () => {
+    it('should fetch mentorship recommendations for a program', async () => {
+      const mockResponse = {
+        matchedMentors: [],
+        notMatchedMentors: [],
+        notMatchedMentees: [],
+      };
+      (apiFetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await getMentorshipRecommendations(1, token);
+
+      expect(apiFetch).toHaveBeenCalledWith(
+        '/api/platform/v1/admin/mentorship/matches/recommendations/1',
+        { token }
+      );
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('createManualMatch', () => {
+    it('should send a POST request to assign a mentor to a mentee', async () => {
+      (apiFetch as jest.Mock).mockResolvedValue(undefined);
+
+      await createManualMatch(20, 5, 10, token);
+
+      expect(apiFetch).toHaveBeenCalledWith('/api/platform/v1/mentees/20/cycles/5/assign-mentor', {
+        method: 'POST',
+        body: { mentorId: 10, notes: undefined },
+        token,
+      });
+    });
+
+    it('should include notes in the request body when provided', async () => {
+      (apiFetch as jest.Mock).mockResolvedValue(undefined);
+
+      await createManualMatch(20, 5, 10, token, 'Good match for React skills');
+
+      expect(apiFetch).toHaveBeenCalledWith('/api/platform/v1/mentees/20/cycles/5/assign-mentor', {
+        method: 'POST',
+        body: { mentorId: 10, notes: 'Good match for React skills' },
+        token,
+      });
+    });
+  });
+});

--- a/admin-wcc-app/admin-wcc-app/__tests__/components/mentorship/MatchCard.test.tsx
+++ b/admin-wcc-app/admin-wcc-app/__tests__/components/mentorship/MatchCard.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import MatchCard from '@/components/mentorship/MatchCard';
+import {createManualMatch} from '@/services/mentorshipService';
+
+jest.mock('@/services/mentorshipService');
+
+const mockMentor = {
+  id: 1,
+  fullName: 'Mentor Name',
+};
+
+const mockMentee = {
+  id: 10,
+  fullName: 'Mentee Name',
+};
+
+const mockMatch = {
+  mentor: mockMentor,
+  mentees: [
+    {
+      mentee: mockMentee,
+      score: 80,
+      applicationStatus: null,
+    },
+  ],
+};
+
+const onMenteeMatched = jest.fn();
+
+describe('MatchCard', () => {
+  it('renders mentor and mentee info', () => {
+    render(
+        <MatchCard
+            match={mockMatch as any}
+            cycleId={1}
+            token="token"
+            onMenteeMatched={onMenteeMatched}
+        />
+    );
+
+    expect(screen.getByText(/Mentor #1/)).toBeInTheDocument();
+    expect(screen.getByText(/Mentee Name/)).toBeInTheDocument();
+    expect(screen.getByText(/Match with Mentee/)).toBeInTheDocument();
+  });
+
+  it('calls createManualMatch when button clicked', async () => {
+    (createManualMatch as jest.Mock).mockResolvedValue({});
+    render(
+        <MatchCard
+            match={mockMatch as any}
+            cycleId={1}
+            token="token"
+            onMenteeMatched={onMenteeMatched}
+        />
+    );
+
+    fireEvent.click(screen.getByText(/Match with Mentee/));
+
+    await waitFor(() => {
+      expect(createManualMatch).toHaveBeenCalledWith(10, 1, 1, 'token');
+      expect(onMenteeMatched).toHaveBeenCalledWith(1, 10);
+    });
+  });
+
+  it('disables button and shows status if applicationStatus is present', () => {
+    const matchWithStatus = {
+      ...mockMatch,
+      mentees: [
+        {
+          ...mockMatch.mentees[0],
+          applicationStatus: 'PENDING',
+        },
+      ],
+    };
+
+    render(
+        <MatchCard
+            match={matchWithStatus as any}
+            cycleId={1}
+            token="token"
+            onMenteeMatched={onMenteeMatched}
+        />
+    );
+
+    expect(screen.queryByText(/Match with Mentee/)).not.toBeInTheDocument();
+    expect(screen.getByText('PENDING')).toBeInTheDocument();
+  });
+});

--- a/admin-wcc-app/admin-wcc-app/__tests__/components/mentorship/MenteeApplicationCard.test.tsx
+++ b/admin-wcc-app/admin-wcc-app/__tests__/components/mentorship/MenteeApplicationCard.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import MenteeApplicationCard from '@/components/mentorship/MenteeApplicationCard';
+
+const mockApp = {
+  menteeId: 10,
+  mentee: {
+    fullName: 'Mentee Name',
+    position: 'Developer',
+  },
+  status: 'PENDING',
+  appliedAt: '2024-01-01T10:00:00Z',
+  rejectionReason: 'Not a good fit',
+};
+
+describe('MenteeApplicationCard', () => {
+  it('renders application info', () => {
+    render(<MenteeApplicationCard application={mockApp as any}/>);
+
+    expect(screen.getByText('Mentee Name')).toBeInTheDocument();
+    expect(screen.getByText('Developer')).toBeInTheDocument();
+    expect(screen.getByText('PENDING')).toBeInTheDocument();
+  });
+
+  it('shows rejection reason when requested', () => {
+    render(<MenteeApplicationCard application={mockApp as any} showRejectionReason={true}/>);
+
+    expect(screen.getByText(/Not a good fit/)).toBeInTheDocument();
+  });
+
+  it('hides rejection reason by default', () => {
+    render(<MenteeApplicationCard application={mockApp as any}/>);
+
+    expect(screen.queryByText(/Not a good fit/)).not.toBeInTheDocument();
+  });
+});

--- a/admin-wcc-app/admin-wcc-app/components/mentorship/MenteeApplicationCard.tsx
+++ b/admin-wcc-app/admin-wcc-app/components/mentorship/MenteeApplicationCard.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import {Avatar, Box, Card, CardContent, Chip, Stack, Typography} from '@mui/material';
+import {MenteeApplicationItem} from '@/types/mentorship';
+
+interface MenteeApplicationCardProps {
+  application: MenteeApplicationItem;
+  showRejectionReason?: boolean;
+}
+
+export default function MenteeApplicationCard({
+                                                application,
+                                                showRejectionReason = false,
+                                              }: MenteeApplicationCardProps) {
+  const getStatusColor = (status: string) => {
+    switch (status.toUpperCase()) {
+      case 'MATCHED':
+      case 'MENTOR_ACCEPTED':
+        return 'success';
+      case 'PENDING':
+      case 'MENTOR_REVIEWING':
+        return 'info';
+      case 'REJECTED':
+      case 'MENTOR_DECLINED':
+      case 'DROPPED':
+      case 'EXPIRED':
+        return 'error';
+      default:
+        return 'default';
+    }
+  };
+
+  return (
+      <Card sx={{mb: 2}}>
+        <CardContent>
+          <Stack direction="row" spacing={2} alignItems="center">
+            <Avatar sx={{bgcolor: 'secondary.main'}}>
+              {application.mentee.fullName.substring(0, 1)}
+            </Avatar>
+            <Box sx={{flex: 1}}>
+              <Typography variant="subtitle1" sx={{fontWeight: 600}}>
+                {application.mentee.fullName}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {application.mentee.position || 'No position provided'}
+              </Typography>
+            </Box>
+            <Stack alignItems="flex-end" spacing={1}>
+              <Chip
+                  label={application.status}
+                  color={getStatusColor(application.status)}
+                  size="small"
+              />
+              {application.appliedAt && (
+                  <Typography variant="caption" color="text.secondary">
+                    Applied: {new Date(application.appliedAt).toLocaleDateString()}
+                  </Typography>
+              )}
+            </Stack>
+          </Stack>
+
+          {showRejectionReason && application.rejectionReason && (
+              <Box sx={{mt: 2, p: 1, bgcolor: 'error.light', borderRadius: 1}}>
+                <Typography variant="body2" color="error.contrastText">
+                  <strong>Reason:</strong> {application.rejectionReason}
+                </Typography>
+              </Box>
+          )}
+        </CardContent>
+      </Card>
+  );
+}

--- a/admin-wcc-app/admin-wcc-app/components/mentorship/MentorApplicationsPanel.tsx
+++ b/admin-wcc-app/admin-wcc-app/components/mentorship/MentorApplicationsPanel.tsx
@@ -1,0 +1,82 @@
+import React, {useEffect, useState} from 'react';
+import {Alert, Box, CircularProgress, Tab, Tabs, Typography} from '@mui/material';
+import {MenteeApplicationItem} from '@/types/mentorship';
+import {getMenteeApplications} from '@/services/mentorshipService';
+import MenteeApplicationCard from './MenteeApplicationCard';
+
+interface MentorApplicationsPanelProps {
+  mentorId: number;
+  cycleId: number;
+  token: string;
+}
+
+export default function MentorApplicationsPanel({
+                                                  mentorId,
+                                                  cycleId,
+                                                  token,
+                                                }: MentorApplicationsPanelProps) {
+  const [tab, setTab] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [applications, setApplications] = useState<MenteeApplicationItem[]>([]);
+
+  const tabs = [
+    {label: 'Pending', statuses: ['PENDING', 'MENTOR_REVIEWING']},
+    {label: 'Accepted', statuses: ['MENTOR_ACCEPTED', 'MATCHED']},
+    {
+      label: 'Rejected',
+      statuses: ['MENTOR_DECLINED', 'REJECTED', 'DROPPED', 'EXPIRED'],
+      showReason: true,
+    },
+  ];
+
+  useEffect(() => {
+    const fetchApps = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await getMenteeApplications(cycleId, tabs[tab].statuses, token, mentorId);
+        setApplications(data);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to fetch applications');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (cycleId && token) {
+      fetchApps();
+    }
+  }, [tab, mentorId, cycleId, token]);
+
+  return (
+      <Box sx={{mt: 2}}>
+        <Typography variant="h6" gutterBottom>
+          Mentor's Applications
+        </Typography>
+        <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{mb: 2}}>
+          {tabs.map((t, i) => (
+              <Tab key={i} label={t.label}/>
+          ))}
+        </Tabs>
+
+        {loading ? (
+            <Box sx={{display: 'flex', justifyContent: 'center', p: 3}}>
+              <CircularProgress/>
+            </Box>
+        ) : error ? (
+            <Alert severity="error">{error}</Alert>
+        ) : applications.length > 0 ? (
+            applications.map((app) => (
+                <MenteeApplicationCard
+                    key={app.menteeId}
+                    application={app}
+                    showRejectionReason={tabs[tab].showReason}
+                />
+            ))
+        ) : (
+            <Typography color="text.secondary">No applications found in this category.</Typography>
+        )}
+      </Box>
+  );
+}

--- a/admin-wcc-app/components/AdminLayout.tsx
+++ b/admin-wcc-app/components/AdminLayout.tsx
@@ -42,6 +42,11 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                 Mentees
               </Button>
             )}
+            {(isAdmin || isMentorshipAdmin) && (
+              <Button component={Link} href="/admin/mentorship" color="inherit">
+                Mentorship
+              </Button>
+            )}
             {(isAdmin || isLeader) && (
               <Button component={Link} href="/admin/users" color="inherit">
                 Users

--- a/admin-wcc-app/components/mentors/SkillsSection.tsx
+++ b/admin-wcc-app/components/mentors/SkillsSection.tsx
@@ -33,21 +33,6 @@ export default function SkillsSection({ skills }: SkillsSectionProps) {
           {skills.yearsExperience} years experience
         </Typography>
       )}
-      {skills.areas && skills.areas.length > 0 && (
-        <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-          {skills.areas.map((a) => (
-            <Chip
-              key={a.technicalArea}
-              label={
-                a.proficiencyLevel
-                  ? `${areaLabel(a.technicalArea)} · ${profLabel(a.proficiencyLevel)}`
-                  : areaLabel(a.technicalArea)
-              }
-              size="small"
-            />
-          ))}
-        </Box>
-      )}
       {skills.languages && skills.languages.length > 0 && (
         <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
           {skills.languages.map((l) => (
@@ -60,6 +45,21 @@ export default function SkillsSection({ skills }: SkillsSectionProps) {
               }
               size="small"
               color="secondary"
+            />
+          ))}
+        </Box>
+      )}
+      {skills.areas && skills.areas.length > 0 && (
+        <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+          {skills.areas.map((a) => (
+            <Chip
+              key={a.technicalArea}
+              label={
+                a.proficiencyLevel
+                  ? `${areaLabel(a.technicalArea)} · ${profLabel(a.proficiencyLevel)}`
+                  : areaLabel(a.technicalArea)
+              }
+              size="small"
             />
           ))}
         </Box>

--- a/admin-wcc-app/components/mentors/SkillsSection.tsx
+++ b/admin-wcc-app/components/mentors/SkillsSection.tsx
@@ -13,11 +13,11 @@ function areaLabel(value: string): string {
   return TECHNICAL_AREAS.find((a) => a.value === value)?.label ?? value;
 }
 
-function langLabel(value: string): string {
+export function langLabel(value: string): string {
   return PROGRAMMING_LANGUAGES.find((l) => l.value === value)?.label ?? value;
 }
 
-function profLabel(value: string): string {
+export function profLabel(value: string): string {
   return PROFICIENCY_LEVELS.find((p) => p.value === value)?.label ?? value;
 }
 

--- a/admin-wcc-app/components/mentorship/MatchCard.tsx
+++ b/admin-wcc-app/components/mentorship/MatchCard.tsx
@@ -1,14 +1,47 @@
-import React from 'react';
-import { Box, Button, Card, CardContent, Grid, Typography } from '@mui/material';
+import React, { useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Grid,
+  Typography,
+} from '@mui/material';
 import { MentorMatches } from '@/types/mentorship';
 import MentorInfoCard from './MentorInfoCard';
 import MenteeCard from './MenteeCard';
+import { createManualMatch } from '@/services/mentorshipService';
 
 interface MatchCardProps {
   match: MentorMatches;
+  cycleId: number;
+  token: string;
+  onMenteeMatched: (mentorId: string | number, menteeId: number) => void;
 }
 
-export default function MatchCard({ match }: MatchCardProps) {
+export default function MatchCard({ match, cycleId, token, onMenteeMatched }: MatchCardProps) {
+  const [loadingMenteeId, setLoadingMenteeId] = useState<number | null>(null);
+  const [error, setError] = useState<{ id: number; message: string } | null>(null);
+  const [successId, setSuccessId] = useState<number | null>(null);
+
+  const handleMatch = async (menteeId: number) => {
+    setLoadingMenteeId(menteeId);
+    setError(null);
+    setSuccessId(null);
+    try {
+      await createManualMatch(menteeId, cycleId, match.mentor.id, token);
+      setSuccessId(menteeId);
+      onMenteeMatched(match.mentor.id, menteeId);
+    } catch (e) {
+      setError({ id: menteeId, message: e instanceof Error ? e.message : 'Failed to match' });
+    } finally {
+      setLoadingMenteeId(null);
+    }
+  };
+
   return (
     <Card sx={{ mb: 4, borderLeft: 6, borderColor: 'primary.main' }}>
       <CardContent>
@@ -34,10 +67,49 @@ export default function MatchCard({ match }: MatchCardProps) {
                 <Box key={suggestion.mentee.id} sx={{ mb: 2 }}>
                   <MenteeCard mentee={suggestion.mentee} score={suggestion.score} />
 
-                  <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: -1, mb: 1 }}>
-                    <Button size="small" variant="contained" color="primary">
-                      Match with {suggestion.mentee.fullName.split(' ')[0]}
-                    </Button>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'flex-end',
+                      mt: -1,
+                      mb: 1,
+                    }}
+                  >
+                    {suggestion.applicationStatus ? (
+                      <Chip
+                        label={suggestion.applicationStatus}
+                        color={suggestion.applicationStatus === 'MATCHED' ? 'success' : 'info'}
+                        size="small"
+                        sx={{ mt: 1 }}
+                      />
+                    ) : (
+                      <Button
+                        size="small"
+                        variant="contained"
+                        color="primary"
+                        disabled={loadingMenteeId !== null}
+                        onClick={() => handleMatch(suggestion.mentee.id)}
+                        startIcon={
+                          loadingMenteeId === suggestion.mentee.id ? (
+                            <CircularProgress size={16} />
+                          ) : null
+                        }
+                      >
+                        Match with {suggestion.mentee.fullName.split(' ')[0]}
+                      </Button>
+                    )}
+
+                    {successId === suggestion.mentee.id && (
+                      <Alert severity="success" sx={{ mt: 1, py: 0, width: '100%' }}>
+                        Matched successfully! Status: MENTOR_REVIEWING
+                      </Alert>
+                    )}
+                    {error?.id === suggestion.mentee.id && (
+                      <Alert severity="error" sx={{ mt: 1, py: 0, width: '100%' }}>
+                        {error.message}
+                      </Alert>
+                    )}
                   </Box>
                 </Box>
               ))

--- a/admin-wcc-app/components/mentorship/MatchCard.tsx
+++ b/admin-wcc-app/components/mentorship/MatchCard.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Box, Button, Card, CardContent, Grid, Typography } from '@mui/material';
+import { MentorMatches } from '@/types/mentorship';
+import MentorInfoCard from './MentorInfoCard';
+import MenteeCard from './MenteeCard';
+
+interface MatchCardProps {
+  match: MentorMatches;
+}
+
+export default function MatchCard({ match }: MatchCardProps) {
+  return (
+    <Card sx={{ mb: 4, borderLeft: 6, borderColor: 'primary.main' }}>
+      <CardContent>
+        <Grid container spacing={4}>
+          <Grid item xs={12} md={5}>
+            <Typography variant="h6" gutterBottom color="primary">
+              Mentor #{match.mentor.id}
+            </Typography>
+            <MentorInfoCard mentor={match.mentor} />
+            <Box sx={{ mt: 2 }}>
+              <Typography variant="body2" color="text.secondary">
+                Review mentor profile and availability before matching.
+              </Typography>
+            </Box>
+          </Grid>
+
+          <Grid item xs={12} md={7}>
+            <Typography variant="h6" gutterBottom color="secondary">
+              Recommended {match.mentees.length || 0} mentees
+            </Typography>
+            {match.mentees.length > 0 ? (
+              match.mentees.map((suggestion) => (
+                <Box key={suggestion.mentee.id} sx={{ mb: 2 }}>
+                  <MenteeCard mentee={suggestion.mentee} score={suggestion.score} />
+
+                  <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: -1, mb: 1 }}>
+                    <Button size="small" variant="contained" color="primary">
+                      Match with {suggestion.mentee.fullName.split(' ')[0]}
+                    </Button>
+                  </Box>
+                </Box>
+              ))
+            ) : (
+              <Typography color="text.secondary">
+                No recommended mentees for this mentor.
+              </Typography>
+            )}
+          </Grid>
+        </Grid>
+      </CardContent>
+    </Card>
+  );
+}

--- a/admin-wcc-app/components/mentorship/MenteeApplicationCard.tsx
+++ b/admin-wcc-app/components/mentorship/MenteeApplicationCard.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { Alert, Avatar, Box, Card, CardContent, Chip, Stack, Typography } from '@mui/material';
+import {
+  Business as BusinessIcon,
+  Public as PublicIcon,
+  Work as WorkIcon,
+} from '@mui/icons-material';
+import { MenteeApplicationItem } from '@/types/mentorship';
+
+interface MenteeApplicationCardProps {
+  application: MenteeApplicationItem;
+  showRejectionReason?: boolean;
+}
+
+const STATUS_COLOR: Record<string, 'default' | 'warning' | 'success' | 'error' | 'info'> = {
+  PENDING: 'warning',
+  MENTOR_REVIEWING: 'info',
+  MENTOR_ACCEPTED: 'success',
+  MATCHED: 'success',
+  MENTOR_DECLINED: 'error',
+  REJECTED: 'error',
+  DROPPED: 'error',
+  EXPIRED: 'default',
+};
+
+export default function MenteeApplicationCard({
+  application,
+  showRejectionReason = false,
+}: MenteeApplicationCardProps) {
+  const { mentee, status, rejectionReason, appliedAt } = application;
+  const location = [mentee.city, mentee.country?.countryName].filter(Boolean).join(', ');
+  const statusColor = STATUS_COLOR[status] ?? 'default';
+
+  return (
+    <Card variant="outlined" sx={{ mb: 2 }}>
+      <CardContent>
+        <Stack direction="row" spacing={2} alignItems="flex-start">
+          <Avatar
+            src={mentee.images?.[0]?.path}
+            alt={mentee.fullName}
+            sx={{ width: 48, height: 48 }}
+          >
+            {mentee.fullName.charAt(0)}
+          </Avatar>
+
+          <Box sx={{ flex: 1 }}>
+            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+              <Typography variant="h6">{mentee.fullName}</Typography>
+              <Chip label={status.replace(/_/g, ' ')} color={statusColor} size="small" />
+            </Stack>
+
+            <Stack
+              direction="row"
+              spacing={1}
+              alignItems="center"
+              color="text.secondary"
+              sx={{ mt: 0.5 }}
+            >
+              <WorkIcon fontSize="small" />
+              <Typography variant="body2">{mentee.position || 'N/A'}</Typography>
+              <BusinessIcon fontSize="small" />
+              <Typography variant="body2">{mentee.companyName || 'N/A'}</Typography>
+              <PublicIcon fontSize="small" />
+              <Typography variant="body2">{location || 'N/A'}</Typography>
+            </Stack>
+
+            {mentee.skills?.areas && mentee.skills.areas.length > 0 && (
+              <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap sx={{ mt: 1 }}>
+                {mentee.skills.areas.slice(0, 4).map((a) => (
+                  <Chip
+                    key={a.technicalArea}
+                    label={a.technicalArea.replace(/_/g, ' ')}
+                    size="small"
+                    color="primary"
+                    variant="outlined"
+                  />
+                ))}
+                {mentee.skills.areas.length > 4 && (
+                  <Chip
+                    label={`+${mentee.skills.areas.length - 4} more`}
+                    size="small"
+                    variant="outlined"
+                  />
+                )}
+              </Stack>
+            )}
+
+            {appliedAt && (
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ display: 'block', mt: 0.5 }}
+              >
+                Applied: {new Date(appliedAt).toLocaleDateString()}
+              </Typography>
+            )}
+
+            {showRejectionReason && rejectionReason && (
+              <Alert severity="error" sx={{ mt: 1 }}>
+                <strong>Rejection reason:</strong> {rejectionReason}
+              </Alert>
+            )}
+          </Box>
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}

--- a/admin-wcc-app/components/mentorship/MenteeCard.tsx
+++ b/admin-wcc-app/components/mentorship/MenteeCard.tsx
@@ -7,8 +7,6 @@ import {
   Chip,
   Collapse,
   Divider,
-  Grid,
-  Grid2,
   IconButton,
   Link,
   Stack,
@@ -24,6 +22,7 @@ import {
 } from '@mui/icons-material';
 import { MenteeItem } from '@/types/mentorship';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import SkillsSection, { langLabel, profLabel } from '@/components/mentors/SkillsSection';
 
 interface MenteeCardProps {
   mentee: MenteeItem;
@@ -93,6 +92,56 @@ export default function MenteeCard({ mentee, score }: MenteeCardProps) {
               <PublicIcon fontSize="small" />
               <Typography variant="body2">{location || 'N/A'}</Typography>
             </Stack>
+
+            {mentee.skills?.areas && mentee.skills.areas.length > 0 && (
+              <Box sx={{ mt: 1 }}>
+                <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+                  {mentee.skills.areas.slice(0, 3).map((a) => (
+                    <Chip
+                      key={a.technicalArea}
+                      label={a.technicalArea.replace(/_/g, ' ')}
+                      size="small"
+                      color="primary"
+                      variant="outlined"
+                    />
+                  ))}
+                  {mentee.skills.areas.length > 3 && (
+                    <Chip
+                      label={`+${mentee.skills.areas.length - 3} more`}
+                      size="small"
+                      variant="outlined"
+                    />
+                  )}
+                </Stack>
+              </Box>
+            )}
+
+            {mentee.skills?.languages && mentee.skills.languages.length > 0 && (
+              <Box sx={{ mt: 0.5 }}>
+                <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+                  {mentee.skills.languages.slice(0, 3).map((l) => (
+                    <Chip
+                      key={l.language}
+                      label={
+                        l.proficiencyLevel
+                          ? `${langLabel(l.language)} · ${profLabel(l.proficiencyLevel)}`
+                          : langLabel(l.language)
+                      }
+                      size="small"
+                      color="secondary"
+                      variant="outlined"
+                    />
+                  ))}
+                  {mentee.skills.languages.length > 3 && (
+                    <Chip
+                      label={`+${mentee.skills.languages.length - 3} more`}
+                      size="small"
+                      variant="outlined"
+                    />
+                  )}
+                </Stack>
+              </Box>
+            )}
           </Box>
           <IconButton onClick={() => setExpand(!expanded)}>
             {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
@@ -110,53 +159,22 @@ export default function MenteeCard({ mentee, score }: MenteeCardProps) {
               {mentee.bio || 'No bio provided.'}
             </Typography>
 
-            <Grid2 container spacing={2}>
-              <Grid item xs={12} md={6}>
-                <Typography variant="subtitle2" gutterBottom>
-                  Skills & Proficiency
-                </Typography>
-                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                  {mentee.skills?.areas?.map((a) => (
-                    <Chip
-                      key={a.technicalArea}
-                      label={`${a.technicalArea.replace(/_/g, ' ')} (${a.proficiencyLevel})`}
-                      size="small"
-                    />
-                  ))}
-                </Stack>
-              </Grid>
-
-              <Box sx={{ mt: 1 }}>
-                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                  {mentee.skills?.mentorshipFocus?.map((f) => (
-                    <Chip
-                      key={f}
-                      label={f.replace(/_/g, ' ')}
-                      size="small"
-                      color="info"
-                      variant="outlined"
-                    />
-                  ))}
-                </Stack>
-              </Box>
-
-              <Grid item xs={12} md={6}>
-                <Typography variant="subtitle2" gutterBottom>
-                  Languages
-                </Typography>
-                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                  {mentee.spokenLanguages?.map((l) => (
-                    <Chip key={l} label={l} size="small" icon={<LanguageIcon />} />
-                  ))}
-                </Stack>
-              </Grid>
-
-              <Box sx={{ mt: 2 }}>
-                <Typography variant="body2">
-                  <strong>Available hours/month:</strong> {mentee.availableHsMonth || 'N/A'}
-                </Typography>
-              </Box>
-            </Grid2>
+            <Box sx={{ mt: 1 }}>{mentee.skills && <SkillsSection skills={mentee.skills} />}</Box>
+            <Box sx={{ mt: 1 }}>
+              <Typography variant="subtitle2" gutterBottom>
+                Languages
+              </Typography>
+              <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                {mentee.spokenLanguages?.map((l) => (
+                  <Chip key={l} label={l} size="small" icon={<LanguageIcon />} />
+                ))}
+              </Stack>
+            </Box>
+            <Box sx={{ mt: 2 }}>
+              <Typography variant="body2">
+                <strong>Available hours/month:</strong> {mentee.availableHsMonth || 'N/A'}
+              </Typography>
+            </Box>
           </Box>
         </Collapse>
       </CardContent>

--- a/admin-wcc-app/components/mentorship/MenteeCard.tsx
+++ b/admin-wcc-app/components/mentorship/MenteeCard.tsx
@@ -1,0 +1,165 @@
+import React, { useState } from 'react';
+import {
+  Avatar,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Collapse,
+  Divider,
+  Grid,
+  Grid2,
+  IconButton,
+  Link,
+  Stack,
+  Typography,
+} from '@mui/material';
+import {
+  Business as BusinessIcon,
+  ExpandLess as ExpandLessIcon,
+  ExpandMore as ExpandMoreIcon,
+  Language as LanguageIcon,
+  Public as PublicIcon,
+  Work as WorkIcon,
+} from '@mui/icons-material';
+import { MenteeItem } from '@/types/mentorship';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+
+interface MenteeCardProps {
+  mentee: MenteeItem;
+  score?: number;
+}
+
+export default function MenteeCard({ mentee, score }: MenteeCardProps) {
+  const [expanded, setExpand] = useState(false);
+
+  const location = [mentee.city, mentee.country?.countryName].filter(Boolean).join(', ');
+
+  return (
+    <Card variant="outlined" sx={{ mb: 2, position: 'relative' }}>
+      {score !== undefined && (
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 10,
+            right: 10,
+            bgcolor: 'primary.main',
+            color: 'white',
+            borderRadius: '50%',
+            width: 40,
+            height: 40,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontWeight: 'bold',
+            zIndex: 1,
+          }}
+        >
+          {score}
+        </Box>
+      )}
+      <CardContent>
+        <Stack direction="row" spacing={2}>
+          <Avatar
+            src={mentee.images?.[0]?.path}
+            alt={mentee.fullName}
+            sx={{ width: 56, height: 56 }}
+          >
+            {mentee.fullName.charAt(0)}
+          </Avatar>
+          <Box sx={{ flex: 1 }}>
+            <Typography variant="h6">{mentee.fullName}</Typography>
+            <Stack direction="row" spacing={1} alignItems="center" color="text.secondary">
+              <Typography variant="body2">Mentee Id: {mentee.id}</Typography>
+              {mentee.network && mentee.network.length > 0 && (
+                <Stack direction="row" spacing={2}>
+                  {mentee.network.map((n) => (
+                    <Link key={n.link} href={n.link} target="_blank" rel="noopener">
+                      <LinkedInIcon fontSize="small" sx={{ color: '#0077b5' }} />
+                    </Link>
+                  ))}
+                </Stack>
+              )}
+            </Stack>
+            <Stack direction="row" spacing={1} alignItems="center" color="text.secondary">
+              <WorkIcon fontSize="small" />
+              <Typography variant="body2">{mentee.position || 'N/A'}</Typography>
+            </Stack>
+            <Stack direction="row" spacing={1} alignItems="center" color="text.secondary">
+              <BusinessIcon fontSize="small" />
+              <Typography variant="body2">{mentee.companyName || 'N/A'}</Typography>
+            </Stack>
+            <Stack direction="row" spacing={1} alignItems="center" color="text.secondary">
+              <PublicIcon fontSize="small" />
+              <Typography variant="body2">{location || 'N/A'}</Typography>
+            </Stack>
+          </Box>
+          <IconButton onClick={() => setExpand(!expanded)}>
+            {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+          </IconButton>
+        </Stack>
+
+        <Collapse in={expanded} timeout="auto" unmountOnExit>
+          <Box sx={{ mt: 2 }}>
+            <Divider sx={{ mb: 2 }} />
+
+            <Typography variant="subtitle2" gutterBottom>
+              Bio
+            </Typography>
+            <Typography variant="body2" color="text.secondary" paragraph>
+              {mentee.bio || 'No bio provided.'}
+            </Typography>
+
+            <Grid2 container spacing={2}>
+              <Grid item xs={12} md={6}>
+                <Typography variant="subtitle2" gutterBottom>
+                  Skills & Proficiency
+                </Typography>
+                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                  {mentee.skills?.areas?.map((a) => (
+                    <Chip
+                      key={a.technicalArea}
+                      label={`${a.technicalArea.replace(/_/g, ' ')} (${a.proficiencyLevel})`}
+                      size="small"
+                    />
+                  ))}
+                </Stack>
+              </Grid>
+
+              <Box sx={{ mt: 1 }}>
+                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                  {mentee.skills?.mentorshipFocus?.map((f) => (
+                    <Chip
+                      key={f}
+                      label={f.replace(/_/g, ' ')}
+                      size="small"
+                      color="info"
+                      variant="outlined"
+                    />
+                  ))}
+                </Stack>
+              </Box>
+
+              <Grid item xs={12} md={6}>
+                <Typography variant="subtitle2" gutterBottom>
+                  Languages
+                </Typography>
+                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                  {mentee.spokenLanguages?.map((l) => (
+                    <Chip key={l} label={l} size="small" icon={<LanguageIcon />} />
+                  ))}
+                </Stack>
+              </Grid>
+
+              <Box sx={{ mt: 2 }}>
+                <Typography variant="body2">
+                  <strong>Available hours/month:</strong> {mentee.availableHsMonth || 'N/A'}
+                </Typography>
+              </Box>
+            </Grid2>
+          </Box>
+        </Collapse>
+      </CardContent>
+    </Card>
+  );
+}

--- a/admin-wcc-app/components/mentorship/MentorApplicationsPanel.tsx
+++ b/admin-wcc-app/components/mentorship/MentorApplicationsPanel.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import { Alert, Box, CircularProgress, Divider, Typography } from '@mui/material';
+import { getMenteeApplications } from '@/services/mentorshipService';
+import { MenteeApplicationItem } from '@/types/mentorship';
+import MenteeApplicationCard from './MenteeApplicationCard';
+
+interface MentorApplicationsPanelProps {
+  mentorId: number;
+  cycleId: number;
+  token: string;
+}
+
+const ALL_STATUSES = [
+  'PENDING',
+  'MENTOR_REVIEWING',
+  'MENTOR_ACCEPTED',
+  'MATCHED',
+  'MENTOR_DECLINED',
+  'REJECTED',
+  'DROPPED',
+  'EXPIRED',
+];
+
+export default function MentorApplicationsPanel({
+  mentorId,
+  cycleId,
+  token,
+}: MentorApplicationsPanelProps) {
+  const [applications, setApplications] = useState<MenteeApplicationItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!mentorId || !token) return;
+
+    setLoading(true);
+    setError(null);
+
+    getMenteeApplications(cycleId, ALL_STATUSES, token, mentorId)
+      .then(setApplications)
+      .catch((err) => setError(err.message || 'Failed to load applications'))
+      .finally(() => setLoading(false));
+  }, [mentorId, cycleId, token]);
+
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom>
+        Applications for Mentor #{mentorId}
+      </Typography>
+      <Divider sx={{ mb: 2 }} />
+
+      {loading && <CircularProgress />}
+      {error && <Alert severity="error">{error}</Alert>}
+
+      {!loading && !error && applications.length === 0 && (
+        <Typography color="text.secondary">No applications found for this mentor.</Typography>
+      )}
+
+      {applications.map((app) => (
+        <MenteeApplicationCard key={app.menteeId} application={app} showRejectionReason />
+      ))}
+    </Box>
+  );
+}

--- a/admin-wcc-app/components/mentorship/MentorInfoCard.tsx
+++ b/admin-wcc-app/components/mentorship/MentorInfoCard.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Avatar, Box, Card, CardContent, Stack, Typography } from '@mui/material';
+import {
+  Business as BusinessIcon,
+  Public as PublicIcon,
+  Work as WorkIcon,
+} from '@mui/icons-material';
+import { MentorItem } from '@/types/mentor';
+import SkillsSection from '@/components/mentors/SkillsSection';
+import BioSection from '@/components/mentors/BioSection';
+
+interface MentorInfoCardProps {
+  mentor: MentorItem;
+}
+
+export default function MentorInfoCard({ mentor }: MentorInfoCardProps) {
+  const location = [mentor.city, mentor.country?.countryName].filter(Boolean).join(', ');
+
+  return (
+    <Card variant="outlined" sx={{ mb: 2, bgcolor: 'grey.50' }}>
+      <CardContent>
+        <Stack direction="row" spacing={2}>
+          <Avatar
+            src={
+              typeof mentor.images?.[0] === 'string'
+                ? mentor.images[0]
+                : (mentor.images?.[0] as any)?.path
+            }
+            alt={mentor.fullName}
+            sx={{ width: 64, height: 64 }}
+          >
+            {mentor.fullName.charAt(0)}
+          </Avatar>
+          <Box sx={{ flex: 1 }}>
+            <Typography variant="h6">{mentor.fullName}</Typography>
+            <Stack direction="row" spacing={1} alignItems="center" color="text.secondary">
+              <WorkIcon fontSize="small" />
+              <Typography variant="body2">{mentor.position || 'N/A'}</Typography>
+            </Stack>
+            <Stack direction="row" spacing={1} alignItems="center" color="text.secondary">
+              <BusinessIcon fontSize="small" />
+              <Typography variant="body2">{mentor.companyName || 'N/A'}</Typography>
+            </Stack>
+            <Stack direction="row" spacing={1} alignItems="center" color="text.secondary">
+              <PublicIcon fontSize="small" />
+              <Typography variant="body2">{location || 'N/A'}</Typography>
+            </Stack>
+          </Box>
+        </Stack>
+
+        <Box sx={{ mt: 1 }}>{mentor.bio && <BioSection bio={mentor.bio} />}</Box>
+        <Box sx={{ mt: 1 }}>{mentor.skills && <SkillsSection skills={mentor.skills} />}</Box>
+        <Box sx={{ mt: 2 }}>
+          <Stack direction="row" spacing={2}>
+            <Typography variant="body2">
+              <strong>Availability Long Term: </strong>
+              {mentor.menteeSection?.longTerm?.numMentee || 0} mentees,{' '}
+              {mentor.menteeSection?.longTerm?.hours || 0} hours
+            </Typography>
+          </Stack>
+        </Box>
+        <Box sx={{ mt: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            Ideal Mentee
+          </Typography>
+          <Stack direction="row" spacing={2}>
+            <Typography variant="body2">{mentor.menteeSection?.idealMentee}</Typography>
+          </Stack>
+        </Box>
+        <Box sx={{ mt: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            Additional
+          </Typography>
+          <Stack direction="row" spacing={2}>
+            <Typography variant="body2">{mentor.menteeSection?.additional}</Typography>
+          </Stack>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}

--- a/admin-wcc-app/lib/api.ts
+++ b/admin-wcc-app/lib/api.ts
@@ -32,10 +32,11 @@ export async function apiFetch<T>(
     credentials: 'include',
   });
   if (!res.ok) {
-    let message = `${res.status} ${res.statusText}`;
+    let message = `${res.status} ${res.statusText || 'Error'}`;
     try {
-      const data = (await res.json()) as { message?: string };
+      const data = (await res.json()) as { message?: string; error?: string };
       if (data.message) message = data.message;
+      else if (data.error) message = `${res.status} ${data.error}`;
     } catch {}
     throw new Error(message);
   }

--- a/admin-wcc-app/pages/admin/mentorship/index.tsx
+++ b/admin-wcc-app/pages/admin/mentorship/index.tsx
@@ -1,0 +1,152 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  Container,
+  Paper,
+  Tab,
+  Tabs,
+  Typography,
+} from '@mui/material';
+import AdminLayout from '@/components/AdminLayout';
+import { getMentorshipRecommendations } from '@/services/mentorshipService';
+import { MentorshipRecommendationResponse } from '@/types/mentorship';
+import { getStoredToken, isTokenExpired } from '@/lib/auth';
+import { useRouter } from 'next/router';
+import MatchCard from '@/components/mentorship/MatchCard';
+import MenteeCard from '@/components/mentorship/MenteeCard';
+import MentorInfoCard from '@/components/mentorship/MentorInfoCard';
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function CustomTabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box sx={{ py: 3 }}>{children}</Box>}
+    </div>
+  );
+}
+
+export default function MentorshipAdminPage() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<MentorshipRecommendationResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [tabValue, setTabValue] = useState(0);
+
+  useEffect(() => {
+    const token = getStoredToken();
+    if (!token || isTokenExpired(token)) {
+      router.replace('/login');
+      return;
+    }
+
+    getMentorshipRecommendations(token)
+      .then((res) => {
+        setData(respToRecommendationResponse(res));
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err.message || 'Failed to fetch recommendations');
+        setLoading(false);
+      });
+  }, [router]);
+
+  const respToRecommendationResponse = (resp: any): MentorshipRecommendationResponse => {
+    return {
+      matchedMentors: resp.matchedMentors || [],
+      notMatchedMentors: resp.notMatchedMentors || [],
+      notMatchedMentees: resp.notMatchedMentees || [],
+    };
+  };
+
+  const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
+    setTabValue(newValue);
+  };
+
+  if (loading) {
+    return (
+      <AdminLayout>
+        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8 }}>
+          <CircularProgress />
+        </Box>
+      </AdminLayout>
+    );
+  }
+
+  return (
+    <AdminLayout>
+      <Container maxWidth="xl">
+        <Typography variant="h4" gutterBottom sx={{ mt: 2, mb: 4 }}>
+          Mentorship - Manual Matching
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 4 }}>
+            {error}
+          </Alert>
+        )}
+
+        <Paper sx={{ width: '100%', mb: 4 }}>
+          <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+            <Tabs value={tabValue} onChange={handleTabChange} aria-label="mentorship tabs">
+              <Tab label={`Recommendations (${data?.matchedMentors.length || 0})`} />
+              <Tab label={`Unmatched Mentors (${data?.notMatchedMentors.length || 0})`} />
+              <Tab label={`Unmatched Mentees (${data?.notMatchedMentees.length || 0})`} />
+            </Tabs>
+          </Box>
+
+          <CustomTabPanel value={tabValue} index={0}>
+            {data?.matchedMentors.map((match, idx) => (
+              <MatchCard key={match.mentor.id || idx} match={match} />
+            ))}
+            {data?.matchedMentors.length === 0 && (
+              <Typography color="text.secondary" align="center">
+                No matches found.
+              </Typography>
+            )}
+          </CustomTabPanel>
+
+          <CustomTabPanel value={tabValue} index={1}>
+            <Box sx={{ maxWidth: 800, mx: 'auto' }}>
+              {data?.notMatchedMentors.map((mentor) => (
+                <MentorInfoCard key={mentor.id} mentor={mentor} />
+              ))}
+              {data?.notMatchedMentors.length === 0 && (
+                <Typography color="text.secondary" align="center">
+                  All mentors have recommendations.
+                </Typography>
+              )}
+            </Box>
+          </CustomTabPanel>
+
+          <CustomTabPanel value={tabValue} index={2}>
+            <Box sx={{ maxWidth: 800, mx: 'auto' }}>
+              {data?.notMatchedMentees.map((mentee) => (
+                <MenteeCard key={mentee.id} mentee={mentee} />
+              ))}
+              {data?.notMatchedMentees.length === 0 && (
+                <Typography color="text.secondary" align="center">
+                  All mentees have recommendations.
+                </Typography>
+              )}
+            </Box>
+          </CustomTabPanel>
+        </Paper>
+      </Container>
+    </AdminLayout>
+  );
+}

--- a/admin-wcc-app/pages/admin/mentorship/index.tsx
+++ b/admin-wcc-app/pages/admin/mentorship/index.tsx
@@ -10,13 +10,14 @@ import {
   Typography,
 } from '@mui/material';
 import AdminLayout from '@/components/AdminLayout';
-import { getMentorshipRecommendations } from '@/services/mentorshipService';
-import { MentorshipRecommendationResponse } from '@/types/mentorship';
+import { getMenteeApplications, getMentorshipRecommendations } from '@/services/mentorshipService';
+import { MenteeApplicationItem, MentorshipRecommendationResponse } from '@/types/mentorship';
 import { getStoredToken, isTokenExpired } from '@/lib/auth';
 import { useRouter } from 'next/router';
 import MatchCard from '@/components/mentorship/MatchCard';
 import MenteeCard from '@/components/mentorship/MenteeCard';
 import MentorInfoCard from '@/components/mentorship/MentorInfoCard';
+import MenteeApplicationCard from '@/components/mentorship/MenteeApplicationCard';
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -47,6 +48,13 @@ export default function MentorshipAdminPage() {
   const [error, setError] = useState<string | null>(null);
   const [tabValue, setTabValue] = useState(0);
 
+  // Application tabs state
+  const [pendingApps, setPendingApps] = useState<MenteeApplicationItem[]>([]);
+  const [acceptedApps, setAcceptedApps] = useState<MenteeApplicationItem[]>([]);
+  const [rejectedApps, setRejectedApps] = useState<MenteeApplicationItem[]>([]);
+  const [appsLoading, setAppsLoading] = useState<Record<number, boolean>>({});
+  const [appsError, setAppsError] = useState<Record<number, string>>({});
+
   useEffect(() => {
     const token = getStoredToken();
     if (!token || isTokenExpired(token)) {
@@ -65,6 +73,39 @@ export default function MentorshipAdminPage() {
       });
   }, [router]);
 
+  useEffect(() => {
+    if (tabValue < 3 || loading) return;
+
+    const token = getStoredToken();
+    if (!token) return;
+
+    const cycleId = 1; // Default to 1, in real scenario we would get it from data
+    const statusMap: Record<number, string[]> = {
+      3: ['PENDING', 'MENTOR_REVIEWING'],
+      4: ['MENTOR_ACCEPTED', 'MATCHED'],
+      5: ['MENTOR_DECLINED', 'REJECTED', 'DROPPED', 'EXPIRED'],
+    };
+
+    const setterMap: Record<
+      number,
+      React.Dispatch<React.SetStateAction<MenteeApplicationItem[]>>
+    > = {
+      3: setPendingApps,
+      4: setAcceptedApps,
+      5: setRejectedApps,
+    };
+
+    if (setterMap[tabValue]) {
+      setAppsLoading((prev) => ({ ...prev, [tabValue]: true }));
+      setAppsError((prev) => ({ ...prev, [tabValue]: '' }));
+
+      getMenteeApplications(cycleId, statusMap[tabValue], token)
+        .then(setterMap[tabValue])
+        .catch((err) => setAppsError((prev) => ({ ...prev, [tabValue]: err.message })))
+        .finally(() => setAppsLoading((prev) => ({ ...prev, [tabValue]: false })));
+    }
+  }, [tabValue, loading]);
+
   const respToRecommendationResponse = (resp: any): MentorshipRecommendationResponse => {
     return {
       matchedMentors: resp.matchedMentors || [],
@@ -75,6 +116,14 @@ export default function MentorshipAdminPage() {
 
   const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
     setTabValue(newValue);
+  };
+
+  const handleMenteeMatched = (mentorId: string | number, menteeId: number) => {
+    // Refresh recommendations to update applicationStatus and matched/unmatched lists
+    const token = getStoredToken();
+    if (token) {
+      getMentorshipRecommendations(token).then((res) => setData(respToRecommendationResponse(res)));
+    }
   };
 
   if (loading) {
@@ -106,12 +155,21 @@ export default function MentorshipAdminPage() {
               <Tab label={`Recommendations (${data?.matchedMentors.length || 0})`} />
               <Tab label={`Unmatched Mentors (${data?.notMatchedMentors.length || 0})`} />
               <Tab label={`Unmatched Mentees (${data?.notMatchedMentees.length || 0})`} />
+              <Tab label="Pending Review" />
+              <Tab label="Accepted" />
+              <Tab label="Rejected" />
             </Tabs>
           </Box>
 
           <CustomTabPanel value={tabValue} index={0}>
             {data?.matchedMentors.map((match, idx) => (
-              <MatchCard key={match.mentor.id || idx} match={match} />
+              <MatchCard
+                key={match.mentor.id || idx}
+                match={match}
+                cycleId={1}
+                token={getStoredToken() || ''}
+                onMenteeMatched={handleMenteeMatched}
+              />
             ))}
             {data?.matchedMentors.length === 0 && (
               <Typography color="text.secondary" align="center">
@@ -142,6 +200,57 @@ export default function MentorshipAdminPage() {
                 <Typography color="text.secondary" align="center">
                   All mentees have recommendations.
                 </Typography>
+              )}
+            </Box>
+          </CustomTabPanel>
+
+          <CustomTabPanel value={tabValue} index={3}>
+            <Box sx={{ maxWidth: 800, mx: 'auto' }}>
+              {appsLoading[3] ? (
+                <CircularProgress />
+              ) : appsError[3] ? (
+                <Alert severity="error">{appsError[3]}</Alert>
+              ) : (
+                pendingApps.map((app) => (
+                  <MenteeApplicationCard key={app.menteeId} application={app} />
+                ))
+              )}
+              {!appsLoading[3] && pendingApps.length === 0 && (
+                <Typography>No pending applications.</Typography>
+              )}
+            </Box>
+          </CustomTabPanel>
+
+          <CustomTabPanel value={tabValue} index={4}>
+            <Box sx={{ maxWidth: 800, mx: 'auto' }}>
+              {appsLoading[4] ? (
+                <CircularProgress />
+              ) : appsError[4] ? (
+                <Alert severity="error">{appsError[4]}</Alert>
+              ) : (
+                acceptedApps.map((app) => (
+                  <MenteeApplicationCard key={app.menteeId} application={app} />
+                ))
+              )}
+              {!appsLoading[4] && acceptedApps.length === 0 && (
+                <Typography>No accepted applications.</Typography>
+              )}
+            </Box>
+          </CustomTabPanel>
+
+          <CustomTabPanel value={tabValue} index={5}>
+            <Box sx={{ maxWidth: 800, mx: 'auto' }}>
+              {appsLoading[5] ? (
+                <CircularProgress />
+              ) : appsError[5] ? (
+                <Alert severity="error">{appsError[5]}</Alert>
+              ) : (
+                rejectedApps.map((app) => (
+                  <MenteeApplicationCard key={app.menteeId} application={app} showRejectionReason />
+                ))
+              )}
+              {!appsLoading[5] && rejectedApps.length === 0 && (
+                <Typography>No rejected applications.</Typography>
               )}
             </Box>
           </CustomTabPanel>

--- a/admin-wcc-app/services/mentorshipService.ts
+++ b/admin-wcc-app/services/mentorshipService.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from '@/lib/api';
-import { MentorshipRecommendationResponse } from '@/types/mentorship';
+import { MenteeApplicationItem, MentorshipRecommendationResponse } from '@/types/mentorship';
 
 const MENTORSHIP_ADMIN_PATH = '/api/platform/v1/admin/mentorship';
 const MENTEES_PATH = '/api/platform/v1/mentees';
@@ -7,10 +7,24 @@ const MENTEES_PATH = '/api/platform/v1/mentees';
 export async function getMentorshipRecommendations(
   token: string
 ): Promise<MentorshipRecommendationResponse> {
-  const CYCLE_ID = 1; // TODO - Change to pickup the current cycle
-
   return apiFetch<MentorshipRecommendationResponse>(
-    `${MENTORSHIP_ADMIN_PATH}/matches/recommendations/${CYCLE_ID}`,
+    `${MENTORSHIP_ADMIN_PATH}/matches/recommendations`,
+    { token }
+  );
+}
+
+export async function getMenteeApplications(
+  cycleId: number,
+  statuses: string[],
+  token: string,
+  mentorId?: number
+): Promise<MenteeApplicationItem[]> {
+  const params = new URLSearchParams({ status: statuses.join(',') });
+  if (mentorId !== undefined) {
+    params.append('mentorId', String(mentorId));
+  }
+  return apiFetch<MenteeApplicationItem[]>(
+    `${MENTORSHIP_ADMIN_PATH}/cycles/${cycleId}/applications?${params.toString()}`,
     { token }
   );
 }

--- a/admin-wcc-app/services/mentorshipService.ts
+++ b/admin-wcc-app/services/mentorshipService.ts
@@ -1,0 +1,30 @@
+import { apiFetch } from '@/lib/api';
+import { MentorshipRecommendationResponse } from '@/types/mentorship';
+
+const MENTORSHIP_ADMIN_PATH = '/api/platform/v1/admin/mentorship';
+const MENTEES_PATH = '/api/platform/v1/mentees';
+
+export async function getMentorshipRecommendations(
+  token: string
+): Promise<MentorshipRecommendationResponse> {
+  const CYCLE_ID = 1; // TODO - Change to pickup the current cycle
+
+  return apiFetch<MentorshipRecommendationResponse>(
+    `${MENTORSHIP_ADMIN_PATH}/matches/recommendations/${CYCLE_ID}`,
+    { token }
+  );
+}
+
+export async function createManualMatch(
+  menteeId: number | string,
+  cycleId: number | string,
+  mentorId: number | string,
+  token: string,
+  notes?: string
+): Promise<void> {
+  return apiFetch<void>(`${MENTEES_PATH}/${menteeId}/cycles/${cycleId}/assign-mentor`, {
+    method: 'POST',
+    body: { mentorId, notes },
+    token,
+  });
+}

--- a/admin-wcc-app/types/mentorship.ts
+++ b/admin-wcc-app/types/mentorship.ts
@@ -1,0 +1,58 @@
+import { MentorItem } from './mentor';
+
+export interface MenteeItem {
+  id: number;
+  fullName: string;
+  position?: string;
+  email?: string;
+  slackDisplayName?: string;
+  country?: {
+    countryCode: string;
+    countryName: string;
+  };
+  city?: string;
+  companyName?: string;
+  memberTypes?: string[];
+  images?: {
+    path: string;
+    alt: string;
+    type: string;
+  }[];
+  network?: {
+    type: string;
+    link: string;
+  }[];
+  isWomen?: boolean;
+  profileStatus?: string;
+  skills?: {
+    yearsExperience?: number;
+    areas?: {
+      technicalArea: string;
+      proficiencyLevel: string;
+    }[];
+    languages?: {
+      language: string;
+      proficiencyLevel: string;
+    }[];
+    mentorshipFocus?: string[];
+  };
+  bio?: string;
+  spokenLanguages?: string[];
+  availableHsMonth?: number;
+}
+
+export interface MenteeMatchSuggestion {
+  mentee: MenteeItem;
+  score: number;
+}
+
+export interface MentorMatches {
+  mentor: MentorItem;
+  mentees: MenteeMatchSuggestion[];
+}
+
+export interface MentorshipRecommendationResponse {
+  matchedMentors: MentorMatches[];
+  notMatchedMentors: MentorItem[];
+  notMatchedMentees: MenteeItem[];
+}

--- a/admin-wcc-app/types/mentorship.ts
+++ b/admin-wcc-app/types/mentorship.ts
@@ -44,6 +44,16 @@ export interface MenteeItem {
 export interface MenteeMatchSuggestion {
   mentee: MenteeItem;
   score: number;
+  applicationStatus?: string | null;
+}
+
+export interface MenteeApplicationItem {
+  menteeId: number;
+  mentee: MenteeItem;
+  mentorId?: number;
+  status: string;
+  rejectionReason?: string;
+  appliedAt?: string;
 }
 
 export interface MentorMatches {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-aop")
+    implementation("org.springframework.boot:spring-boot-starter-cache")
+    implementation("com.github.ben-manes.caffeine:caffeine")
     implementation("org.bouncycastle:bcprov-jdk18on:1.78.1")
     implementation("org.postgresql:postgresql:42.7.2")
     implementation("org.flywaydb:flyway-core")

--- a/src/main/java/com/wcc/platform/configuration/CacheConfig.java
+++ b/src/main/java/com/wcc/platform/configuration/CacheConfig.java
@@ -1,0 +1,30 @@
+package com.wcc.platform.configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.concurrent.TimeUnit;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Configuration for application-level caching using Caffeine. */
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+  /**
+   * Configures a CacheManager using Caffeine with default settings for mentorship-related data.
+   *
+   * @return the configured CacheManager
+   */
+  @Bean
+  public CacheManager cacheManager() {
+    final CaffeineCacheManager cacheManager =
+        new CaffeineCacheManager(
+            "mentorsAvailable", "mentorsStatus", "unmatchedMentees", "menteeApplications");
+    cacheManager.setCaffeine(
+        Caffeine.newBuilder().expireAfterWrite(20, TimeUnit.MINUTES).maximumSize(500));
+    return cacheManager;
+  }
+}

--- a/src/main/java/com/wcc/platform/configuration/GlobalExceptionHandler.java
+++ b/src/main/java/com/wcc/platform/configuration/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@ import com.wcc.platform.domain.exceptions.InvalidTokenException;
 import com.wcc.platform.domain.exceptions.MemberNotFoundException;
 import com.wcc.platform.domain.exceptions.MenteeNotSavedException;
 import com.wcc.platform.domain.exceptions.MenteeRegistrationLimitException;
+import com.wcc.platform.domain.exceptions.MentorCapacityExceededException;
 import com.wcc.platform.domain.exceptions.MentorNotFoundException;
 import com.wcc.platform.domain.exceptions.MentorStatusException;
 import com.wcc.platform.domain.exceptions.MentorshipCycleClosedException;
@@ -120,11 +121,14 @@ public class GlobalExceptionHandler {
     return new ResponseEntity<>(errorDetails, HttpStatus.CONFLICT);
   }
 
-  /** Receive MentorStatusException and return {@link HttpStatus#CONFLICT}. */
-  @ExceptionHandler(MentorStatusException.class)
+  /**
+   * Receive MentorStatusException or MentorCapacityExceededException and return {@link
+   * HttpStatus#CONFLICT}.
+   */
+  @ExceptionHandler({MentorStatusException.class, MentorCapacityExceededException.class})
   @ResponseStatus(HttpStatus.CONFLICT)
   public ResponseEntity<ErrorDetails> handleMentorStatus(
-      final MentorStatusException ex, final WebRequest request) {
+      final RuntimeException ex, final WebRequest request) {
     final var errorDetails =
         new ErrorDetails(
             HttpStatus.CONFLICT.value(), ex.getMessage(), request.getDescription(false));

--- a/src/main/java/com/wcc/platform/configuration/security/RequiresRole.java
+++ b/src/main/java/com/wcc/platform/configuration/security/RequiresRole.java
@@ -6,10 +6,16 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/** Annotation to enforce role-based access control on methods or classes. */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 public @interface RequiresRole {
+
+  /** The roles required to access the annotated method or class. */
   RoleType[] value();
 
+  /**
+   * Defines the logical operator to apply when multiple roles are specified. By default, it uses OR
+   */
   LogicalOperator operator() default LogicalOperator.OR;
 }

--- a/src/main/java/com/wcc/platform/controller/MentorshipAdminMatchesController.java
+++ b/src/main/java/com/wcc/platform/controller/MentorshipAdminMatchesController.java
@@ -7,10 +7,11 @@ import com.wcc.platform.domain.platform.mentorship.CycleStatus;
 import com.wcc.platform.domain.platform.mentorship.MatchCancelRequest;
 import com.wcc.platform.domain.platform.mentorship.MentorshipCycleEntity;
 import com.wcc.platform.domain.platform.mentorship.MentorshipMatch;
+import com.wcc.platform.domain.platform.mentorship.recommendation.MentorshipRecommendationResponse;
 import com.wcc.platform.domain.platform.type.RoleType;
 import com.wcc.platform.repository.MentorshipCycleRepository;
-import com.wcc.platform.service.MenteeService;
 import com.wcc.platform.service.MentorshipMatchingService;
+import com.wcc.platform.service.MentorshipRecommendationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -27,7 +28,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -43,9 +43,23 @@ public class MentorshipAdminMatchesController {
 
   private final MentorshipMatchingService matchingService;
   private final MentorshipCycleRepository cycleRepository;
-  private final MenteeService menteeService;
+  private final MentorshipRecommendationService recommendationService;
 
   // ==================== Match Management ====================
+
+  /**
+   * API to get suggested mentee matches for unmatched mentors.
+   *
+   * @return Recommended matches
+   */
+  @GetMapping("/matches/recommendations/{cycleId}")
+  //  @RequiresRole({RoleType.ADMIN})
+  @Operation(summary = "Get suggested mentee matches for unmatched mentors")
+  public ResponseEntity<MentorshipRecommendationResponse> getMatchRecommendations(
+      @Parameter(description = "Cycle ID") @PathVariable final Long cycleId) {
+    final var recommendations = recommendationService.getRecommendations(cycleId);
+    return ResponseEntity.ok(recommendations);
+  }
 
   /**
    * API for admin to confirm a match from an accepted application. This creates the official
@@ -57,7 +71,6 @@ public class MentorshipAdminMatchesController {
   @PostMapping("/matches/confirm/{applicationId}")
   @RequiresPermission(Permission.MATCH_MANAGE)
   @Operation(summary = "Admin confirms a mentorship match from accepted application")
-  @ResponseStatus(HttpStatus.CREATED)
   public ResponseEntity<MentorshipMatch> confirmMatch(
       @Parameter(description = "Application ID to confirm as match") @PathVariable
           final Long applicationId) {
@@ -74,7 +87,6 @@ public class MentorshipAdminMatchesController {
   @GetMapping("/matches")
   @RequiresPermission(Permission.MATCH_MANAGE)
   @Operation(summary = "Get all matches for a cycle")
-  @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<List<MentorshipMatch>> getCycleMatches(
       @Parameter(description = "Cycle ID") @RequestParam final Long cycleId) {
     final List<MentorshipMatch> matches = matchingService.getCycleMatches(cycleId);
@@ -91,7 +103,6 @@ public class MentorshipAdminMatchesController {
   @PatchMapping("/matches/{matchId}/complete")
   @RequiresPermission(Permission.MATCH_MANAGE)
   @Operation(summary = "Complete a mentorship match")
-  @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<MentorshipMatch> completeMatch(
       @Parameter(description = "Match ID") @PathVariable final Long matchId,
       @Parameter(description = "Completion notes") @RequestParam(required = false)
@@ -110,7 +121,6 @@ public class MentorshipAdminMatchesController {
   @PatchMapping("/matches/{matchId}/cancel")
   @RequiresPermission(Permission.MATCH_MANAGE)
   @Operation(summary = "Cancel a mentorship match")
-  @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<MentorshipMatch> cancelMatch(
       @Parameter(description = "Match ID") @PathVariable final Long matchId,
       @Valid @RequestBody final MatchCancelRequest request) {
@@ -128,7 +138,6 @@ public class MentorshipAdminMatchesController {
   @PatchMapping("/matches/{matchId}/increment-session")
   @RequiresPermission(Permission.MATCH_MANAGE)
   @Operation(summary = "Increment session count for a match")
-  @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<MentorshipMatch> incrementSessionCount(
       @Parameter(description = "Match ID") @PathVariable final Long matchId) {
     final MentorshipMatch updated = matchingService.incrementSessionCount(matchId);
@@ -145,7 +154,6 @@ public class MentorshipAdminMatchesController {
   @GetMapping("/cycles/current")
   @RequiresRole({RoleType.ADMIN, RoleType.MENTORSHIP_ADMIN})
   @Operation(summary = "Get the currently open mentorship cycle")
-  @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<MentorshipCycleEntity> getCurrentCycle() {
     return cycleRepository
         .findOpenCycle()
@@ -162,7 +170,6 @@ public class MentorshipAdminMatchesController {
   @GetMapping("/cycles")
   @RequiresRole({RoleType.ADMIN, RoleType.MENTORSHIP_ADMIN})
   @Operation(summary = "Get cycles by status")
-  @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<List<MentorshipCycleEntity>> getCyclesByStatus(
       @Parameter(description = "Cycle status") @RequestParam final CycleStatus status) {
     final List<MentorshipCycleEntity> cycles = cycleRepository.findByStatus(status);
@@ -178,7 +185,6 @@ public class MentorshipAdminMatchesController {
   @GetMapping("/cycles/{cycleId}")
   @RequiresRole({RoleType.ADMIN, RoleType.MENTORSHIP_ADMIN})
   @Operation(summary = "Get a cycle by ID")
-  @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<MentorshipCycleEntity> getCycleById(
       @Parameter(description = "Cycle ID") @PathVariable final Long cycleId) {
     return cycleRepository
@@ -195,7 +201,6 @@ public class MentorshipAdminMatchesController {
   @GetMapping("/cycles/all")
   @RequiresRole({RoleType.ADMIN, RoleType.MENTORSHIP_ADMIN})
   @Operation(summary = "Get all mentorship cycles")
-  @ResponseStatus(HttpStatus.OK)
   public ResponseEntity<List<MentorshipCycleEntity>> getAllCycles() {
     final List<MentorshipCycleEntity> cycles = cycleRepository.getAll();
     return ResponseEntity.ok(cycles);

--- a/src/main/java/com/wcc/platform/controller/MentorshipAdminMatchesController.java
+++ b/src/main/java/com/wcc/platform/controller/MentorshipAdminMatchesController.java
@@ -3,13 +3,16 @@ package com.wcc.platform.controller;
 import com.wcc.platform.configuration.security.RequiresPermission;
 import com.wcc.platform.configuration.security.RequiresRole;
 import com.wcc.platform.domain.auth.Permission;
+import com.wcc.platform.domain.platform.mentorship.ApplicationStatus;
 import com.wcc.platform.domain.platform.mentorship.CycleStatus;
 import com.wcc.platform.domain.platform.mentorship.MatchCancelRequest;
+import com.wcc.platform.domain.platform.mentorship.MenteeApplicationAdminResponse;
 import com.wcc.platform.domain.platform.mentorship.MentorshipCycleEntity;
 import com.wcc.platform.domain.platform.mentorship.MentorshipMatch;
 import com.wcc.platform.domain.platform.mentorship.recommendation.MentorshipRecommendationResponse;
 import com.wcc.platform.domain.platform.type.RoleType;
 import com.wcc.platform.repository.MentorshipCycleRepository;
+import com.wcc.platform.service.MenteeWorkflowService;
 import com.wcc.platform.service.MentorshipMatchingService;
 import com.wcc.platform.service.MentorshipRecommendationService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,11 +42,13 @@ import org.springframework.web.bind.annotation.RestController;
 @SecurityRequirement(name = "apiKey")
 @Tag(name = "Platform: Mentorship Admin", description = "Admin endpoints for mentorship management")
 @RequiredArgsConstructor
+@SuppressWarnings("PMD.ExcessiveImports")
 public class MentorshipAdminMatchesController {
 
   private final MentorshipMatchingService matchingService;
   private final MentorshipCycleRepository cycleRepository;
   private final MentorshipRecommendationService recommendationService;
+  private final MenteeWorkflowService workflowService;
 
   // ==================== Match Management ====================
 
@@ -52,13 +57,38 @@ public class MentorshipAdminMatchesController {
    *
    * @return Recommended matches
    */
-  @GetMapping("/matches/recommendations/{cycleId}")
-  //  @RequiresRole({RoleType.ADMIN})
-  @Operation(summary = "Get suggested mentee matches for unmatched mentors")
-  public ResponseEntity<MentorshipRecommendationResponse> getMatchRecommendations(
-      @Parameter(description = "Cycle ID") @PathVariable final Long cycleId) {
-    final var recommendations = recommendationService.getRecommendations(cycleId);
+  @GetMapping("/matches/recommendations")
+  @RequiresRole({RoleType.ADMIN, RoleType.LEADER})
+  @Operation(
+      summary = "Get suggested mentee matches for unmatched mentors",
+      security = {@SecurityRequirement(name = "bearerAuth")})
+  public ResponseEntity<MentorshipRecommendationResponse> getMatchRecommendations() {
+    final var recommendations = recommendationService.getRecommendations();
     return ResponseEntity.ok(recommendations);
+  }
+
+  /**
+   * API to get mentee applications for a specific cycle and statuses.
+   *
+   * @param cycleId the cycle ID
+   * @param status list of application statuses to filter by
+   * @param mentorId optional mentor ID filter
+   * @return list of mentee applications
+   */
+  @GetMapping("/cycles/{cycleId}/applications")
+  @RequiresRole({RoleType.ADMIN, RoleType.MENTORSHIP_ADMIN})
+  @Operation(
+      summary = "Get mentee applications for a specific cycle and statuses",
+      security = {@SecurityRequirement(name = "bearerAuth")})
+  public ResponseEntity<List<MenteeApplicationAdminResponse>> getApplications(
+      @Parameter(description = "Cycle ID") @PathVariable final Long cycleId,
+      @Parameter(description = "Application statuses") @RequestParam
+          final List<ApplicationStatus> status,
+      @Parameter(description = "Mentor ID filter") @RequestParam(required = false)
+          final Long mentorId) {
+
+    final var applications = workflowService.getApplicationsForAdmin(cycleId, status, mentorId);
+    return ResponseEntity.ok(applications);
   }
 
   /**

--- a/src/main/java/com/wcc/platform/domain/exceptions/ApplicationMenteeWorkflowException.java
+++ b/src/main/java/com/wcc/platform/domain/exceptions/ApplicationMenteeWorkflowException.java
@@ -7,6 +7,10 @@ public class ApplicationMenteeWorkflowException extends RuntimeException {
     super(message);
   }
 
+  public ApplicationMenteeWorkflowException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
   public ApplicationMenteeWorkflowException(final Long applicationId) {
     super("Application is not allowed to be changed ID: " + applicationId);
   }

--- a/src/main/java/com/wcc/platform/domain/exceptions/DuplicateApplicationException.java
+++ b/src/main/java/com/wcc/platform/domain/exceptions/DuplicateApplicationException.java
@@ -3,7 +3,7 @@ package com.wcc.platform.domain.exceptions;
 /**
  * Exception thrown when a mentee attempts to submit a duplicate application.
  */
-public class DuplicateApplicationException extends RuntimeException {
+public class DuplicateApplicationException extends DuplicatedException {
 
     public DuplicateApplicationException(final String message) {
         super(message);

--- a/src/main/java/com/wcc/platform/domain/platform/mentorship/MatchStatus.java
+++ b/src/main/java/com/wcc/platform/domain/platform/mentorship/MatchStatus.java
@@ -4,57 +4,57 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 /**
- * Enum representing the status of a confirmed mentorship match.
- * Corresponds to the match_status enum in the database.
- * Tracks the lifecycle of a mentor-mentee pairing from activation to completion.
+ * Enum representing the status of a confirmed mentorship match. Corresponds to the match_status
+ * enum in the database. Tracks the lifecycle of a mentor-mentee pairing from activation to
+ * completion.
  */
 @Getter
 @RequiredArgsConstructor
 public enum MatchStatus {
-    ACTIVE("active", "Currently active mentorship"),
-    COMPLETED("completed", "Successfully completed"),
-    CANCELLED("cancelled", "Cancelled by either party or admin"),
-    ON_HOLD("on_hold", "Temporarily paused");
+  ACTIVE("active", "Currently active mentorship"),
+  COMPLETED("completed", "Successfully completed"),
+  CANCELLED("cancelled", "Cancelled by either party or admin"),
+  ON_HOLD("on_hold", "Temporarily paused");
 
-    private final String value;
-    private final String description;
+  private final String value;
+  private final String description;
 
-    /**
-     * Get MatchStatus from database string value.
-     *
-     * @param value the database string value
-     * @return the corresponding MatchStatus
-     * @throws IllegalArgumentException if the value doesn't match any enum
-     */
-    public static MatchStatus fromValue(final String value) {
-        for (final MatchStatus status : values()) {
-            if (status.value.equalsIgnoreCase(value)) {
-                return status;
-            }
-        }
-        throw new IllegalArgumentException("Unknown match status: " + value);
+  /**
+   * Get MatchStatus from database string value.
+   *
+   * @param value the database string value
+   * @return the corresponding MatchStatus
+   * @throws IllegalArgumentException if the value doesn't match any enum
+   */
+  public static MatchStatus fromValue(final String value) {
+    for (final MatchStatus status : values()) {
+      if (status.value.equalsIgnoreCase(value)) {
+        return status;
+      }
     }
+    throw new IllegalArgumentException("Unknown match status: " + value);
+  }
 
-    /**
-     * Check if the match is in a terminal state (no longer active).
-     *
-     * @return true if status is terminal
-     */
-    public boolean isTerminal() {
-        return this == COMPLETED || this == CANCELLED;
-    }
+  /**
+   * Check if the match is in a terminal state (no longer active).
+   *
+   * @return true if status is terminal
+   */
+  public boolean isTerminal() {
+    return this == COMPLETED || this == CANCELLED;
+  }
 
-    /**
-     * Check if the match is currently ongoing.
-     *
-     * @return true if active or on hold
-     */
-    public boolean isOngoing() {
-        return this == ACTIVE || this == ON_HOLD;
-    }
+  /**
+   * Check if the match is currently ongoing.
+   *
+   * @return true if active or on hold
+   */
+  public boolean isOngoing() {
+    return this == ACTIVE || this == ON_HOLD;
+  }
 
-    @Override
-    public String toString() {
-        return value;
-    }
+  @Override
+  public String toString() {
+    return value;
+  }
 }

--- a/src/main/java/com/wcc/platform/domain/platform/mentorship/Mentee.java
+++ b/src/main/java/com/wcc/platform/domain/platform/mentorship/Mentee.java
@@ -19,6 +19,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 
+/** Represents a mentee in the platform. */
 @Getter
 @NoArgsConstructor
 @ToString(callSuper = true)
@@ -34,6 +35,7 @@ public class Mentee extends Member {
   @Min(1)
   private Integer availableHsMonth;
 
+  /** Mentee Builder. */
   @Builder(builderMethodName = "menteeBuilder")
   public Mentee(
       final Long id,

--- a/src/main/java/com/wcc/platform/domain/platform/mentorship/MenteeApplicationAdminResponse.java
+++ b/src/main/java/com/wcc/platform/domain/platform/mentorship/MenteeApplicationAdminResponse.java
@@ -1,0 +1,16 @@
+package com.wcc.platform.domain.platform.mentorship;
+
+import java.time.ZonedDateTime;
+
+/**
+ * Response DTO for admin view of mentee applications. Includes mentee profile, status, and
+ * rejection reason.
+ */
+public record MenteeApplicationAdminResponse(
+    Long applicationId,
+    Long menteeId,
+    Mentee mentee,
+    Long mentorId,
+    ApplicationStatus status,
+    String rejectionReason,
+    ZonedDateTime appliedAt) {}

--- a/src/main/java/com/wcc/platform/domain/platform/mentorship/recommendation/MenteeMatchSuggestion.java
+++ b/src/main/java/com/wcc/platform/domain/platform/mentorship/recommendation/MenteeMatchSuggestion.java
@@ -1,5 +1,6 @@
 package com.wcc.platform.domain.platform.mentorship.recommendation;
 
+import com.wcc.platform.domain.platform.mentorship.ApplicationStatus;
 import com.wcc.platform.domain.platform.mentorship.Mentee;
 
 /**
@@ -7,5 +8,10 @@ import com.wcc.platform.domain.platform.mentorship.Mentee;
  *
  * @param mentee the mentee object
  * @param score the match score
+ * @param applicationStatus the application status
  */
-public record MenteeMatchSuggestion(Mentee mentee, int score) {}
+public record MenteeMatchSuggestion(Mentee mentee, int score, ApplicationStatus applicationStatus) {
+  public MenteeMatchSuggestion(final Mentee mentee, final int score) {
+    this(mentee, score, null);
+  }
+}

--- a/src/main/java/com/wcc/platform/domain/platform/mentorship/recommendation/MenteeMatchSuggestion.java
+++ b/src/main/java/com/wcc/platform/domain/platform/mentorship/recommendation/MenteeMatchSuggestion.java
@@ -1,0 +1,11 @@
+package com.wcc.platform.domain.platform.mentorship.recommendation;
+
+import com.wcc.platform.domain.platform.mentorship.Mentee;
+
+/**
+ * DTO for a suggested mentee and their match score.
+ *
+ * @param mentee the mentee object
+ * @param score the match score
+ */
+public record MenteeMatchSuggestion(Mentee mentee, int score) {}

--- a/src/main/java/com/wcc/platform/domain/platform/mentorship/recommendation/MentorMatchSuggestion.java
+++ b/src/main/java/com/wcc/platform/domain/platform/mentorship/recommendation/MentorMatchSuggestion.java
@@ -1,0 +1,12 @@
+package com.wcc.platform.domain.platform.mentorship.recommendation;
+
+import com.wcc.platform.domain.platform.mentorship.Mentor;
+import java.util.List;
+
+/**
+ * DTO for a mentor and their suggested mentee matches with scores.
+ *
+ * @param mentor the mentor object
+ * @param mentees list of suggested mentee matches with scores
+ */
+public record MentorMatchSuggestion(Mentor mentor, List<MenteeMatchSuggestion> mentees) {}

--- a/src/main/java/com/wcc/platform/domain/platform/mentorship/recommendation/MentorshipRecommendationResponse.java
+++ b/src/main/java/com/wcc/platform/domain/platform/mentorship/recommendation/MentorshipRecommendationResponse.java
@@ -1,0 +1,17 @@
+package com.wcc.platform.domain.platform.mentorship.recommendation;
+
+import com.wcc.platform.domain.platform.mentorship.Mentee;
+import com.wcc.platform.domain.platform.mentorship.Mentor;
+import java.util.List;
+
+/**
+ * DTO for recommended matches response.
+ *
+ * @param matchedMentors list of mentors with their suggested mentee matches
+ * @param notMatchedMentors list of mentors who have no suggested matches
+ * @param notMatchedMentees list of mentees who are not suggested for any mentor
+ */
+public record MentorshipRecommendationResponse(
+    List<MentorMatchSuggestion> matchedMentors,
+    List<Mentor> notMatchedMentors,
+    List<Mentee> notMatchedMentees) {}

--- a/src/main/java/com/wcc/platform/repository/MenteeApplicationRepository.java
+++ b/src/main/java/com/wcc/platform/repository/MenteeApplicationRepository.java
@@ -71,7 +71,7 @@ public interface MenteeApplicationRepository extends CrudRepository<MenteeApplic
    * @return list of all applications
    */
   List<MenteeApplication> getAll();
-  
+
   /**
    * Counts the number of mentee applications for a specific mentee in a specific cycle.
    *
@@ -109,4 +109,24 @@ public interface MenteeApplicationRepository extends CrudRepository<MenteeApplic
    * @return List of applications
    */
   List<MenteeApplication> findByStatusAndCycle(ApplicationStatus status, Long cycleId);
+
+  /**
+   * Find applications by cycle and a list of statuses.
+   *
+   * @param cycleId the cycle ID
+   * @param statuses the list of statuses
+   * @return list of applications
+   */
+  List<MenteeApplication> findByCycleAndStatuses(Long cycleId, List<ApplicationStatus> statuses);
+
+  /**
+   * Find applications by cycle, statuses, and mentor.
+   *
+   * @param cycleId the cycle ID
+   * @param statuses the list of statuses
+   * @param mentorId the mentor ID
+   * @return list of applications
+   */
+  List<MenteeApplication> findByCycleAndStatusesAndMentor(
+      Long cycleId, List<ApplicationStatus> statuses, Long mentorId);
 }

--- a/src/main/java/com/wcc/platform/repository/MenteeRepository.java
+++ b/src/main/java/com/wcc/platform/repository/MenteeRepository.java
@@ -41,4 +41,12 @@ public interface MenteeRepository extends CrudRepository<Mentee, Long> {
    * @return list of mentees
    */
   List<Mentee> findAllById(List<Long> menteeIds);
+
+  /**
+   * Find mentees who are ACTIVE and have no active matches in the given cycle.
+   *
+   * @param cycleId the mentorship cycle ID
+   * @return list of unmatched mentees
+   */
+  List<Mentee> findUnmatchedMenteesForCycle(Long cycleId);
 }

--- a/src/main/java/com/wcc/platform/repository/MentorRepository.java
+++ b/src/main/java/com/wcc/platform/repository/MentorRepository.java
@@ -36,6 +36,14 @@ public interface MentorRepository extends CrudRepository<Mentor, Long> {
   Mentor updateProfileStatus(Long mentorId, ProfileStatus profileStatus);
 
   /**
+   * Return all mentors with a specific profile status.
+   *
+   * @param status profile status
+   * @return list of mentors
+   */
+  List<Mentor> findAvailableMentors(ProfileStatus status);
+
+  /**
    * Reject a mentor by setting their profile status to REJECTED and recording the reason.
    *
    * @param mentorId the mentor's unique identifier

--- a/src/main/java/com/wcc/platform/repository/MentorRepository.java
+++ b/src/main/java/com/wcc/platform/repository/MentorRepository.java
@@ -44,6 +44,14 @@ public interface MentorRepository extends CrudRepository<Mentor, Long> {
   List<Mentor> findAvailableMentors(ProfileStatus status);
 
   /**
+   * Find mentors who are ACTIVE and have remaining capacity in the given cycle.
+   *
+   * @param cycleId the mentorship cycle ID
+   * @return list of mentors with availability
+   */
+  List<Mentor> findMentorsWithAvailabilityForCycle(Long cycleId);
+
+  /**
    * Reject a mentor by setting their profile status to REJECTED and recording the reason.
    *
    * @param mentorId the mentor's unique identifier

--- a/src/main/java/com/wcc/platform/repository/MentorshipCycleRepository.java
+++ b/src/main/java/com/wcc/platform/repository/MentorshipCycleRepository.java
@@ -51,4 +51,11 @@ public interface MentorshipCycleRepository extends CrudRepository<MentorshipCycl
    * @return list of all cycles
    */
   List<MentorshipCycleEntity> getAll();
+
+  /**
+   * Find the most recent cycle, regardless of status.
+   *
+   * @return Optional containing the last cycle
+   */
+  Optional<MentorshipCycleEntity> findLastCompletedCycle();
 }

--- a/src/main/java/com/wcc/platform/repository/postgres/mentorship/PostgresMenteeApplicationRepository.java
+++ b/src/main/java/com/wcc/platform/repository/postgres/mentorship/PostgresMenteeApplicationRepository.java
@@ -7,9 +7,13 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -74,10 +78,22 @@ public class PostgresMenteeApplicationRepository implements MenteeApplicationRep
           + "WHERE application_status = ?::application_status "
           + "AND cycle_id = ?";
 
+  private static final String SQL_CYCLE_STATUSES =
+      "SELECT * FROM mentee_applications WHERE cycle_id = :cycleId "
+          + "AND application_status::text IN (:statuses) "
+          + "ORDER BY applied_at DESC";
+
+  private static final String SQL_STATUSES_MENTOR =
+      "SELECT * FROM mentee_applications WHERE cycle_id = :cycleId "
+          + "AND application_status::text IN (:statuses) "
+          + "AND mentor_id = :mentorId "
+          + "ORDER BY applied_at DESC";
+
   private static final String DELETE_BY_ID =
       "DELETE FROM mentee_applications WHERE application_id = ?";
 
   private final JdbcTemplate jdbc;
+  private final NamedParameterJdbcTemplate namedJdbc;
 
   @Transactional
   @Override
@@ -211,6 +227,29 @@ public class PostgresMenteeApplicationRepository implements MenteeApplicationRep
   public List<MenteeApplication> findByStatusAndCycle(
       final ApplicationStatus status, final Long cycleId) {
     return jdbc.query(SEL_BY_STS_CYC, (rs, rowNum) -> mapRow(rs), status.getValue(), cycleId);
+  }
+
+  @Override
+  @Cacheable(value = "menteeApplications", key = "{#cycleId, #statuses}")
+  public List<MenteeApplication> findByCycleAndStatuses(
+      final Long cycleId, final List<ApplicationStatus> statuses) {
+    final MapSqlParameterSource params = new MapSqlParameterSource();
+    params.addValue("cycleId", cycleId);
+    params.addValue("statuses", statuses.stream().map(s -> s.name().toLowerCase(Locale.ROOT)).toList());
+
+    return namedJdbc.query(SQL_CYCLE_STATUSES, params, (rs, rowNum) -> mapRow(rs));
+  }
+
+  @Override
+  @Cacheable(value = "menteeApplications", key = "{#cycleId, #statuses, #mentorId}")
+  public List<MenteeApplication> findByCycleAndStatusesAndMentor(
+      final Long cycleId, final List<ApplicationStatus> statuses, final Long mentorId) {
+    final MapSqlParameterSource params = new MapSqlParameterSource();
+    params.addValue("cycleId", cycleId);
+    params.addValue("statuses", statuses.stream().map(s -> s.name().toLowerCase(Locale.ROOT)).toList());
+    params.addValue("mentorId", mentorId);
+
+    return namedJdbc.query(SQL_STATUSES_MENTOR, params, (rs, rowNum) -> mapRow(rs));
   }
 
   private MenteeApplication mapRow(final ResultSet rs) throws SQLException {

--- a/src/main/java/com/wcc/platform/repository/postgres/mentorship/PostgresMenteeRepository.java
+++ b/src/main/java/com/wcc/platform/repository/postgres/mentorship/PostgresMenteeRepository.java
@@ -3,6 +3,7 @@ package com.wcc.platform.repository.postgres.mentorship;
 import com.wcc.platform.domain.cms.attributes.MentorshipFocusArea;
 import com.wcc.platform.domain.exceptions.MenteeNotSavedException;
 import com.wcc.platform.domain.platform.member.ProfileStatus;
+import com.wcc.platform.domain.platform.mentorship.MatchStatus;
 import com.wcc.platform.domain.platform.mentorship.Mentee;
 import com.wcc.platform.domain.platform.mentorship.Skills;
 import com.wcc.platform.repository.MemberRepository;
@@ -14,6 +15,8 @@ import jakarta.validation.Validator;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -50,6 +53,15 @@ public class PostgresMenteeRepository implements MenteeRepository {
       "DELETE FROM mentee_languages WHERE mentee_id = ?";
   private static final String DELETE_FOCUS_AREAS =
       "DELETE FROM mentee_mentorship_focus_areas WHERE mentee_id = ?";
+  private static final String SQL_UNMATCHED_MENTEES =
+      "SELECT m.* FROM mentees m "
+          + "LEFT JOIN mentorship_matches mm ON m.mentee_id = mm.mentee_id "
+          + "AND mm.cycle_id = ? AND mm.match_status = '"
+          + MatchStatus.ACTIVE.getValue()
+          + "' WHERE m.mentees_profile_status = "
+          + ProfileStatus.ACTIVE.getStatusId()
+          + " GROUP BY m.mentee_id "
+          + "HAVING COUNT(mm.match_id) = 0";
 
   private final JdbcTemplate jdbc;
   private final MenteeMapper menteeMapper;
@@ -151,11 +163,22 @@ public class PostgresMenteeRepository implements MenteeRepository {
 
   @Override
   public List<Mentee> findByStatus(final ProfileStatus status) {
-    return jdbc.query(SELECT_BY_STATUS, (rs, rowNum) -> menteeMapper.mapRowToMentee(rs),
-        status.getStatusId());
+    return jdbc.query(
+        SELECT_BY_STATUS, (rs, rowNum) -> menteeMapper.mapRowToMentee(rs), status.getStatusId());
   }
 
   @Override
+  @Cacheable(value = "unmatchedMentees", key = "#cycleId")
+  public List<Mentee> findUnmatchedMenteesForCycle(final Long cycleId) {
+    return jdbc.query(
+        SQL_UNMATCHED_MENTEES, (rs, rowNum) -> menteeMapper.mapRowToMentee(rs), cycleId);
+  }
+
+  @Override
+  @Transactional
+  @CacheEvict(
+      value = {"mentorsAvailable", "unmatchedMentees", "menteeApplications"},
+      allEntries = true)
   public Mentee updateProfileStatus(final Long menteeId, final ProfileStatus status) {
     jdbc.update(SQL_SET_STATUS, status.getStatusId(), menteeId);
     return findById(menteeId)

--- a/src/main/java/com/wcc/platform/repository/postgres/mentorship/PostgresMentorRepository.java
+++ b/src/main/java/com/wcc/platform/repository/postgres/mentorship/PostgresMentorRepository.java
@@ -4,6 +4,7 @@ import static com.wcc.platform.repository.postgres.constants.MentorConstants.COL
 
 import com.wcc.platform.domain.exceptions.MentorNotFoundException;
 import com.wcc.platform.domain.platform.member.ProfileStatus;
+import com.wcc.platform.domain.platform.mentorship.MatchStatus;
 import com.wcc.platform.domain.platform.mentorship.Mentor;
 import com.wcc.platform.repository.MemberRepository;
 import com.wcc.platform.repository.MentorRepository;
@@ -14,6 +15,8 @@ import jakarta.validation.Validator;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,6 +66,17 @@ public class PostgresMentorRepository implements MentorRepository {
   private static final String SQL_FIND_ID_BY_EMAIL =
       "SELECT mentors.mentor_id FROM mentors LEFT JOIN members ON mentors.mentor_id = members.id"
           + " WHERE members.email = ?";
+  private static final String SQL_MENTOR_CAPACITY =
+      "SELECT m.* FROM mentors m "
+          + "JOIN mentor_mentee_section mms ON m.mentor_id = mms.mentor_id "
+          + "LEFT JOIN mentorship_matches mm ON m.mentor_id = mm.mentor_id "
+          + "AND mm.cycle_id = ? AND mm.match_status = '"
+          + MatchStatus.ACTIVE.getValue()
+          + "' WHERE m.profile_status = "
+          + ProfileStatus.ACTIVE.getStatusId()
+          + " AND mms.long_term_num_mentee IS NOT NULL "
+          + "GROUP BY m.mentor_id, mms.long_term_num_mentee "
+          + "HAVING COUNT(mm.match_id) < mms.long_term_num_mentee";
 
   private final JdbcTemplate jdbc;
   private final MentorMapper mentorMapper;
@@ -102,13 +116,24 @@ public class PostgresMentorRepository implements MentorRepository {
   }
 
   @Override
+  @Cacheable(value = "mentorsStatus", key = "#status.getStatusId()")
   public List<Mentor> findAvailableMentors(final ProfileStatus status) {
     return jdbc.query(
         SQL_GET_BY_STATUS, (rs, rowNum) -> mentorMapper.mapRowToMentor(rs), status.getStatusId());
   }
 
   @Override
+  @Cacheable(value = "mentorsAvailable", key = "#cycleId")
+  public List<Mentor> findMentorsWithAvailabilityForCycle(final Long cycleId) {
+    return jdbc.query(
+        SQL_MENTOR_CAPACITY, (rs, rowNum) -> mentorMapper.mapRowToMentor(rs), cycleId);
+  }
+
+  @Override
   @Transactional
+  @CacheEvict(
+      value = {"mentorsAvailable", "unmatchedMentees", "menteeApplications"},
+      allEntries = true)
   public Mentor create(final Mentor mentor) {
     validate(mentor);
 

--- a/src/main/java/com/wcc/platform/repository/postgres/mentorship/PostgresMentorRepository.java
+++ b/src/main/java/com/wcc/platform/repository/postgres/mentorship/PostgresMentorRepository.java
@@ -59,6 +59,7 @@ public class PostgresMentorRepository implements MentorRepository {
       "SELECT mentors.* FROM mentors LEFT JOIN members ON mentors.mentor_id = members.id "
           + "WHERE members.email = ?";
   private static final String SQL_GET_ALL = "SELECT * FROM mentors";
+  private static final String SQL_GET_BY_STATUS = "SELECT * FROM mentors WHERE profile_status = ?";
   private static final String SQL_FIND_ID_BY_EMAIL =
       "SELECT mentors.mentor_id FROM mentors LEFT JOIN members ON mentors.mentor_id = members.id"
           + " WHERE members.email = ?";
@@ -98,6 +99,12 @@ public class PostgresMentorRepository implements MentorRepository {
           return null;
         },
         email);
+  }
+
+  @Override
+  public List<Mentor> findAvailableMentors(final ProfileStatus status) {
+    return jdbc.query(
+        SQL_GET_BY_STATUS, (rs, rowNum) -> mentorMapper.mapRowToMentor(rs), status.getStatusId());
   }
 
   @Override

--- a/src/main/java/com/wcc/platform/repository/postgres/mentorship/PostgresMentorshipCycleRepository.java
+++ b/src/main/java/com/wcc/platform/repository/postgres/mentorship/PostgresMentorshipCycleRepository.java
@@ -43,6 +43,9 @@ public class PostgresMentorshipCycleRepository implements MentorshipCycleReposit
   private static final String SELECT_BY_YEAR =
       "SELECT * FROM mentorship_cycles WHERE cycle_year = ? ORDER BY cycle_month";
 
+  private static final String SELECT_LAST_CYCLE =
+      "SELECT * FROM mentorship_cycles ORDER BY cycle_year DESC, cycle_month DESC LIMIT 1";
+
   private static final String INSERT_CYCLE =
       "INSERT INTO mentorship_cycles "
           + "(cycle_year, mentorship_type, cycle_month, registration_start_date, "
@@ -156,6 +159,12 @@ public class PostgresMentorshipCycleRepository implements MentorshipCycleReposit
   @Override
   public List<MentorshipCycleEntity> getAll() {
     return jdbc.query(SELECT_ALL, (rs, rowNum) -> mapRow(rs));
+  }
+
+  @Override
+  public Optional<MentorshipCycleEntity> findLastCompletedCycle() {
+    return jdbc.query(
+        SELECT_LAST_CYCLE, rs -> rs.next() ? Optional.of(mapRow(rs)) : Optional.empty());
   }
 
   private MentorshipCycleEntity mapRow(final ResultSet rs) throws SQLException {

--- a/src/main/java/com/wcc/platform/service/AuthService.java
+++ b/src/main/java/com/wcc/platform/service/AuthService.java
@@ -12,13 +12,13 @@ import com.wcc.platform.repository.MemberRepository;
 import com.wcc.platform.repository.UserAccountRepository;
 import com.wcc.platform.repository.UserTokenRepository;
 import java.security.SecureRandom;
-import java.util.EnumSet;
-import java.util.Objects;
-import java.util.Locale;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -246,7 +246,7 @@ public class AuthService {
       return (UserAccount.User) principal;
     }
 
-    throw new ForbiddenException("Invalid authentication principal");
+    throw new ForbiddenException("Invalid authentication");
   }
 
   /**

--- a/src/main/java/com/wcc/platform/service/EmailService.java
+++ b/src/main/java/com/wcc/platform/service/EmailService.java
@@ -50,7 +50,6 @@ public class EmailService {
    *
    * @param emailRequest the email request containing recipient, subject, body, and other details
    * @return EmailResponse containing the status of the email sending operation
-   * @throws EmailSendException if the email fails to send
    */
   public EmailResponse sendEmail(final EmailRequest emailRequest) {
     try {
@@ -70,6 +69,8 @@ public class EmailService {
         mimeMessageHelper.setReplyTo(emailRequest.getReplyTo());
       }
 
+      log.debug("Sending email content: {}", message);
+
       javaMailSender.send(message);
 
       log.info("Email sent successfully to: {}", emailRequest.getRecipients());
@@ -81,12 +82,13 @@ public class EmailService {
           .recipient(String.join(";", emailRequest.getRecipients()))
           .build();
     } catch (MessagingException | MailException e) {
-      log.error(
-          "Failed to send email to: {}. Error: {}",
-          emailRequest.getRecipients(),
-          e.getMessage(),
-          e);
-      throw new EmailSendException("Failed to send email to: " + emailRequest.getRecipients(), e);
+      final var errorMsg =
+          "Failed to send email to: "
+              + String.join(";", emailRequest.getRecipients())
+              + ". Error: "
+              + e.getMessage();
+      log.error(errorMsg, e);
+      throw new EmailSendException(errorMsg, e);
     }
   }
 

--- a/src/main/java/com/wcc/platform/service/MenteeService.java
+++ b/src/main/java/com/wcc/platform/service/MenteeService.java
@@ -281,7 +281,7 @@ public class MenteeService {
   }
 
   /**
-   * Get all mentees having applications pending for manual match for cycle
+   * Get all mentees having applications pending for manual match for cycle.
    *
    * @return list of mentees
    */

--- a/src/main/java/com/wcc/platform/service/MenteeWorkflowService.java
+++ b/src/main/java/com/wcc/platform/service/MenteeWorkflowService.java
@@ -9,6 +9,7 @@ import com.wcc.platform.domain.exceptions.MentorNotFoundException;
 import com.wcc.platform.domain.platform.mentorship.ApplicationStatus;
 import com.wcc.platform.domain.platform.mentorship.Mentee;
 import com.wcc.platform.domain.platform.mentorship.MenteeApplication;
+import com.wcc.platform.domain.platform.mentorship.MenteeApplicationAdminResponse;
 import com.wcc.platform.domain.platform.mentorship.MenteeApplicationResponse;
 import com.wcc.platform.domain.platform.mentorship.MentorshipCycleEntity;
 import com.wcc.platform.repository.MenteeApplicationRepository;
@@ -18,10 +19,12 @@ import com.wcc.platform.repository.MentorshipMatchRepository;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,13 +44,52 @@ public class MenteeWorkflowService {
   private final MentorshipService mentorshipService;
 
   /**
+   * Find applications for admin view by cycle, statuses, and optionally mentor.
+   *
+   * @param cycleId the cycle ID
+   * @param statuses the list of statuses
+   * @param mentorId the optional mentor ID
+   * @return list of applications with mentee profile
+   */
+  public List<MenteeApplicationAdminResponse> getApplicationsForAdmin(
+      final Long cycleId, final List<ApplicationStatus> statuses, final Long mentorId) {
+
+    final List<MenteeApplication> applications =
+        mentorId != null
+            ? applicationRepository.findByCycleAndStatusesAndMentor(cycleId, statuses, mentorId)
+            : applicationRepository.findByCycleAndStatuses(cycleId, statuses);
+
+    final Set<Long> menteeIds =
+        applications.stream().map(MenteeApplication::getMenteeId).collect(Collectors.toSet());
+
+    final Map<Long, Mentee> menteeMap =
+        menteeRepository.findAllById(List.copyOf(menteeIds)).stream()
+            .collect(Collectors.toMap(Mentee::getId, Function.identity()));
+
+    return applications.stream()
+        .map(
+            app ->
+                new MenteeApplicationAdminResponse(
+                    app.getApplicationId(),
+                    app.getMenteeId(),
+                    menteeMap.get(app.getMenteeId()),
+                    app.getMentorId(),
+                    app.getStatus(),
+                    app.getMentorResponse(),
+                    app.getAppliedAt()))
+        .toList();
+  }
+
+  /**
    * Admin approves a mentee application.
    *
    * @param applicationId the application ID
    * @return updated application
-   * @throws ApplicationNotFoundException if application not found
    */
   @Transactional
+  @CacheEvict(
+      value = {"mentorsAvailable", "unmatchedMentees", "menteeApplications"},
+      allEntries = true)
   public MenteeApplication approveApplication(final Long applicationId) {
     final MenteeApplication application = getApplicationOrThrow(applicationId);
 
@@ -81,6 +123,9 @@ public class MenteeWorkflowService {
    * @throws ApplicationNotFoundException if application not found
    */
   @Transactional
+  @CacheEvict(
+      value = {"mentorsAvailable", "unmatchedMentees", "menteeApplications"},
+      allEntries = true)
   public MenteeApplication rejectApplication(final Long applicationId, final String reason) {
     final MenteeApplication application = getApplicationOrThrow(applicationId);
 
@@ -118,6 +163,9 @@ public class MenteeWorkflowService {
    * @throws MentorCapacityExceededException if mentor at capacity
    */
   @Transactional
+  @CacheEvict(
+      value = {"mentorsAvailable", "unmatchedMentees", "menteeApplications"},
+      allEntries = true)
   public MenteeApplication acceptApplication(
       final Long applicationId, final String mentorResponse) {
 
@@ -153,6 +201,9 @@ public class MenteeWorkflowService {
    * @throws ApplicationNotFoundException if application not found
    */
   @Transactional
+  @CacheEvict(
+      value = {"mentorsAvailable", "unmatchedMentees", "menteeApplications"},
+      allEntries = true)
   public MenteeApplication declineApplication(final Long applicationId, final String reason) {
 
     final MenteeApplication application = getApplicationOrThrow(applicationId);
@@ -188,6 +239,9 @@ public class MenteeWorkflowService {
    * @throws ApplicationNotFoundException if application not found
    */
   @Transactional
+  @CacheEvict(
+      value = {"mentorsAvailable", "unmatchedMentees", "menteeApplications"},
+      allEntries = true)
   public MenteeApplication withdrawApplication(final Long applicationId, final String reason) {
 
     final MenteeApplication application = getApplicationOrThrow(applicationId);
@@ -274,6 +328,9 @@ public class MenteeWorkflowService {
    * @return the newly created application
    */
   @Transactional
+  @CacheEvict(
+      value = {"mentorsAvailable", "unmatchedMentees", "menteeApplications"},
+      allEntries = true)
   public MenteeApplication assignMentor(
       final Long menteeId, final Long cycleId, final Long mentorId, final String notes) {
     if (mentorshipService.getMentorRepository().findById(mentorId).isEmpty()) {
@@ -291,23 +348,7 @@ public class MenteeWorkflowService {
 
     checkMentorCapacity(mentorId, cycleId);
 
-    final var manualMatchApps =
-        applicationRepository.findByMenteeCycleAndStatusOrderByPriority(
-            menteeId, cycleId, ApplicationStatus.PENDING_MANUAL_MATCH);
-
-    final MenteeApplication manualMatchApp =
-        manualMatchApps.stream()
-            .findFirst()
-            .orElseThrow(
-                () ->
-                    new ContentNotFoundException(
-                        String.format(
-                            "No PENDING_MANUAL_MATCH application found for mentee %d in cycle %d",
-                            menteeId, cycleId)));
     final var reason = "Manual assignment by admin [" + notes + "]";
-
-    applicationRepository.updateStatus(
-        manualMatchApp.getApplicationId(), ApplicationStatus.REJECTED, reason);
 
     final MenteeApplication newApplication =
         MenteeApplication.builder()
@@ -317,21 +358,25 @@ public class MenteeWorkflowService {
             .priorityOrder(null)
             .status(ApplicationStatus.PENDING)
             .applicationMessage(reason)
+            .whyMentor(reason)
             .build();
 
-    final MenteeApplication created = applicationRepository.create(newApplication);
+    try {
+      final MenteeApplication created = applicationRepository.create(newApplication);
+      log.info("Manually assigned mentor {} to mentee {} in cycle {}", mentorId, menteeId, cycleId);
 
-    log.info("Manually assigned mentor {} to mentee {} in cycle {}", mentorId, menteeId, cycleId);
+      mentorshipService.getNotificationService().sendApplicationUpdate(Optional.empty(), created);
 
-    mentorshipService.getNotificationService().sendApplicationUpdate(Optional.empty(), created);
-
-    return created;
+      return created;
+    } catch (DuplicateApplicationException ex) {
+      throw new ApplicationMenteeWorkflowException(ex.getMessage(), ex);
+    }
   }
 
   /**
    * Confirms that no match was found for a mentee in the manual match queue. Sets the
    * PENDING_MANUAL_MATCH application to NO_MATCH_FOUND status. This is a terminal state - no
-   * further actions possible for this mentee in this cycle.
+   * further actions are possible for this mentee in this cycle.
    *
    * @param menteeId the mentee ID
    * @param cycleId the cycle ID

--- a/src/main/java/com/wcc/platform/service/MentorshipMatchingService.java
+++ b/src/main/java/com/wcc/platform/service/MentorshipMatchingService.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,6 +46,9 @@ public class MentorshipMatchingService {
    * @throws MentorCapacityExceededException if mentor at capacity
    */
   @Transactional
+  @CacheEvict(
+      value = {"mentorsAvailable", "unmatchedMentees", "menteeApplications"},
+      allEntries = true)
   public MentorshipMatch confirmMatch(final Long applicationId) {
     final MenteeApplication application =
         applicationRepository
@@ -107,6 +111,9 @@ public class MentorshipMatchingService {
    * @throws IllegalArgumentException if match not found
    */
   @Transactional
+  @CacheEvict(
+      value = {"mentorsAvailable", "unmatchedMentees", "menteeApplications"},
+      allEntries = true)
   public MentorshipMatch completeMatch(final Long matchId, final String notes) {
     final MentorshipMatch match = getMatchOrThrow(matchId);
 

--- a/src/main/java/com/wcc/platform/service/MentorshipRecommendationService.java
+++ b/src/main/java/com/wcc/platform/service/MentorshipRecommendationService.java
@@ -1,0 +1,160 @@
+package com.wcc.platform.service;
+
+import com.wcc.platform.domain.cms.attributes.MentorshipFocusArea;
+import com.wcc.platform.domain.cms.attributes.TechnicalArea;
+import com.wcc.platform.domain.platform.member.ProfileStatus;
+import com.wcc.platform.domain.platform.mentorship.LanguageProficiency;
+import com.wcc.platform.domain.platform.mentorship.Mentee;
+import com.wcc.platform.domain.platform.mentorship.Mentor;
+import com.wcc.platform.domain.platform.mentorship.MentorshipCycleEntity;
+import com.wcc.platform.domain.platform.mentorship.TechnicalAreaProficiency;
+import com.wcc.platform.domain.platform.mentorship.recommendation.MenteeMatchSuggestion;
+import com.wcc.platform.domain.platform.mentorship.recommendation.MentorMatchSuggestion;
+import com.wcc.platform.domain.platform.mentorship.recommendation.MentorshipRecommendationResponse;
+import com.wcc.platform.repository.MenteeRepository;
+import com.wcc.platform.repository.MentorRepository;
+import com.wcc.platform.repository.MentorshipCycleRepository;
+import com.wcc.platform.repository.MentorshipMatchRepository;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/** Service for generating mentorship recommendations based on mentor and mentee criteria. */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MentorshipRecommendationService {
+
+  private static final int LANGUAGE_SCORE = 50;
+  private static final int AREA_SCORE = 30;
+  private static final int FOCUS_SCORE = 10;
+
+  private final MentorRepository mentorRepository;
+  private final MenteeRepository menteeRepository;
+  private final MentorshipMatchRepository matchRepository;
+  private final MentorshipCycleRepository cycleRepository;
+
+  /**
+   * Get suggested mentee matches for each mentor who has availability.
+   *
+   * @param cycleId the ID of the mentorship cycle
+   * @return recommendation response
+   */
+  public MentorshipRecommendationResponse getRecommendations(final Long cycleId) {
+    final MentorshipCycleEntity cycle = cycleRepository.findById(cycleId).orElse(null);
+    if (cycle == null) {
+      log.warn("No open mentorship cycle found for recommendations");
+      return new MentorshipRecommendationResponse(List.of(), List.of(), List.of());
+    }
+
+    final var availableMentors =
+        mentorRepository.findAvailableMentors(ProfileStatus.ACTIVE).stream()
+            .filter(m -> m.getMenteeSection().longTerm() != null)
+            .filter(
+                m -> {
+                  final int currentMentees =
+                      matchRepository.countActiveMenteesByMentorAndCycle(m.getId(), cycleId);
+                  return currentMentees < m.getMenteeSection().longTerm().numMentee();
+                })
+            .toList();
+
+    final var unmatchedMentees =
+        menteeRepository.findByStatus(ProfileStatus.ACTIVE).stream()
+            .filter(m -> !matchRepository.isMenteeMatchedInCycle(m.getId(), cycleId))
+            .toList();
+
+    final List<MentorMatchSuggestion> matchedMentors =
+        availableMentors.stream()
+            .map(mentor -> buildMentorSuggestion(mentor, unmatchedMentees))
+            .filter(s -> !s.mentees().isEmpty())
+            .toList();
+
+    final Set<Long> suggestedMenteeIds =
+        matchedMentors.stream()
+            .flatMap(s -> s.mentees().stream())
+            .map(m -> m.mentee().getId())
+            .collect(Collectors.toSet());
+
+    final Set<Long> matchedMentorIds =
+        matchedMentors.stream().map(s -> s.mentor().getId()).collect(Collectors.toSet());
+
+    if (log.isDebugEnabled()) {
+      matchedMentors.forEach(
+          s -> log.debug("Mentor ID: {} Suggestions: {}", s.mentor().getId(), s.mentees()));
+    }
+
+    final var notMatchedMentors =
+        availableMentors.stream()
+            .filter(mentor -> !matchedMentorIds.contains(mentor.getId()))
+            .toList();
+
+    final var notMatchedMentees =
+        unmatchedMentees.stream()
+            .filter(mentee -> !suggestedMenteeIds.contains(mentee.getId()))
+            .toList();
+
+    return new MentorshipRecommendationResponse(
+        matchedMentors, notMatchedMentors, notMatchedMentees);
+  }
+
+  private MentorMatchSuggestion buildMentorSuggestion(
+      final Mentor mentor, final List<Mentee> unmatchedMentees) {
+    final List<MenteeMatchSuggestion> scoredMentees =
+        unmatchedMentees.stream()
+            .map(mentee -> new MenteeMatchSuggestion(mentee, calculateScore(mentor, mentee)))
+            .filter(s -> s.score() > 0)
+            .sorted(Comparator.comparingInt(MenteeMatchSuggestion::score).reversed())
+            .toList();
+    return new MentorMatchSuggestion(mentor, scoredMentees);
+  }
+
+  private int calculateScore(final Mentor mentor, final Mentee mentee) {
+    return scoreLanguages(mentor, mentee) + scoreAreas(mentor, mentee) + scoreFocus(mentor, mentee);
+  }
+
+  private int scoreLanguages(final Mentor mentor, final Mentee mentee) {
+    if (mentor.getSkills().languages().isEmpty()) {
+      return 0;
+    }
+    final var mentorLangs =
+        mentor.getSkills().languages().stream()
+            .map(LanguageProficiency::language)
+            .collect(Collectors.toSet());
+    return (int)
+            mentee.getSkills().languages().stream()
+                .map(LanguageProficiency::language)
+                .filter(mentorLangs::contains)
+                .count()
+        * LANGUAGE_SCORE;
+  }
+
+  private int scoreAreas(final Mentor mentor, final Mentee mentee) {
+    if (mentor.getSkills().areas().isEmpty()) {
+      return 0;
+    }
+    final Set<TechnicalArea> mentorAreas =
+        mentor.getSkills().areas().stream()
+            .map(TechnicalAreaProficiency::technicalArea)
+            .collect(Collectors.toSet());
+    return (int)
+            mentee.getSkills().areas().stream()
+                .map(TechnicalAreaProficiency::technicalArea)
+                .filter(mentorAreas::contains)
+                .count()
+        * AREA_SCORE;
+  }
+
+  private int scoreFocus(final Mentor mentor, final Mentee mentee) {
+    final var mentorFocus =
+        mentor.getSkills().mentorshipFocus().isEmpty()
+            ? EnumSet.noneOf(MentorshipFocusArea.class)
+            : EnumSet.copyOf(mentor.getSkills().mentorshipFocus());
+    return (int) mentee.getSkills().mentorshipFocus().stream().filter(mentorFocus::contains).count()
+        * FOCUS_SCORE;
+  }
+}

--- a/src/main/java/com/wcc/platform/service/MentorshipRecommendationService.java
+++ b/src/main/java/com/wcc/platform/service/MentorshipRecommendationService.java
@@ -2,19 +2,21 @@ package com.wcc.platform.service;
 
 import com.wcc.platform.domain.cms.attributes.MentorshipFocusArea;
 import com.wcc.platform.domain.cms.attributes.TechnicalArea;
-import com.wcc.platform.domain.platform.member.ProfileStatus;
+import com.wcc.platform.domain.platform.mentorship.ApplicationStatus;
 import com.wcc.platform.domain.platform.mentorship.LanguageProficiency;
 import com.wcc.platform.domain.platform.mentorship.Mentee;
+import com.wcc.platform.domain.platform.mentorship.MenteeApplication;
 import com.wcc.platform.domain.platform.mentorship.Mentor;
-import com.wcc.platform.domain.platform.mentorship.MentorshipCycleEntity;
+import com.wcc.platform.domain.platform.mentorship.MentorshipType;
 import com.wcc.platform.domain.platform.mentorship.TechnicalAreaProficiency;
 import com.wcc.platform.domain.platform.mentorship.recommendation.MenteeMatchSuggestion;
 import com.wcc.platform.domain.platform.mentorship.recommendation.MentorMatchSuggestion;
 import com.wcc.platform.domain.platform.mentorship.recommendation.MentorshipRecommendationResponse;
+import com.wcc.platform.repository.MenteeApplicationRepository;
 import com.wcc.platform.repository.MenteeRepository;
 import com.wcc.platform.repository.MentorRepository;
 import com.wcc.platform.repository.MentorshipCycleRepository;
-import com.wcc.platform.repository.MentorshipMatchRepository;
+import java.time.Year;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
@@ -36,41 +38,29 @@ public class MentorshipRecommendationService {
 
   private final MentorRepository mentorRepository;
   private final MenteeRepository menteeRepository;
-  private final MentorshipMatchRepository matchRepository;
   private final MentorshipCycleRepository cycleRepository;
+  private final MenteeApplicationRepository applicationRepository;
 
   /**
    * Get suggested mentee matches for each mentor who has availability.
    *
-   * @param cycleId the ID of the mentorship cycle
    * @return recommendation response
    */
-  public MentorshipRecommendationResponse getRecommendations(final Long cycleId) {
-    final MentorshipCycleEntity cycle = cycleRepository.findById(cycleId).orElse(null);
-    if (cycle == null) {
-      log.warn("No open mentorship cycle found for recommendations");
+  public MentorshipRecommendationResponse getRecommendations() {
+    final var cycle = cycleRepository.findByYearAndType(Year.now(), MentorshipType.LONG_TERM);
+    if (cycle.isEmpty()) {
+      log.warn("No mentorship cycle found for recommendations");
       return new MentorshipRecommendationResponse(List.of(), List.of(), List.of());
     }
 
-    final var availableMentors =
-        mentorRepository.findAvailableMentors(ProfileStatus.ACTIVE).stream()
-            .filter(m -> m.getMenteeSection().longTerm() != null)
-            .filter(
-                m -> {
-                  final int currentMentees =
-                      matchRepository.countActiveMenteesByMentorAndCycle(m.getId(), cycleId);
-                  return currentMentees < m.getMenteeSection().longTerm().numMentee();
-                })
-            .toList();
+    final Long cycleId = cycle.get().getCycleId();
 
-    final var unmatchedMentees =
-        menteeRepository.findByStatus(ProfileStatus.ACTIVE).stream()
-            .filter(m -> !matchRepository.isMenteeMatchedInCycle(m.getId(), cycleId))
-            .toList();
+    final var availableMentors = mentorRepository.findMentorsWithAvailabilityForCycle(cycleId);
+    final var unmatchedMentees = menteeRepository.findUnmatchedMenteesForCycle(cycleId);
 
     final List<MentorMatchSuggestion> matchedMentors =
         availableMentors.stream()
-            .map(mentor -> buildMentorSuggestion(mentor, unmatchedMentees))
+            .map(mentor -> buildMentorSuggestion(mentor, unmatchedMentees, cycleId))
             .filter(s -> !s.mentees().isEmpty())
             .toList();
 
@@ -103,14 +93,27 @@ public class MentorshipRecommendationService {
   }
 
   private MentorMatchSuggestion buildMentorSuggestion(
-      final Mentor mentor, final List<Mentee> unmatchedMentees) {
+      final Mentor mentor, final List<Mentee> unmatchedMentees, final Long cycleId) {
     final List<MenteeMatchSuggestion> scoredMentees =
         unmatchedMentees.stream()
-            .map(mentee -> new MenteeMatchSuggestion(mentee, calculateScore(mentor, mentee)))
+            .map(mentee -> buildMenteeSuggestion(mentor, mentee, cycleId))
             .filter(s -> s.score() > 0)
             .sorted(Comparator.comparingInt(MenteeMatchSuggestion::score).reversed())
             .toList();
     return new MentorMatchSuggestion(mentor, scoredMentees);
+  }
+
+  private MenteeMatchSuggestion buildMenteeSuggestion(
+      final Mentor mentor, final Mentee mentee, final Long cycleId) {
+    final int score = calculateScore(mentor, mentee);
+    final ApplicationStatus status =
+        applicationRepository.findByMenteeAndCycle(mentee.getId(), cycleId).stream()
+            .filter(app -> mentor.getId().equals(app.getMentorId()))
+            .findFirst()
+            .map(MenteeApplication::getStatus)
+            .orElse(null);
+
+    return new MenteeMatchSuggestion(mentee, score, status);
   }
 
   private int calculateScore(final Mentor mentor, final Mentee mentee) {

--- a/src/test/java/com/wcc/platform/service/MentorshipRecommendationServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/MentorshipRecommendationServiceTest.java
@@ -13,6 +13,7 @@ import com.wcc.platform.domain.platform.mentorship.LanguageProficiency;
 import com.wcc.platform.domain.platform.mentorship.Mentee;
 import com.wcc.platform.domain.platform.mentorship.Mentor;
 import com.wcc.platform.domain.platform.mentorship.MentorshipCycleEntity;
+import com.wcc.platform.domain.platform.mentorship.MentorshipType;
 import com.wcc.platform.domain.platform.mentorship.Skills;
 import com.wcc.platform.domain.platform.mentorship.TechnicalAreaProficiency;
 import com.wcc.platform.domain.platform.mentorship.recommendation.MentorshipRecommendationResponse;
@@ -22,7 +23,7 @@ import com.wcc.platform.repository.MenteeApplicationRepository;
 import com.wcc.platform.repository.MenteeRepository;
 import com.wcc.platform.repository.MentorRepository;
 import com.wcc.platform.repository.MentorshipCycleRepository;
-import com.wcc.platform.repository.MentorshipMatchRepository;
+import java.time.Year;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,7 +39,6 @@ class MentorshipRecommendationServiceTest {
 
   @Mock private MentorRepository mentorRepository;
   @Mock private MenteeRepository menteeRepository;
-  @Mock private MentorshipMatchRepository matchRepository;
   @Mock private MentorshipCycleRepository cycleRepository;
 
   @Mock private MenteeApplicationRepository applicationRepository;
@@ -48,12 +48,14 @@ class MentorshipRecommendationServiceTest {
   @BeforeEach
   void setUp() {
     final var cycle = MentorshipCycleEntity.builder().cycleId(1L).build();
-    when(cycleRepository.findOpenCycle()).thenReturn(Optional.of(cycle));
+    when(cycleRepository.findByYearAndType(Year.now(), MentorshipType.LONG_TERM))
+        .thenReturn(Optional.of(cycle));
   }
 
   @Test
   @DisplayName(
-      "Given active mentor and mentee with matching skills, when getRecommendations is called, then return suggestions with score")
+      "Given active mentor and mentee with matching skills, "
+          + "when getRecommendations is called, then return suggestions with score")
   void shouldReturnRecommendationsWhenSkillsMatch() {
     // Mentor with Java and Backend
     Mentor mentorBase = SetupMentorFactories.createMentorTest(1L, "Mentor Java", "mentor@test.com");
@@ -115,7 +117,8 @@ class MentorshipRecommendationServiceTest {
 
   @Test
   @DisplayName(
-      "Given mentor at capacity, when getRecommendations is called, then mentor is not included in suggestions")
+      "Given mentor at capacity, when getRecommendations is called, "
+          + "then mentor is not included in suggestions")
   void shouldNotRecommendWhenMentorAtCapacity() {
     when(mentorRepository.findMentorsWithAvailabilityForCycle(1L)).thenReturn(List.of());
     when(menteeRepository.findUnmatchedMenteesForCycle(1L)).thenReturn(List.of());
@@ -128,7 +131,8 @@ class MentorshipRecommendationServiceTest {
 
   @Test
   @DisplayName(
-      "Given mentee already matched, when getRecommendations is called, then mentee is not recommended")
+      "Given mentee already matched, when getRecommendations is called, "
+          + "then mentee is not recommended")
   void shouldNotRecommendWhenMenteeAlreadyMatched() {
     Mentor mentor = SetupMentorFactories.createMentorTest(1L, "Mentor Java", "mentor@test.com");
 

--- a/src/test/java/com/wcc/platform/service/MentorshipRecommendationServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/MentorshipRecommendationServiceTest.java
@@ -18,6 +18,7 @@ import com.wcc.platform.domain.platform.mentorship.TechnicalAreaProficiency;
 import com.wcc.platform.domain.platform.mentorship.recommendation.MentorshipRecommendationResponse;
 import com.wcc.platform.factories.SetupMenteeFactories;
 import com.wcc.platform.factories.SetupMentorFactories;
+import com.wcc.platform.repository.MenteeApplicationRepository;
 import com.wcc.platform.repository.MenteeRepository;
 import com.wcc.platform.repository.MentorRepository;
 import com.wcc.platform.repository.MentorshipCycleRepository;
@@ -40,12 +41,14 @@ class MentorshipRecommendationServiceTest {
   @Mock private MentorshipMatchRepository matchRepository;
   @Mock private MentorshipCycleRepository cycleRepository;
 
+  @Mock private MenteeApplicationRepository applicationRepository;
+
   @InjectMocks private MentorshipRecommendationService service;
 
   @BeforeEach
   void setUp() {
     final var cycle = MentorshipCycleEntity.builder().cycleId(1L).build();
-    when(cycleRepository.findById(1L)).thenReturn(Optional.of(cycle));
+    when(cycleRepository.findOpenCycle()).thenReturn(Optional.of(cycle));
   }
 
   @Test
@@ -94,12 +97,11 @@ class MentorshipRecommendationServiceTest {
                     List.of(MentorshipFocusArea.GROW_BEGINNER_TO_MID)))
             .build();
 
-    when(mentorRepository.findAvailableMentors(ProfileStatus.ACTIVE)).thenReturn(List.of(mentor));
-    when(menteeRepository.findByStatus(ProfileStatus.ACTIVE)).thenReturn(List.of(mentee));
-    when(matchRepository.countActiveMenteesByMentorAndCycle(anyLong(), anyLong())).thenReturn(0);
-    when(matchRepository.isMenteeMatchedInCycle(anyLong(), anyLong())).thenReturn(false);
+    when(mentorRepository.findMentorsWithAvailabilityForCycle(1L)).thenReturn(List.of(mentor));
+    when(menteeRepository.findUnmatchedMenteesForCycle(1L)).thenReturn(List.of(mentee));
+    when(applicationRepository.findByMenteeAndCycle(anyLong(), anyLong())).thenReturn(List.of());
 
-    MentorshipRecommendationResponse response = service.getRecommendations(1L);
+    MentorshipRecommendationResponse response = service.getRecommendations();
 
     assertThat(response.matchedMentors()).hasSize(1);
     assertThat(response.matchedMentors().getFirst().mentor().getId()).isEqualTo(1L);
@@ -115,32 +117,10 @@ class MentorshipRecommendationServiceTest {
   @DisplayName(
       "Given mentor at capacity, when getRecommendations is called, then mentor is not included in suggestions")
   void shouldNotRecommendWhenMentorAtCapacity() {
-    Mentor mentorBase = SetupMentorFactories.createMentorTest(1L, "Mentor Full", "mentor@test.com");
-    Mentor mentor =
-        Mentor.mentorBuilder()
-            .id(mentorBase.getId())
-            .fullName(mentorBase.getFullName())
-            .email(mentorBase.getEmail())
-            .profileStatus(ProfileStatus.ACTIVE)
-            .bio(mentorBase.getBio())
-            .skills(mentorBase.getSkills())
-            .menteeSection(mentorBase.getMenteeSection())
-            .build();
+    when(mentorRepository.findMentorsWithAvailabilityForCycle(1L)).thenReturn(List.of());
+    when(menteeRepository.findUnmatchedMenteesForCycle(1L)).thenReturn(List.of());
 
-    // Set capacity to 1
-    mentor
-        .getMenteeSection()
-        .longTerm()
-        .numMentee(); // this is record, so it might be final, let's see.
-
-    when(mentorRepository.findAvailableMentors(ProfileStatus.ACTIVE)).thenReturn(List.of(mentor));
-    when(menteeRepository.findByStatus(ProfileStatus.ACTIVE)).thenReturn(List.of());
-
-    // Assume capacity is 1 from SetupMentorFactories and it already has 1 match
-    int capacity = mentor.getMenteeSection().longTerm().numMentee();
-    when(matchRepository.countActiveMenteesByMentorAndCycle(1L, 1L)).thenReturn(capacity);
-
-    MentorshipRecommendationResponse response = service.getRecommendations(1L);
+    MentorshipRecommendationResponse response = service.getRecommendations();
 
     assertThat(response.matchedMentors()).isEmpty();
     assertThat(response.notMatchedMentors()).isEmpty();
@@ -151,14 +131,11 @@ class MentorshipRecommendationServiceTest {
       "Given mentee already matched, when getRecommendations is called, then mentee is not recommended")
   void shouldNotRecommendWhenMenteeAlreadyMatched() {
     Mentor mentor = SetupMentorFactories.createMentorTest(1L, "Mentor Java", "mentor@test.com");
-    Mentee mentee = SetupMenteeFactories.createMenteeTest(10L, "Mentee Java", "mentee@test.com");
 
-    when(mentorRepository.findAvailableMentors(ProfileStatus.ACTIVE)).thenReturn(List.of(mentor));
-    when(menteeRepository.findByStatus(ProfileStatus.ACTIVE)).thenReturn(List.of(mentee));
-    when(matchRepository.countActiveMenteesByMentorAndCycle(1L, 1L)).thenReturn(0);
-    when(matchRepository.isMenteeMatchedInCycle(10L, 1L)).thenReturn(true);
+    when(mentorRepository.findMentorsWithAvailabilityForCycle(1L)).thenReturn(List.of(mentor));
+    when(menteeRepository.findUnmatchedMenteesForCycle(1L)).thenReturn(List.of());
 
-    MentorshipRecommendationResponse response = service.getRecommendations(1L);
+    MentorshipRecommendationResponse response = service.getRecommendations();
 
     assertThat(response.matchedMentors()).isEmpty();
     assertThat(response.notMatchedMentors()).extracting(Mentor::getId).containsExactly(1L);
@@ -210,12 +187,11 @@ class MentorshipRecommendationServiceTest {
                     List.of(MentorshipFocusArea.SWITCH_TO_MANAGEMENT)))
             .build();
 
-    when(mentorRepository.findAvailableMentors(ProfileStatus.ACTIVE)).thenReturn(List.of(mentor));
-    when(menteeRepository.findByStatus(ProfileStatus.ACTIVE)).thenReturn(List.of(mentee));
-    when(matchRepository.countActiveMenteesByMentorAndCycle(1L, 1L)).thenReturn(0);
-    when(matchRepository.isMenteeMatchedInCycle(10L, 1L)).thenReturn(false);
+    when(mentorRepository.findMentorsWithAvailabilityForCycle(1L)).thenReturn(List.of(mentor));
+    when(menteeRepository.findUnmatchedMenteesForCycle(1L)).thenReturn(List.of(mentee));
+    when(applicationRepository.findByMenteeAndCycle(anyLong(), anyLong())).thenReturn(List.of());
 
-    MentorshipRecommendationResponse response = service.getRecommendations(1L);
+    MentorshipRecommendationResponse response = service.getRecommendations();
 
     assertThat(response.matchedMentors()).isEmpty();
     assertThat(response.notMatchedMentors()).extracting(Mentor::getId).containsExactly(1L);

--- a/src/test/java/com/wcc/platform/service/MentorshipRecommendationServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/MentorshipRecommendationServiceTest.java
@@ -1,0 +1,224 @@
+package com.wcc.platform.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.wcc.platform.domain.cms.attributes.CodeLanguage;
+import com.wcc.platform.domain.cms.attributes.MentorshipFocusArea;
+import com.wcc.platform.domain.cms.attributes.ProficiencyLevel;
+import com.wcc.platform.domain.cms.attributes.TechnicalArea;
+import com.wcc.platform.domain.platform.member.ProfileStatus;
+import com.wcc.platform.domain.platform.mentorship.LanguageProficiency;
+import com.wcc.platform.domain.platform.mentorship.Mentee;
+import com.wcc.platform.domain.platform.mentorship.Mentor;
+import com.wcc.platform.domain.platform.mentorship.MentorshipCycleEntity;
+import com.wcc.platform.domain.platform.mentorship.Skills;
+import com.wcc.platform.domain.platform.mentorship.TechnicalAreaProficiency;
+import com.wcc.platform.domain.platform.mentorship.recommendation.MentorshipRecommendationResponse;
+import com.wcc.platform.factories.SetupMenteeFactories;
+import com.wcc.platform.factories.SetupMentorFactories;
+import com.wcc.platform.repository.MenteeRepository;
+import com.wcc.platform.repository.MentorRepository;
+import com.wcc.platform.repository.MentorshipCycleRepository;
+import com.wcc.platform.repository.MentorshipMatchRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MentorshipRecommendationServiceTest {
+
+  @Mock private MentorRepository mentorRepository;
+  @Mock private MenteeRepository menteeRepository;
+  @Mock private MentorshipMatchRepository matchRepository;
+  @Mock private MentorshipCycleRepository cycleRepository;
+
+  @InjectMocks private MentorshipRecommendationService service;
+
+  @BeforeEach
+  void setUp() {
+    final var cycle = MentorshipCycleEntity.builder().cycleId(1L).build();
+    when(cycleRepository.findById(1L)).thenReturn(Optional.of(cycle));
+  }
+
+  @Test
+  @DisplayName(
+      "Given active mentor and mentee with matching skills, when getRecommendations is called, then return suggestions with score")
+  void shouldReturnRecommendationsWhenSkillsMatch() {
+    // Mentor with Java and Backend
+    Mentor mentorBase = SetupMentorFactories.createMentorTest(1L, "Mentor Java", "mentor@test.com");
+    Mentor mentor =
+        Mentor.mentorBuilder()
+            .id(mentorBase.getId())
+            .fullName(mentorBase.getFullName())
+            .email(mentorBase.getEmail())
+            .profileStatus(ProfileStatus.ACTIVE)
+            .menteeSection(mentorBase.getMenteeSection())
+            .bio(mentorBase.getBio())
+            .skills(
+                new Skills(
+                    5,
+                    List.of(
+                        new TechnicalAreaProficiency(
+                            TechnicalArea.BACKEND, ProficiencyLevel.ADVANCED)),
+                    List.of(new LanguageProficiency(CodeLanguage.JAVA, ProficiencyLevel.ADVANCED)),
+                    List.of(MentorshipFocusArea.GROW_BEGINNER_TO_MID)))
+            .build();
+
+    // Mentee with Java and Backend
+    Mentee menteeBase =
+        SetupMenteeFactories.createMenteeTest(10L, "Mentee Java", "mentee@test.com");
+    Mentee mentee =
+        Mentee.menteeBuilder()
+            .id(menteeBase.getId())
+            .fullName(menteeBase.getFullName())
+            .email(menteeBase.getEmail())
+            .profileStatus(ProfileStatus.ACTIVE)
+            .bio(menteeBase.getBio())
+            .spokenLanguages(List.of("English"))
+            .availableHsMonth(menteeBase.getAvailableHsMonth())
+            .skills(
+                new Skills(
+                    1,
+                    List.of(
+                        new TechnicalAreaProficiency(
+                            TechnicalArea.BACKEND, ProficiencyLevel.BEGINNER)),
+                    List.of(new LanguageProficiency(CodeLanguage.JAVA, ProficiencyLevel.BEGINNER)),
+                    List.of(MentorshipFocusArea.GROW_BEGINNER_TO_MID)))
+            .build();
+
+    when(mentorRepository.findAvailableMentors(ProfileStatus.ACTIVE)).thenReturn(List.of(mentor));
+    when(menteeRepository.findByStatus(ProfileStatus.ACTIVE)).thenReturn(List.of(mentee));
+    when(matchRepository.countActiveMenteesByMentorAndCycle(anyLong(), anyLong())).thenReturn(0);
+    when(matchRepository.isMenteeMatchedInCycle(anyLong(), anyLong())).thenReturn(false);
+
+    MentorshipRecommendationResponse response = service.getRecommendations(1L);
+
+    assertThat(response.matchedMentors()).hasSize(1);
+    assertThat(response.matchedMentors().getFirst().mentor().getId()).isEqualTo(1L);
+    assertThat(response.matchedMentors().getFirst().mentees()).hasSize(1);
+    assertThat(response.matchedMentors().getFirst().mentees().getFirst().mentee().getId())
+        .isEqualTo(10L);
+    assertThat(response.matchedMentors().getFirst().mentees().getFirst().score()).isGreaterThan(0);
+    assertThat(response.notMatchedMentors()).isEmpty();
+    assertThat(response.notMatchedMentees()).isEmpty();
+  }
+
+  @Test
+  @DisplayName(
+      "Given mentor at capacity, when getRecommendations is called, then mentor is not included in suggestions")
+  void shouldNotRecommendWhenMentorAtCapacity() {
+    Mentor mentorBase = SetupMentorFactories.createMentorTest(1L, "Mentor Full", "mentor@test.com");
+    Mentor mentor =
+        Mentor.mentorBuilder()
+            .id(mentorBase.getId())
+            .fullName(mentorBase.getFullName())
+            .email(mentorBase.getEmail())
+            .profileStatus(ProfileStatus.ACTIVE)
+            .bio(mentorBase.getBio())
+            .skills(mentorBase.getSkills())
+            .menteeSection(mentorBase.getMenteeSection())
+            .build();
+
+    // Set capacity to 1
+    mentor
+        .getMenteeSection()
+        .longTerm()
+        .numMentee(); // this is record, so it might be final, let's see.
+
+    when(mentorRepository.findAvailableMentors(ProfileStatus.ACTIVE)).thenReturn(List.of(mentor));
+    when(menteeRepository.findByStatus(ProfileStatus.ACTIVE)).thenReturn(List.of());
+
+    // Assume capacity is 1 from SetupMentorFactories and it already has 1 match
+    int capacity = mentor.getMenteeSection().longTerm().numMentee();
+    when(matchRepository.countActiveMenteesByMentorAndCycle(1L, 1L)).thenReturn(capacity);
+
+    MentorshipRecommendationResponse response = service.getRecommendations(1L);
+
+    assertThat(response.matchedMentors()).isEmpty();
+    assertThat(response.notMatchedMentors()).isEmpty();
+  }
+
+  @Test
+  @DisplayName(
+      "Given mentee already matched, when getRecommendations is called, then mentee is not recommended")
+  void shouldNotRecommendWhenMenteeAlreadyMatched() {
+    Mentor mentor = SetupMentorFactories.createMentorTest(1L, "Mentor Java", "mentor@test.com");
+    Mentee mentee = SetupMenteeFactories.createMenteeTest(10L, "Mentee Java", "mentee@test.com");
+
+    when(mentorRepository.findAvailableMentors(ProfileStatus.ACTIVE)).thenReturn(List.of(mentor));
+    when(menteeRepository.findByStatus(ProfileStatus.ACTIVE)).thenReturn(List.of(mentee));
+    when(matchRepository.countActiveMenteesByMentorAndCycle(1L, 1L)).thenReturn(0);
+    when(matchRepository.isMenteeMatchedInCycle(10L, 1L)).thenReturn(true);
+
+    MentorshipRecommendationResponse response = service.getRecommendations(1L);
+
+    assertThat(response.matchedMentors()).isEmpty();
+    assertThat(response.notMatchedMentors()).extracting(Mentor::getId).containsExactly(1L);
+    assertThat(response.notMatchedMentees()).isEmpty();
+  }
+
+  @Test
+  @DisplayName(
+      "Given no skills match, when getRecommendations is called, then return empty matches")
+  void shouldReturnEmptyWhenNoSkillsMatch() {
+    Mentor mentorBase = SetupMentorFactories.createMentorTest(1L, "Mentor Java", "mentor@test.com");
+    Mentor mentor =
+        Mentor.mentorBuilder()
+            .id(mentorBase.getId())
+            .fullName(mentorBase.getFullName())
+            .email(mentorBase.getEmail())
+            .profileStatus(ProfileStatus.ACTIVE)
+            .menteeSection(mentorBase.getMenteeSection())
+            .bio(mentorBase.getBio())
+            .skills(
+                new Skills(
+                    5,
+                    List.of(
+                        new TechnicalAreaProficiency(
+                            TechnicalArea.BACKEND, ProficiencyLevel.ADVANCED)),
+                    List.of(new LanguageProficiency(CodeLanguage.JAVA, ProficiencyLevel.ADVANCED)),
+                    List.of(MentorshipFocusArea.GROW_BEGINNER_TO_MID)))
+            .build();
+
+    Mentee menteeBase =
+        SetupMenteeFactories.createMenteeTest(10L, "Mentee Python", "mentee@test.com");
+    Mentee mentee =
+        Mentee.menteeBuilder()
+            .id(menteeBase.getId())
+            .fullName(menteeBase.getFullName())
+            .email(menteeBase.getEmail())
+            .profileStatus(ProfileStatus.ACTIVE)
+            .bio(menteeBase.getBio())
+            .spokenLanguages(List.of("English"))
+            .availableHsMonth(menteeBase.getAvailableHsMonth())
+            .skills(
+                new Skills(
+                    1,
+                    List.of(
+                        new TechnicalAreaProficiency(
+                            TechnicalArea.FRONTEND, ProficiencyLevel.BEGINNER)),
+                    List.of(
+                        new LanguageProficiency(CodeLanguage.PYTHON, ProficiencyLevel.BEGINNER)),
+                    List.of(MentorshipFocusArea.SWITCH_TO_MANAGEMENT)))
+            .build();
+
+    when(mentorRepository.findAvailableMentors(ProfileStatus.ACTIVE)).thenReturn(List.of(mentor));
+    when(menteeRepository.findByStatus(ProfileStatus.ACTIVE)).thenReturn(List.of(mentee));
+    when(matchRepository.countActiveMenteesByMentorAndCycle(1L, 1L)).thenReturn(0);
+    when(matchRepository.isMenteeMatchedInCycle(10L, 1L)).thenReturn(false);
+
+    MentorshipRecommendationResponse response = service.getRecommendations(1L);
+
+    assertThat(response.matchedMentors()).isEmpty();
+    assertThat(response.notMatchedMentors()).extracting(Mentor::getId).containsExactly(1L);
+    assertThat(response.notMatchedMentees()).extracting(Mentee::getId).containsExactly(10L);
+  }
+}

--- a/src/testInt/java/com/wcc/platform/repository/postgres/PostgresMemberRepositoryIntegrationTest.java
+++ b/src/testInt/java/com/wcc/platform/repository/postgres/PostgresMemberRepositoryIntegrationTest.java
@@ -40,6 +40,7 @@ class PostgresMemberRepositoryIntegrationTest extends DefaultDatabaseSetup {
             .build();
 
     repository.deleteByEmail(member.getEmail());
+    repository.deleteById(Long.MAX_VALUE);
   }
 
   @Test
@@ -70,7 +71,7 @@ class PostgresMemberRepositoryIntegrationTest extends DefaultDatabaseSetup {
 
   @Test
   void createReturnEmptyForNotFoundMemberId() {
-    var optionalMember = repository.findById(7L);
+    var optionalMember = repository.findById(Long.MAX_VALUE);
 
     assertTrue(optionalMember.isEmpty(), "Should not find optionalMember with this id");
   }

--- a/src/testInt/java/com/wcc/platform/repository/postgres/PostgresMenteeApplicationRepositoryIntegrationTest.java
+++ b/src/testInt/java/com/wcc/platform/repository/postgres/PostgresMenteeApplicationRepositoryIntegrationTest.java
@@ -1,9 +1,6 @@
 package com.wcc.platform.repository.postgres;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.wcc.platform.domain.platform.mentorship.ApplicationStatus;
 import com.wcc.platform.domain.platform.mentorship.CycleStatus;
@@ -108,13 +105,13 @@ class PostgresMenteeApplicationRepositoryIntegrationTest extends DefaultDatabase
 
     MenteeApplication created = applicationRepository.create(application);
 
-    assertNotNull(created.getApplicationId());
-    assertEquals(mentee.getId(), created.getMenteeId());
-    assertEquals(mentor.getId(), created.getMentorId());
-    assertEquals(cycle.getCycleId(), created.getCycleId());
-    assertEquals(ApplicationStatus.PENDING, created.getStatus());
-    assertEquals("I want to learn", created.getApplicationMessage());
-    assertNotNull(created.getAppliedAt());
+    assertThat(created.getApplicationId()).isNotNull();
+    assertThat(created.getMenteeId()).isEqualTo(mentee.getId());
+    assertThat(created.getMentorId()).isEqualTo(mentor.getId());
+    assertThat(created.getCycleId()).isEqualTo(cycle.getCycleId());
+    assertThat(created.getStatus()).isEqualTo(ApplicationStatus.PENDING);
+    assertThat(created.getApplicationMessage()).isEqualTo("I want to learn");
+    assertThat(created.getAppliedAt()).isNotNull();
   }
 
   @Test
@@ -124,8 +121,8 @@ class PostgresMenteeApplicationRepositoryIntegrationTest extends DefaultDatabase
 
     Optional<MenteeApplication> found = applicationRepository.findById(created.getApplicationId());
 
-    assertTrue(found.isPresent());
-    assertEquals(created.getApplicationId(), found.get().getApplicationId());
+    assertThat(found).isPresent();
+    assertThat(found.get().getApplicationId()).isEqualTo(created.getApplicationId());
   }
 
   @Test
@@ -138,9 +135,9 @@ class PostgresMenteeApplicationRepositoryIntegrationTest extends DefaultDatabase
         applicationRepository.updateStatus(
             created.getApplicationId(), ApplicationStatus.MENTOR_ACCEPTED, "Welcome!");
 
-    assertEquals(ApplicationStatus.MENTOR_ACCEPTED, updated.getStatus());
-    assertEquals("Welcome!", updated.getMentorResponse());
-    assertNotNull(updated.getReviewedAt());
+    assertThat(updated.getStatus()).isEqualTo(ApplicationStatus.MENTOR_ACCEPTED);
+    assertThat(updated.getMentorResponse()).isEqualTo("Welcome!");
+    assertThat(updated.getReviewedAt()).isNotNull();
   }
 
   @Test
@@ -152,7 +149,7 @@ class PostgresMenteeApplicationRepositoryIntegrationTest extends DefaultDatabase
         applicationRepository.findByMenteeAndCycle(mentee.getId(), cycle.getCycleId());
 
     assertThat(apps).hasSize(1);
-    assertEquals(mentee.getId(), apps.get(0).getMenteeId());
+    assertThat(apps.getFirst().getMenteeId()).isEqualTo(mentee.getId());
   }
 
   @Test
@@ -163,7 +160,35 @@ class PostgresMenteeApplicationRepositoryIntegrationTest extends DefaultDatabase
     List<MenteeApplication> apps = applicationRepository.findByMentor(mentor.getId());
 
     assertThat(apps).hasSize(1);
-    assertEquals(mentor.getId(), apps.get(0).getMentorId());
+    assertThat(apps.getFirst().getMentorId()).isEqualTo(mentor.getId());
+  }
+
+  @Test
+  @DisplayName("Given applications exist, when finding by cycle and statuses, then return list")
+  void shouldFindByCycleAndStatuses() {
+    createTestApplication(1);
+
+    List<MenteeApplication> apps =
+        applicationRepository.findByCycleAndStatuses(
+            cycle.getCycleId(), List.of(ApplicationStatus.PENDING));
+
+    assertThat(apps).hasSize(1);
+    assertThat(apps.getFirst().getStatus()).isEqualTo(ApplicationStatus.PENDING);
+  }
+
+  @Test
+  @DisplayName(
+      "Given applications exist, when finding by cycle, statuses and mentor, then return list")
+  void shouldFindByCycleAndStatusesAndMentor() {
+    createTestApplication(1);
+
+    List<MenteeApplication> apps =
+        applicationRepository.findByCycleAndStatusesAndMentor(
+            cycle.getCycleId(), List.of(ApplicationStatus.PENDING), mentor.getId());
+
+    assertThat(apps).hasSize(1);
+    assertThat(apps.getFirst().getMentorId()).isEqualTo(mentor.getId());
+    assertThat(apps.getFirst().getStatus()).isEqualTo(ApplicationStatus.PENDING);
   }
 
   @Test
@@ -173,7 +198,7 @@ class PostgresMenteeApplicationRepositoryIntegrationTest extends DefaultDatabase
 
     Long count = applicationRepository.countMenteeApplications(mentee.getId(), cycle.getCycleId());
 
-    assertEquals(1L, count);
+    assertThat(count).isEqualTo(1L);
   }
 
   @Test
@@ -192,8 +217,8 @@ class PostgresMenteeApplicationRepositoryIntegrationTest extends DefaultDatabase
 
     MenteeApplication created = applicationRepository.create(application);
 
-    assertNotNull(created.getWhyMentor());
-    assertEquals("Because this mentor has expertise in my field", created.getWhyMentor());
+    assertThat(created.getWhyMentor()).isNotNull();
+    assertThat(created.getWhyMentor()).isEqualTo("Because this mentor has expertise in my field");
   }
 
   @Test
@@ -211,8 +236,8 @@ class PostgresMenteeApplicationRepositoryIntegrationTest extends DefaultDatabase
 
     MenteeApplication created = applicationRepository.create(application);
 
-    assertNotNull(created.getApplicationId());
-    assertEquals("I want to learn", created.getApplicationMessage());
+    assertThat(created.getApplicationId()).isNotNull();
+    assertThat(created.getApplicationMessage()).isEqualTo("I want to learn");
   }
 
   private MenteeApplication createTestApplication(final int priority) {


### PR DESCRIPTION
## Description

- Caffeine cache is wired up for recommendation and application queries, with targeted eviction on writes.
- Introduces GET /matches/recommendations/{cycleId}  to suggest ranked mentee matches for available mentors based on language, technical area, and mentorship focus alignment. Scoring is split into dedicated private methods
(scoreLanguages, scoreAreas, scoreFocus) 
- Implement a full recommendation and manual matching workflow for the mentorship admin panel. The backend now exposes an endpoint to retrieve skill-based mentor–mentee suggestions, and a separate admin endpoint to
manually assign a mentee to a mentor by transitioning an existing PENDING_MANUAL_MATCH application through REJECTED before creating a new PENDING assignment.
- Exception handling is hardened: DuplicateApplicationException now extends DuplicatedException to receive a 409 response, and MentorCapacityExceededException is registered in GlobalExceptionHandler for the same. EmailService now throws EmailSendException on SMTP failure instead of swallowing the error.
- The admin frontend gains a new Applications tab with per-status filtering, a MentorApplicationsPanel that lists applications per mentor, success/error feedback in MatchCard after assign actions, and improved
error message extraction from API responses.

<!--
Example PR: https://github.com/Women-Coding-Community/wcc-backend/pull/118
-->

## Related Issue

closes #658

## Change Type

- [x] New Feature

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->