### PR TITLE
feat: Google Drive integration with environment-based credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ src/main/resources/application-local.yml
 /scripts/init-dev-env.sh
 .vercel
 /scripts/init-prod-env.sh
+service-account.json
 
 # bruno
 api-flows/results.html

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ src/main/resources/application-local.yml
 /scripts/init-dev-env.sh
 .vercel
 /scripts/init-prod-env.sh
-service-account.json
 
 # bruno
 api-flows/results.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application using Gradle and JDK 21 (Temurin)
-FROM gradle:8.7-jdk21-alpine AS build
+FROM gradle:8.7-jdk21 AS build
 WORKDIR /app
 
 # Copy configuration files to cache dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application using Gradle and JDK 21 (Temurin)
-FROM gradle:8.7-jdk21 AS build
+FROM gradle:8.10-jdk21 AS build
 WORKDIR /app
 
 # Copy configuration files to cache dependencies

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     implementation("com.google.api-client:google-api-client:2.8.1")
     implementation("com.google.oauth-client:google-oauth-client-jetty:1.34.1")
     implementation("com.google.apis:google-api-services-drive:v3-rev20230822-2.0.0")
+    implementation("com.google.auth:google-auth-library-oauth2-http:1.23.0")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.skyscreamer:jsonassert:1.5.3")

--- a/src/main/java/com/wcc/platform/configuration/GlobalExceptionHandler.java
+++ b/src/main/java/com/wcc/platform/configuration/GlobalExceptionHandler.java
@@ -34,6 +34,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -41,6 +42,7 @@ import org.springframework.web.context.request.WebRequest;
 
 /** Global controller to handle all exceptions for the API. */
 @SuppressWarnings({"PMD.ExcessiveImports"})
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -70,6 +72,7 @@ public class GlobalExceptionHandler {
   @ResponseStatus(INTERNAL_SERVER_ERROR)
   public ResponseEntity<ErrorDetails> handleInternalError(
       final RuntimeException ex, final WebRequest request) {
+    log.error("Internal error: {}", ex.getMessage(), ex);
     final var errorDetails =
         new ErrorDetails(
             INTERNAL_SERVER_ERROR.value(), ex.getMessage(), request.getDescription(false));

--- a/src/main/java/com/wcc/platform/configuration/GoogleDriveConfig.java
+++ b/src/main/java/com/wcc/platform/configuration/GoogleDriveConfig.java
@@ -1,0 +1,26 @@
+package com.wcc.platform.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration properties for Google Drive integration.
+ *
+ * <p>The {@code credentialsJson} field holds the full JSON content of a Google service account key.
+ * In production (Fly.io), set the {@code GOOGLE_DRIVE_CREDENTIALS_JSON} environment variable to
+ * this JSON content — no file needs to be bundled into the Docker image.
+ */
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "storage.google-drive")
+public class GoogleDriveConfig {
+
+  /**
+   * Full JSON content of the Google service account key. Mapped from the {@code
+   * GOOGLE_DRIVE_CREDENTIALS_JSON} environment variable.
+   */
+  private String credentialsJson;
+}

--- a/src/main/java/com/wcc/platform/repository/googledrive/GoogleDriveFileStorageRepository.java
+++ b/src/main/java/com/wcc/platform/repository/googledrive/GoogleDriveFileStorageRepository.java
@@ -1,21 +1,17 @@
 package com.wcc.platform.repository.googledrive;
 
-import com.google.api.client.auth.oauth2.Credential;
-import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
-import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
-import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
-import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.InputStreamContent;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.gson.GsonFactory;
-import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.DriveScopes;
 import com.google.api.services.drive.model.File;
 import com.google.api.services.drive.model.FileList;
 import com.google.api.services.drive.model.Permission;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.wcc.platform.domain.exceptions.PlatformInternalException;
 import com.wcc.platform.domain.platform.filestorage.FileStored;
 import com.wcc.platform.properties.FolderStorageProperties;
@@ -24,7 +20,6 @@ import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.List;
@@ -49,8 +44,7 @@ public class GoogleDriveFileStorageRepository implements FileStorageRepository {
   private static final String APPLICATION_NAME = "WCC Backend";
   private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
   private static final List<String> SCOPES = Collections.singletonList(DriveScopes.DRIVE);
-  private static final String CREDS_FILE_PATH = "/credentials.json";
-  private static final String TOKENS_DIR_PATH = "tokens";
+  private static final String SERVICE_ACCOUNT_PATH = "/service-account.json";
 
   private final Drive driveService;
 
@@ -63,68 +57,34 @@ public class GoogleDriveFileStorageRepository implements FileStorageRepository {
     this.folders = folders;
   }
 
-  /** Spring constructor: builds Drive client and reads folders from properties. */
+  /** Spring constructor: builds Drive client using service account credentials. */
   @Autowired
   public GoogleDriveFileStorageRepository(final FolderStorageProperties folders)
       throws GeneralSecurityException, IOException {
     final NetHttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     this.driveService =
-        new Drive.Builder(httpTransport, JSON_FACTORY, getCredentials(httpTransport))
+        new Drive.Builder(httpTransport, JSON_FACTORY, loadServiceAccountCredentials())
             .setApplicationName(APPLICATION_NAME)
             .build();
     this.folders = folders;
   }
 
-  /** Constructor that initializes the Google Drive service (no Spring). */
-  public GoogleDriveFileStorageRepository() throws GeneralSecurityException, IOException {
-    final NetHttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-    this.driveService =
-        new Drive.Builder(httpTransport, JSON_FACTORY, getCredentials(httpTransport))
-            .setApplicationName(APPLICATION_NAME)
-            .build();
-    this.folders = new FolderStorageProperties();
-  }
-
   /**
-   * Creates an authorized Credential object.
+   * Loads Google Drive credentials from a service account JSON file.
    *
-   * @param httpTransport The network HTTP Transport.
-   * @return An authorized Credential object.
-   * @throws IOException If the credentials.json file cannot be found.
+   * @return An {@link HttpCredentialsAdapter} wrapping the service account credentials.
+   * @throws IOException If the service account file cannot be found or read.
    */
-  private static Credential getCredentials(final NetHttpTransport httpTransport)
-      throws IOException {
+  private static HttpCredentialsAdapter loadServiceAccountCredentials() throws IOException {
     try (InputStream in =
-        GoogleDriveFileStorageRepository.class.getResourceAsStream(CREDS_FILE_PATH)) {
+        GoogleDriveFileStorageRepository.class.getResourceAsStream(SERVICE_ACCOUNT_PATH)) {
       if (in == null) {
-        throw new FileNotFoundException("Resource not found: " + CREDS_FILE_PATH);
+        throw new FileNotFoundException("Resource not found: " + SERVICE_ACCOUNT_PATH);
       }
-      final var clientSecrets = GoogleClientSecrets.load(JSON_FACTORY, new InputStreamReader(in));
-      final String clientId = clientSecrets.getDetails().getClientId();
-      final String userKey = "user-" + (clientId == null ? "unknown" : clientId);
-
-      final var flow =
-          new GoogleAuthorizationCodeFlow.Builder(
-                  httpTransport, JSON_FACTORY, clientSecrets, SCOPES)
-              .setDataStoreFactory(new FileDataStoreFactory(new java.io.File(TOKENS_DIR_PATH)))
-              .setAccessType("offline")
-              .build();
-
-      final Credential credential = flow.loadCredential(userKey);
-      if (credential != null) {
-        log.info(
-            "Using existing Google Drive credentials from '{}' for clientId '{}'. "
-                + "No browser authorization needed.",
-            TOKENS_DIR_PATH,
-            clientId);
-        return credential;
-      }
-
-      log.info(
-          "No existing credentials found for clientId '{}'. Opening browser for authorization...",
-          clientId);
-      final LocalServerReceiver receiver = new LocalServerReceiver.Builder().setPort(8888).build();
-      return new AuthorizationCodeInstalledApp(flow, receiver).authorize(userKey);
+      final GoogleCredentials credentials =
+          GoogleCredentials.fromStream(in).createScoped(SCOPES);
+      log.info("Loaded Google Drive service account credentials.");
+      return new HttpCredentialsAdapter(credentials);
     }
   }
 
@@ -159,11 +119,15 @@ public class GoogleDriveFileStorageRepository implements FileStorageRepository {
           new InputStreamContent(contentType, new ByteArrayInputStream(fileData));
 
       final var file =
-          files().create(fileMetadata, mediaContent).setFields("id, name, webViewLink").execute();
+          files()
+              .create(fileMetadata, mediaContent)
+              .setSupportsAllDrives(true)
+              .setFields("id, name, webViewLink")
+              .execute();
 
       final var permission = new Permission().setType("anyone").setRole("reader");
 
-      permissions().create(file.getId(), permission).execute();
+      permissions().create(file.getId(), permission).setSupportsAllDrives(true).execute();
 
       return new FileStored(file.getId(), file.getWebViewLink());
     } catch (IOException e) {

--- a/src/main/java/com/wcc/platform/repository/googledrive/GoogleDriveFileStorageRepository.java
+++ b/src/main/java/com/wcc/platform/repository/googledrive/GoogleDriveFileStorageRepository.java
@@ -12,14 +12,15 @@ import com.google.api.services.drive.model.FileList;
 import com.google.api.services.drive.model.Permission;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.wcc.platform.configuration.GoogleDriveConfig;
 import com.wcc.platform.domain.exceptions.PlatformInternalException;
 import com.wcc.platform.domain.platform.filestorage.FileStored;
 import com.wcc.platform.properties.FolderStorageProperties;
 import com.wcc.platform.repository.FileStorageRepository;
 import java.io.ByteArrayInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.List;
@@ -44,7 +45,6 @@ public class GoogleDriveFileStorageRepository implements FileStorageRepository {
   private static final String APPLICATION_NAME = "WCC Backend";
   private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
   private static final List<String> SCOPES = Collections.singletonList(DriveScopes.DRIVE);
-  private static final String SERVICE_ACCOUNT_PATH = "/service-account.json";
 
   private final Drive driveService;
 
@@ -57,33 +57,48 @@ public class GoogleDriveFileStorageRepository implements FileStorageRepository {
     this.folders = folders;
   }
 
-  /** Spring constructor: builds Drive client using service account credentials. */
+  /**
+   * Spring constructor: builds the Drive client using service account credentials supplied via
+   * {@link GoogleDriveConfig#getCredentialsJson()}, which is mapped from the {@code
+   * GOOGLE_DRIVE_CREDENTIALS_JSON} environment variable.
+   */
   @Autowired
-  public GoogleDriveFileStorageRepository(final FolderStorageProperties folders)
+  public GoogleDriveFileStorageRepository(
+      final FolderStorageProperties folders, final GoogleDriveConfig googleDriveConfig)
       throws GeneralSecurityException, IOException {
     final NetHttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     this.driveService =
-        new Drive.Builder(httpTransport, JSON_FACTORY, loadServiceAccountCredentials())
+        new Drive.Builder(
+                httpTransport,
+                JSON_FACTORY,
+                loadServiceAccountCredentials(googleDriveConfig.getCredentialsJson()))
             .setApplicationName(APPLICATION_NAME)
             .build();
     this.folders = folders;
   }
 
   /**
-   * Loads Google Drive credentials from a service account JSON file.
+   * Loads Google Drive service account credentials from a JSON string.
    *
-   * @return An {@link HttpCredentialsAdapter} wrapping the service account credentials.
-   * @throws IOException If the service account file cannot be found or read.
+   * <p>The JSON content is expected to be the full service account key file, provided via the
+   * {@code GOOGLE_DRIVE_CREDENTIALS_JSON} environment variable.
+   *
+   * @param credentialsJson the service account key JSON as a string
+   * @return an {@link HttpCredentialsAdapter} wrapping the scoped credentials
+   * @throws IOException if the JSON is blank or cannot be parsed
+   * @throws IllegalStateException if {@code credentialsJson} is blank
    */
-  private static HttpCredentialsAdapter loadServiceAccountCredentials() throws IOException {
+  private static HttpCredentialsAdapter loadServiceAccountCredentials(final String credentialsJson)
+      throws IOException {
+    if (StringUtils.isBlank(credentialsJson)) {
+      throw new IllegalStateException(
+          "Google Drive credentials are not configured. "
+              + "Set the GOOGLE_DRIVE_CREDENTIALS_JSON environment variable.");
+    }
     try (InputStream in =
-        GoogleDriveFileStorageRepository.class.getResourceAsStream(SERVICE_ACCOUNT_PATH)) {
-      if (in == null) {
-        throw new FileNotFoundException("Resource not found: " + SERVICE_ACCOUNT_PATH);
-      }
-      final GoogleCredentials credentials =
-          GoogleCredentials.fromStream(in).createScoped(SCOPES);
-      log.info("Loaded Google Drive service account credentials.");
+        new ByteArrayInputStream(credentialsJson.getBytes(StandardCharsets.UTF_8))) {
+      final GoogleCredentials credentials = GoogleCredentials.fromStream(in).createScoped(SCOPES);
+      log.info("Loaded Google Drive service account credentials from environment.");
       return new HttpCredentialsAdapter(credentials);
     }
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,7 +80,7 @@ app:
 storage:
   type: local
   google-drive:
-    credentials-json: ${GOOGLE_DRIVE_CREDENTIALS_JSON:}
+    credentials-json:
   folders:
     main-folder: folder-id
     resources-folder: folder-id

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,6 +79,8 @@ app:
 
 storage:
   type: local
+  google-drive:
+    credentials-json: ${GOOGLE_DRIVE_CREDENTIALS_JSON:}
   folders:
     main-folder: folder-id
     resources-folder: folder-id

--- a/src/test/java/com/wcc/platform/repository/googledrive/GoogleDriveFileStorageRepositoryTest.java
+++ b/src/test/java/com/wcc/platform/repository/googledrive/GoogleDriveFileStorageRepositoryTest.java
@@ -51,12 +51,14 @@ class GoogleDriveFileStorageRepositoryTest {
 
     when(driveServiceMock.files()).thenReturn(filesMock);
     when(filesMock.create(any(File.class), any())).thenReturn(fileCreateMock);
+    when(fileCreateMock.setSupportsAllDrives(true)).thenReturn(fileCreateMock);
     when(fileCreateMock.setFields("id, name, webViewLink")).thenReturn(fileCreateMock);
     when(fileCreateMock.execute()).thenReturn(expectedFile);
 
     when(driveServiceMock.permissions()).thenReturn(permissionsMock);
     when(permissionsMock.create(eq(expectedFile.getId()), any(Permission.class)))
         .thenReturn(permissionCreateMock);
+    when(permissionCreateMock.setSupportsAllDrives(true)).thenReturn(permissionCreateMock);
     when(permissionCreateMock.execute()).thenReturn(new Permission());
 
     var actualFile =
@@ -85,12 +87,14 @@ class GoogleDriveFileStorageRepositoryTest {
 
     when(driveServiceMock.files()).thenReturn(filesMock);
     when(filesMock.create(any(File.class), any())).thenReturn(fileCreateMock);
+    when(fileCreateMock.setSupportsAllDrives(true)).thenReturn(fileCreateMock);
     when(fileCreateMock.setFields("id, name, webViewLink")).thenReturn(fileCreateMock);
     when(fileCreateMock.execute()).thenReturn(expectedFile);
 
     when(driveServiceMock.permissions()).thenReturn(permissionsMock);
     when(permissionsMock.create(eq(expectedFile.getId()), any(Permission.class)))
         .thenReturn(permissionCreateMock);
+    when(permissionCreateMock.setSupportsAllDrives(true)).thenReturn(permissionCreateMock);
     when(permissionCreateMock.execute()).thenReturn(new Permission());
 
     var googleDriveService = new GoogleDriveFileStorageRepository(driveServiceMock, properties);
@@ -110,6 +114,7 @@ class GoogleDriveFileStorageRepositoryTest {
 
     when(driveServiceMock.files()).thenReturn(filesMock);
     when(filesMock.create(any(File.class), any())).thenReturn(fileCreateMock);
+    when(fileCreateMock.setSupportsAllDrives(true)).thenReturn(fileCreateMock);
     when(fileCreateMock.setFields("id, name, webViewLink")).thenReturn(fileCreateMock);
     when(fileCreateMock.execute()).thenThrow(new IOException("Test exception"));
 

--- a/src/test/java/com/wcc/platform/repository/googledrive/GoogleDriveFileStorageRepositoryTest.java
+++ b/src/test/java/com/wcc/platform/repository/googledrive/GoogleDriveFileStorageRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.wcc.platform.repository.googledrive;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -11,10 +12,12 @@ import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.model.File;
 import com.google.api.services.drive.model.FileList;
 import com.google.api.services.drive.model.Permission;
+import com.wcc.platform.configuration.GoogleDriveConfig;
 import com.wcc.platform.domain.exceptions.PlatformInternalException;
 import com.wcc.platform.properties.FolderStorageProperties;
 import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -40,6 +43,18 @@ class GoogleDriveFileStorageRepositoryTest {
     properties.setMainFolder(FOLDER_ID_ROOT);
 
     service = new GoogleDriveFileStorageRepository(driveServiceMock, properties);
+  }
+
+  @Test
+  @DisplayName("Given blank credentials JSON, when constructing the repository, then it should throw IllegalStateException")
+  void shouldThrowIllegalStateExceptionWhenCredentialsJsonIsBlank() {
+    var config = new GoogleDriveConfig();
+    config.setCredentialsJson("");
+
+    assertThatThrownBy(
+            () -> new GoogleDriveFileStorageRepository(new FolderStorageProperties(), config))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("GOOGLE_DRIVE_CREDENTIALS_JSON");
   }
 
   @Test

--- a/src/testInt/java/com/wcc/platform/repository/googledrive/GoogleDriveFileStorageRepositoryIntegrationTest.java
+++ b/src/testInt/java/com/wcc/platform/repository/googledrive/GoogleDriveFileStorageRepositoryIntegrationTest.java
@@ -86,10 +86,12 @@ class GoogleDriveFileStorageRepositoryIntegrationTest extends DefaultDatabaseSet
       // Given
       File expectedFile = createTestFile();
       when(mockFiles.create(any(File.class), any())).thenReturn(mockCreate);
+      when(mockCreate.setSupportsAllDrives(true)).thenReturn(mockCreate);
       when(mockCreate.setFields(any(String.class))).thenReturn(mockCreate);
       when(mockCreate.execute()).thenReturn(expectedFile);
       when(mockPermissions.create(eq(TEST_FILE_ID), any(Permission.class)))
           .thenReturn(mockPermissionCreate);
+      when(mockPermissionCreate.setSupportsAllDrives(true)).thenReturn(mockPermissionCreate);
       when(mockPermissionCreate.execute()).thenReturn(new Permission());
 
       // When
@@ -114,10 +116,12 @@ class GoogleDriveFileStorageRepositoryIntegrationTest extends DefaultDatabaseSet
       File expectedFile = createTestFile();
 
       when(mockFiles.create(any(File.class), any())).thenReturn(mockCreate);
+      when(mockCreate.setSupportsAllDrives(true)).thenReturn(mockCreate);
       when(mockCreate.setFields(any(String.class))).thenReturn(mockCreate);
       when(mockCreate.execute()).thenReturn(expectedFile);
       when(mockPermissions.create(eq(TEST_FILE_ID), any(Permission.class)))
           .thenReturn(mockPermissionCreate);
+      when(mockPermissionCreate.setSupportsAllDrives(true)).thenReturn(mockPermissionCreate);
       when(mockPermissionCreate.execute()).thenReturn(new Permission());
 
       // When
@@ -134,6 +138,7 @@ class GoogleDriveFileStorageRepositoryIntegrationTest extends DefaultDatabaseSet
     void shouldThrowExceptionWhenUploadFails() throws IOException {
       // Given
       when(mockFiles.create(any(File.class), any())).thenReturn(mockCreate);
+      when(mockCreate.setSupportsAllDrives(true)).thenReturn(mockCreate);
       when(mockCreate.setFields(any(String.class))).thenReturn(mockCreate);
       when(mockCreate.execute()).thenThrow(new IOException("Upload failed"));
 

--- a/src/testInt/java/com/wcc/platform/repository/googledrive/GoogleDriveFileStorageRepositoryPerformanceTest.java
+++ b/src/testInt/java/com/wcc/platform/repository/googledrive/GoogleDriveFileStorageRepositoryPerformanceTest.java
@@ -63,10 +63,12 @@ class GoogleDriveFileStorageRepositoryPerformanceTest extends DefaultDatabaseSet
     mockFile.setName(fileName);
 
     when(mockFiles.create(any(File.class), any())).thenReturn(mockCreate);
+    when(mockCreate.setSupportsAllDrives(true)).thenReturn(mockCreate);
     when(mockCreate.setFields(any(String.class))).thenReturn(mockCreate);
     when(mockCreate.execute()).thenReturn(mockFile);
     when(mockPermissions.create(any(String.class), any(Permission.class)))
         .thenReturn(mockPermissionCreate);
+    when(mockPermissionCreate.setSupportsAllDrives(true)).thenReturn(mockPermissionCreate);
     when(mockPermissionCreate.execute()).thenReturn(new Permission());
 
     // When


### PR DESCRIPTION
## Summary

- Replaces the interactive OAuth2 browser flow with a Google service account, making the integration production-safe on Fly.io
- Loads service account credentials from the `GOOGLE_DRIVE_CREDENTIALS_JSON` environment variable at runtime
- Adds `GoogleDriveConfig` `@ConfigurationProperties` class to bind the new property

## Test plan

- [ ] On Fly.io, set the secret: `fly secrets set GOOGLE_DRIVE_CREDENTIALS_JSON="$(cat service-account.json)" -a wcc-backend`
- [ ] Verify file upload works end-to-end after deployment