### PR TITLE
Add QA profile with seeded role-based accounts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,9 +253,8 @@ spring.mail.username: ${MAIL_USERNAME}  # SMTP username (from env var)
 spring.mail.password: ${MAIL_PASSWORD}  # SMTP password (from env var)
 
 app.cors.allowed-origins: http://localhost:3000,https://your-frontend.com
-app.seed.admin.enabled: true        # Auto-create admin user
-app.seed.admin.email: admin@wcc.dev
-app.seed.admin.password: wcc-admin
+app.seed.enabled: true              # Enable user seeding at startup
+# app.seed.users: list of {email, password, full-name, roles, member-types} entries
 ```
 
 **CORS:** Update `app.cors.allowed-origins` when deploying frontend to include production URL.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
 # Stage 1: Build the application using Gradle and JDK 21 (Temurin)
-FROM gradle:8.7-jdk21-alpine AS build
+FROM gradle:8.7 AS build
 WORKDIR /app
 
-# Copy configuration files to cache dependencies
+# Copy configuration files first so dependency resolution is cached
+# independently of source changes
 COPY build.gradle.kts settings.gradle.kts ./
+
+# Warm the dependency cache. This layer is only rebuilt when the build
+# files change, so editing source no longer re-downloads dependencies.
+RUN gradle dependencies --no-daemon
 
 # Copy source code and build the application
 # Using the 'gradle' command directly since it's pre-installed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
 # Stage 1: Build the application using Gradle and JDK 21 (Temurin)
-FROM gradle:8.7 AS build
+FROM gradle:8.7-jdk21-alpine AS build
 WORKDIR /app
 
 # Copy configuration files first so dependency resolution is cached
 # independently of source changes
 COPY build.gradle.kts settings.gradle.kts ./
-
-# Warm the dependency cache. This layer is only rebuilt when the build
-# files change, so editing source no longer re-downloads dependencies.
-RUN gradle dependencies --no-daemon
 
 # Copy source code and build the application
 # Using the 'gradle' command directly since it's pre-installed

--- a/README.md
+++ b/README.md
@@ -361,11 +361,8 @@ A default admin user is auto-created at startup for local testing:
 - Email: admin@wcc.dev
 - Password: wcc-admin
 
-You can change or disable this seeding with properties:
-
-- app.seed.admin.enabled=false (disable seeding)
-- app.seed.admin.email=your@email
-- app.seed.admin.password=yourpassword
+You can disable seeding with `app.seed.enabled=false`, or add/change users by editing
+the `app.seed.users` list in `application.yml` (or an environment-specific profile override).
 
 1. Copy env example and adjust as needed:
 

--- a/docker/docker-compose.qa.yml
+++ b/docker/docker-compose.qa.yml
@@ -1,0 +1,69 @@
+# Local QA stack: same as docker-compose.yml but runs the `docker,qa` profile,
+# which seeds MENTORSHIP_ADMIN, MENTOR and LEADER accounts in addition to admin.
+#
+# Usage:
+#   docker compose -f docker/docker-compose.qa.yml up --build
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: MFpFnhhICniFNPA
+      POSTGRES_DB: wcc
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - app-network
+
+  mailhog:
+    image: mailhog/mailhog:latest
+    container_name: mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+    networks:
+      - app-network
+
+
+  springboot-app:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    container_name: springboot-app
+    ports:
+      - "8080:8080"
+      - "5005:5005"
+    depends_on:
+      - postgres
+      - mailhog
+    environment:
+      SPRING_PROFILES_ACTIVE: docker,qa
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/wcc
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: MFpFnhhICniFNPA
+      SPRING_APP_BASE_URL: http://localhost:8080
+      SPRING_MAIL_HOST: mailhog
+      SPRING_MAIL_PORT: 1025
+      SPRING_MAIL_USERNAME: noreply@wcc.local
+      SPRING_MAIL_PASSWORD: ""
+      SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_REQUIRED: "false"
+    healthcheck:
+      # http://localhost:8080/actuator/health is always DOWN because of the
+      # lack of mail service authentication
+      test: [ "CMD-SHELL", "wget -qO- http://localhost:8080/actuator/health/ping | grep UP || exit 1" ]
+      interval: 10s
+      timeout: 1s
+      retries: 5
+      start_period: 5s
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge
+
+volumes:
+  postgres-data:

--- a/docs/qa_local_setup.md
+++ b/docs/qa_local_setup.md
@@ -62,7 +62,7 @@ All accounts use the password **`wcc-admin`**.
 
 | Email                      | Role             | Member type | Notes                                            |
 |----------------------------|------------------|-------------|--------------------------------------------------|
-| `admin@wcc.dev`            | ADMIN            | —           | Linked to its own generic member *QA Admin*      |
+| `admin@wcc.dev`            | ADMIN            | MEMBER      | Linked to its own generated member *QA Admin*    |
 | `mentorship-admin@wcc.dev` | MENTORSHIP_ADMIN | MEMBER      | Can approve/reject mentors and manage matches    |
 | `mentor@wcc.dev`           | MENTOR           | MENTOR      | Has an **ACTIVE** mentor profile                 |
 | `leader@wcc.dev`           | LEADER           | LEADER      |                                                  |
@@ -151,8 +151,8 @@ docker compose -f docker/docker-compose.qa.yml up --build
   * creates a member matching each user's email,
   * creates the user account with the configured password and roles,
   * for users with the `MENTOR` role, creates a full mentor profile and activates it.
-* The default `admin@wcc.dev` account is configured separately under `app.seed.admin` in
-  the base `application.yml` and is seeded in every profile.
+* All four accounts (including admin) are defined in `app.seed.users`. The base
+  `application.yml` seeds just the admin; the `qa` profile adds the remaining roles.
 
 ## Adding or changing seeded users
 
@@ -182,10 +182,9 @@ Valid `roles` values: `ADMIN`, `MENTORSHIP_ADMIN`, `LEADER`, `MENTOR`, `MENTEE`,
 
 ## Notes and caveats
 
-* **Admin uses a generic profile.** In the QA profile, the `admin@wcc.dev` account is
-  linked to its own generated member (*QA Admin*, matching the admin email) via
-  `app.seed.admin.create-own-member: true`. Outside the QA profile the admin links to the
-  pre-existing seed member (id 1) instead — that default is unchanged.
+* **Admin uses a generated profile.** The `admin@wcc.dev` account is always linked to its
+  own generated member (*QA Admin*). Like all seeded accounts, it is defined as a list
+  entry under `app.seed.users` — not separately configured.
 * **Mentor is ACTIVE.** The seeded mentor is activated directly (no approval email is
   sent). To instead test the mentor approval flow, see the mentor `accept`/`reject`
   endpoints under `PATCH /api/platform/v1/mentors/{mentorId}/accept|reject` (requires the

--- a/docs/qa_local_setup.md
+++ b/docs/qa_local_setup.md
@@ -1,0 +1,206 @@
+# QA Local Setup — Backend with Seeded Accounts
+
+A guide for the QA team to run the WCC backend locally with a known set of pre-seeded
+user accounts (one per role), so role-based and mentorship flows can be tested without
+manually creating data.
+
+<!-- TOC -->
+
+* [QA Local Setup — Backend with Seeded Accounts](#qa-local-setup--backend-with-seeded-accounts)
+  * [What you get](#what-you-get)
+  * [Prerequisites](#prerequisites)
+  * [Quick start](#quick-start)
+  * [Seeded accounts](#seeded-accounts)
+  * [Logging in](#logging-in)
+  * [Verifying the seed](#verifying-the-seed)
+  * [Resetting the environment](#resetting-the-environment)
+  * [How the seeding works](#how-the-seeding-works)
+  * [Adding or changing seeded users](#adding-or-changing-seeded-users)
+  * [Notes and caveats](#notes-and-caveats)
+  * [Troubleshooting](#troubleshooting)
+
+<!-- TOC -->
+
+## What you get
+
+Running the QA stack starts the backend, a PostgreSQL database and a MailHog mock mail
+server, and seeds **four user accounts** — one for each main role (Admin, Mentorship
+Admin, Mentor, Leader). The mentor account is provisioned with an **ACTIVE mentor
+profile**, so it appears in the admin portal's mentor list and is eligible for matching.
+
+## Prerequisites
+
+* **Docker Desktop** running (`docker ps` should succeed).
+* Ports **8080** (API), **5432** (Postgres), **1025/8025** (MailHog) free on your machine.
+
+No Java, Gradle or database installation is needed — everything runs in containers.
+
+## Quick start
+
+From the repository root:
+
+```shell
+docker compose -f docker/docker-compose.qa.yml up --build
+```
+
+The first build takes a few minutes (it compiles the app inside the container). When you
+see the application start log, the API is available at:
+
+* API base: `http://localhost:8080`
+* Swagger UI: `http://localhost:8080/swagger-ui/index.html`
+* MailHog inbox (outgoing emails): `http://localhost:8025`
+
+To stop the stack, press `Ctrl+C`, or in another terminal:
+
+```shell
+docker compose -f docker/docker-compose.qa.yml down
+```
+
+## Seeded accounts
+
+All accounts use the password **`wcc-admin`**.
+
+| Email                      | Role             | Member type | Notes                                            |
+|----------------------------|------------------|-------------|--------------------------------------------------|
+| `admin@wcc.dev`            | ADMIN            | —           | Linked to its own generic member *QA Admin*      |
+| `mentorship-admin@wcc.dev` | MENTORSHIP_ADMIN | MEMBER      | Can approve/reject mentors and manage matches    |
+| `mentor@wcc.dev`           | MENTOR           | MENTOR      | Has an **ACTIVE** mentor profile                 |
+| `leader@wcc.dev`           | LEADER           | LEADER      |                                                  |
+
+## Logging in
+
+Authenticate against the login endpoint to receive a bearer token:
+
+```shell
+curl -s -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"mentor@wcc.dev","password":"wcc-admin"}'
+```
+
+The response contains a `token`, the account `roles`, and the linked `member` profile:
+
+```json
+{
+  "token": "…",
+  "expiresAt": "…",
+  "roles": ["MENTOR"],
+  "member": { "id": 5, "fullName": "QA Mentor", "email": "mentor@wcc.dev", … }
+}
+```
+
+Use the token on subsequent calls:
+
+```shell
+curl -s http://localhost:8080/api/platform/v1/mentors \
+  -H "Authorization: Bearer <token>"
+```
+
+The same credentials work to log into the admin portal (`admin-wcc-app`) when it is
+pointed at `http://localhost:8080`.
+
+## Verifying the seed
+
+Check the application logs for the seeding messages:
+
+```shell
+docker logs springboot-app 2>&1 | grep -iE "Seeded|mentor profile"
+```
+
+Expected lines:
+
+```
+Seeded user: admin@wcc.dev (roles: [Platform Administrator])
+Seeded user: mentorship-admin@wcc.dev (roles: [Mentorship Administrator])
+Seeded ACTIVE mentor profile: mentor@wcc.dev (id: …)
+Seeded user: leader@wcc.dev (roles: [Platform Leader])
+```
+
+Or query the database directly:
+
+```shell
+docker exec postgres psql -U postgres -d wcc -c \
+  "SELECT ua.email, array_agg(rt.name) AS roles \
+   FROM user_accounts ua \
+   LEFT JOIN user_roles ur ON ur.user_id = ua.id \
+   LEFT JOIN role_types rt ON rt.id = ur.role_id \
+   GROUP BY ua.email ORDER BY ua.email;"
+```
+
+## Resetting the environment
+
+The database is stored in a Docker volume, so accounts persist across restarts. To wipe
+everything and re-seed from a clean state (for example after changing the seed config):
+
+```shell
+docker compose -f docker/docker-compose.qa.yml down -v
+docker compose -f docker/docker-compose.qa.yml up --build
+```
+
+> The `-v` flag deletes the `postgres-data` volume. The seeder is idempotent and **skips
+> accounts that already exist**, so without `-v` changes to seeded users will not be
+> applied to an existing database.
+
+## How the seeding works
+
+* The QA stack runs Spring profiles `docker,qa` (set in
+  [`docker/docker-compose.qa.yml`](../docker/docker-compose.qa.yml)).
+* The `qa` profile loads
+  [`src/main/resources/application-qa.yml`](../src/main/resources/application-qa.yml),
+  which defines the seeded users under `app.seed.users`.
+* On startup, `DevAdminSeeder` (an `ApplicationRunner`) reads that list and:
+  * creates a member matching each user's email,
+  * creates the user account with the configured password and roles,
+  * for users with the `MENTOR` role, creates a full mentor profile and activates it.
+* The default `admin@wcc.dev` account is configured separately under `app.seed.admin` in
+  the base `application.yml` and is seeded in every profile.
+
+## Adding or changing seeded users
+
+Edit `src/main/resources/application-qa.yml` and add an entry under `app.seed.users`:
+
+```yaml
+app:
+  seed:
+    users:
+      - email: new-user@wcc.dev
+        password: wcc-admin
+        full-name: QA New User
+        roles: [LEADER]          # one or more RoleType values
+        member-types: [LEADER]   # optional; one or more MemberType values
+```
+
+After changing the file, rebuild with a clean database (see
+[Resetting the environment](#resetting-the-environment)).
+
+Valid `roles` values: `ADMIN`, `MENTORSHIP_ADMIN`, `LEADER`, `MENTOR`, `MENTEE`,
+`CONTRIBUTOR`, `VIEWER`. Valid `member-types`: `DIRECTOR`, `COLLABORATOR`, `EVANGELIST`,
+`LEADER`, `MENTEE`, `MENTOR`, `MEMBER`, `PARTNER`, `SPEAKER`, `VOLUNTEER`.
+
+> **Avoid mapping a member type that escalates privileges** — for example `DIRECTOR` maps
+> to the ADMIN role, so a member with that type would gain admin permissions. Use `MEMBER`
+> for a neutral, read-only member type.
+
+## Notes and caveats
+
+* **Admin uses a generic profile.** In the QA profile, the `admin@wcc.dev` account is
+  linked to its own generated member (*QA Admin*, matching the admin email) via
+  `app.seed.admin.create-own-member: true`. Outside the QA profile the admin links to the
+  pre-existing seed member (id 1) instead — that default is unchanged.
+* **Mentor is ACTIVE.** The seeded mentor is activated directly (no approval email is
+  sent). To instead test the mentor approval flow, see the mentor `accept`/`reject`
+  endpoints under `PATCH /api/platform/v1/mentors/{mentorId}/accept|reject` (requires the
+  `MENTOR_APPROVE` permission — held by ADMIN and MENTORSHIP_ADMIN).
+* **Single stack.** The QA compose uses the same container names, ports and volume as the
+  regular `docker-compose.yml`, so run one or the other — not both at the same time.
+* **Local only.** The `qa` profile and its plaintext passwords are intended for local
+  testing and must never be activated in a deployed environment.
+
+## Troubleshooting
+
+| Symptom                                   | Cause / fix                                                                                  |
+|-------------------------------------------|----------------------------------------------------------------------------------------------|
+| Build hangs at `FROM …` pulling an image  | Docker Desktop network is wedged — restart Docker Desktop, then retry.                        |
+| `401 Unauthorized` on login               | Wrong password (must be `wcc-admin`) or the seed didn't run — check the logs.                 |
+| Seeded user changes not taking effect     | The account already exists; reset with `down -v` (see above).                                 |
+| Port already in use                       | The regular stack is running, or another process holds 8080/5432 — stop it and retry.        |
+| Login works but `member` is missing       | The account has no linked member — verify the user exists in `user_accounts` with a member id. |

--- a/src/main/java/com/wcc/platform/bootstrap/DevAdminSeeder.java
+++ b/src/main/java/com/wcc/platform/bootstrap/DevAdminSeeder.java
@@ -1,71 +1,259 @@
 package com.wcc.platform.bootstrap;
 
 import com.wcc.platform.domain.auth.UserAccount;
+import com.wcc.platform.domain.cms.attributes.Country;
+import com.wcc.platform.domain.cms.pages.mentorship.MenteeSection;
+import com.wcc.platform.domain.platform.member.Member;
+import com.wcc.platform.domain.platform.member.ProfileStatus;
+import com.wcc.platform.domain.platform.mentorship.Mentor;
+import com.wcc.platform.domain.platform.mentorship.Skills;
 import com.wcc.platform.domain.platform.type.RoleType;
+import com.wcc.platform.repository.MemberRepository;
+import com.wcc.platform.repository.MentorRepository;
 import com.wcc.platform.repository.UserAccountRepository;
+import com.wcc.platform.service.MentorshipService;
 import java.util.List;
+import java.util.Locale;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
- * Seeds a default admin user for local testing so the frontend can authenticate against real data.
- * Enabled by default, can be disabled with app.seed.admin.enabled=false.
+ * Seeds default user accounts for local testing so the frontend can authenticate against real data.
+ * The default admin is enabled by default and can be disabled with app.seed.admin.enabled=false.
+ * Additional role-specific accounts (for example MENTORSHIP_ADMIN, MENTOR and LEADER) are seeded
+ * from the app.seed.users configuration list, each linked to a member so login returns full profile
+ * information.
  */
 @Component
 public class DevAdminSeeder implements ApplicationRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(DevAdminSeeder.class);
+  private static final long ADMIN_MEMBER_ID = 1L;
 
   private final UserAccountRepository userAccountRepository;
+  private final MemberRepository memberRepository;
+  private final MentorRepository mentorRepository;
+  private final MentorshipService mentorshipService;
   private final DevAdminSeederProperties seedProperties;
+  private final SeedUsersProperties seedUsersProperties;
   private final PasswordEncoder passwordEncoder;
 
   /**
-   * Constructs a DevAdminSeeder instance with dependencies and configuration values.
-   *
-   * @param userAccountRepository repository for managing user accounts, used to check the presence
-   *     of and create the default admin user.
-   * @param seedProperties configuration properties for the dev admin seeder.
-   * @param passwordEncoder Argon2 password encoder.
+   * Constructs a DevAdminSeeder with repositories, mentorship service and seed configuration.
+   * @param userAccountRepository repository for user accounts
+   * @param memberRepository repository for members
+   * @param mentorRepository repository for mentors, used to activate seeded mentor profiles
+   * @param mentorshipService service used to provision mentor profiles for MENTOR-role users
+   * @param seedProperties configuration for the default admin seeder
+   * @param seedUsersProperties configuration for the additional seeded users
+   * @param passwordEncoder Argon2 password encoder
    */
   public DevAdminSeeder(
       final UserAccountRepository userAccountRepository,
+      final MemberRepository memberRepository,
+      final MentorRepository mentorRepository,
+      final MentorshipService mentorshipService,
       final DevAdminSeederProperties seedProperties,
+      final SeedUsersProperties seedUsersProperties,
       final PasswordEncoder passwordEncoder) {
     this.userAccountRepository = userAccountRepository;
+    this.memberRepository = memberRepository;
+    this.mentorRepository = mentorRepository;
+    this.mentorshipService = mentorshipService;
     this.seedProperties = seedProperties;
+    this.seedUsersProperties = seedUsersProperties;
     this.passwordEncoder = passwordEncoder;
   }
 
   @Override
   public void run(final ApplicationArguments args) {
+    seedAdmin();
+    seedConfiguredUsers();
+  }
+
+  private void seedAdmin() {
     if (!seedProperties.isEnabled()) {
       LOG.info("Admin seeder disabled (app.seed.admin.enabled=false)");
       return;
     }
-    final var email = seedProperties.getEmail();
-    if (!StringUtils.hasText(email) || !StringUtils.hasText(seedProperties.getPassword())) {
-      LOG.warn("Admin seeder skipped: email or password not provided");
+    final Long memberId = resolveAdminMemberId();
+    seedUser(
+        seedProperties.getEmail(), seedProperties.getPassword(), List.of(RoleType.ADMIN), memberId);
+  }
+
+  /**
+   * Resolves the member linked to the admin account. By default the admin links to the pre-existing
+   * seed member ({@link #ADMIN_MEMBER_ID}); when {@code createOwnMember} is enabled (QA), a
+   * generic member matching the admin email is created instead.
+   *
+   * @return the member id to link to the admin account
+   */
+  private Long resolveAdminMemberId() {
+    if (!seedProperties.isCreateOwnMember()) {
+      return ADMIN_MEMBER_ID;
+    }
+    final var adminSeed = new SeedUser();
+    adminSeed.setEmail(seedProperties.getEmail());
+    adminSeed.setFullName(
+        StringUtils.hasText(seedProperties.getFullName())
+            ? seedProperties.getFullName()
+            : "QA Admin");
+    adminSeed.setRoles(List.of(RoleType.ADMIN));
+    return resolveMemberId(adminSeed);
+  }
+
+  private void seedConfiguredUsers() {
+    for (final SeedUser user : seedUsersProperties.getUsers()) {
+      if (!user.isEnabled()) {
+        LOG.info("Seed user disabled, skipping: {}", user.getEmail());
+        continue;
+      }
+      final Long memberId = resolveMemberId(user);
+      provisionSeededAccount(user, memberId);
+    }
+  }
+
+  /**
+   * Ensures the configured QA account exists with the expected password and roles. When the account
+   * was already auto-provisioned (for example by mentor creation, which assigns a random password),
+   * its password and roles are reset to the configured values so the credentials are predictable.
+   *
+   * @param user the seed user configuration
+   * @param memberId the member to link when creating a new account
+   */
+  private void provisionSeededAccount(final SeedUser user, final Long memberId) {
+    final var email = user.getEmail();
+    final var password = user.getPassword();
+    final var roles = user.getRoles();
+    if (!StringUtils.hasText(email) || !StringUtils.hasText(password)) {
+      LOG.warn("Seed user skipped: email or password not provided");
+      return;
+    }
+    if (CollectionUtils.isEmpty(roles)) {
+      LOG.warn("Seed user skipped, no roles provided: {}", email);
       return;
     }
 
+    final var hash = passwordEncoder.encode(password);
     final var existing = userAccountRepository.findByEmail(email);
     if (existing.isPresent()) {
-      LOG.info("Default admin user already exists: {}", email);
+      final var accountId = existing.get().getId();
+      userAccountRepository.updatePassword(accountId, hash);
+      userAccountRepository.updateRole(accountId, roles);
+      LOG.info("Reset seeded user credentials: {} (roles: {})", email, roles);
       return;
     }
 
-    final var hash = passwordEncoder.encode(seedProperties.getPassword());
+    userAccountRepository.create(new UserAccount(null, memberId, email, hash, roles, true));
+    LOG.info("Seeded user: {} (roles: {})", email, roles);
+  }
 
-    final UserAccount user =
-        new UserAccount(1, 1L, seedProperties.getEmail(), hash, List.of(RoleType.ADMIN), true);
+  /**
+   * Resolves the member to link to a seeded user, creating one if it does not already exist so that
+   * login returns full profile information. Users holding the MENTOR role are provisioned with a
+   * full mentor profile so they appear in the admin portal's mentor list.
+   *
+   * @param user the seed user configuration
+   * @return the linked member id, or null when the email is missing
+   */
+  private Long resolveMemberId(final SeedUser user) {
+    final var email = user.getEmail();
+    if (!StringUtils.hasText(email)) {
+      return null;
+    }
+
+    final var existing = memberRepository.findByEmail(email);
+    if (existing.isPresent()) {
+      return existing.get().getId();
+    }
+
+    if (user.getRoles() != null && user.getRoles().contains(RoleType.MENTOR)) {
+      final var mentorId = createMentorProfile(user).getId();
+      mentorRepository.updateProfileStatus(mentorId, ProfileStatus.ACTIVE);
+      LOG.info("Seeded ACTIVE mentor profile: {} (id: {})", email, mentorId);
+      return mentorId;
+    }
+
+    final var member =
+        Member.builder()
+            .fullName(displayName(user))
+            .position("QA Seed User")
+            .email(email)
+            .slackDisplayName(slackName(email))
+            .country(new Country("GB", "United Kingdom"))
+            .memberTypes(user.getMemberTypes() == null ? List.of() : user.getMemberTypes())
+            .build();
+    return memberRepository.create(member).getId();
+  }
+
+  /**
+   * Creates a minimal but valid mentor profile for a seeded user. The service persists it in
+   * PENDING status; the caller then activates it directly (without sending an approval email) so
+   * the mentor appears as ACTIVE in the admin portal.
+   *
+   * @param user the seed user configuration
+   * @return the created mentor, including its generated id
+   */
+  private Mentor createMentorProfile(final SeedUser user) {
+    final var mentor =
+        Mentor.mentorBuilder()
+            .fullName(displayName(user))
+            .position("QA Mentor")
+            .email(user.getEmail())
+            .slackDisplayName(slackName(user.getEmail()))
+            .country(new Country("GB", "United Kingdom"))
+            .profileStatus(ProfileStatus.PENDING)
+            .skills(new Skills(5, List.of(), List.of(), List.of()))
+            .spokenLanguages(List.of("English"))
+            .bio("QA seeded mentor profile for testing the admin portal.")
+            .menteeSection(
+                new MenteeSection("Motivated mentees keen to grow.", null, null, List.of()))
+            .isWomen(true)
+            .build();
+    return mentorshipService.create(mentor);
+  }
+
+  private String displayName(final SeedUser user) {
+    return StringUtils.hasText(user.getFullName()) ? user.getFullName() : user.getEmail();
+  }
+
+  private String slackName(final String email) {
+    return email.split("@", 2)[0].toLowerCase(Locale.ENGLISH);
+  }
+
+  /**
+   * Creates a user account with the given credentials and roles when one does not already exist for
+   * the email. Idempotent so it can run on every startup without duplicating accounts.
+   *
+   * @param email the login email of the account to seed
+   * @param password the plain-text password to hash and store
+   * @param roles the roles to assign to the account
+   * @param memberId the member to link, or null for a role-only account
+   */
+  private void seedUser(
+      final String email, final String password, final List<RoleType> roles, final Long memberId) {
+    if (!StringUtils.hasText(email) || !StringUtils.hasText(password)) {
+      LOG.warn("Seed user skipped: email or password not provided");
+      return;
+    }
+    if (CollectionUtils.isEmpty(roles)) {
+      LOG.warn("Seed user skipped, no roles provided: {}", email);
+      return;
+    }
+    if (userAccountRepository.findByEmail(email).isPresent()) {
+      LOG.info("Seed user already exists: {}", email);
+      return;
+    }
+
+    final var hash = passwordEncoder.encode(password);
+    final var user = new UserAccount(null, memberId, email, hash, roles, true);
     userAccountRepository.create(user);
-    LOG.info(
-        "Seeded default admin user: {} (roles: {})", seedProperties.getEmail(), user.getRoles());
+    LOG.info("Seeded user: {} (roles: {})", email, roles);
   }
 }

--- a/src/main/java/com/wcc/platform/bootstrap/DevAdminSeeder.java
+++ b/src/main/java/com/wcc/platform/bootstrap/DevAdminSeeder.java
@@ -1,12 +1,20 @@
 package com.wcc.platform.bootstrap;
 
+import static com.wcc.platform.domain.cms.attributes.CodeLanguage.JAVASCRIPT;
+import static com.wcc.platform.domain.cms.attributes.ProficiencyLevel.BEGINNER;
+import static com.wcc.platform.domain.cms.attributes.ProficiencyLevel.EXPERT;
+import static com.wcc.platform.domain.cms.attributes.TechnicalArea.FULLSTACK;
+
 import com.wcc.platform.domain.auth.UserAccount;
 import com.wcc.platform.domain.cms.attributes.Country;
+import com.wcc.platform.domain.cms.attributes.MentorshipFocusArea;
 import com.wcc.platform.domain.cms.pages.mentorship.MenteeSection;
 import com.wcc.platform.domain.platform.member.Member;
 import com.wcc.platform.domain.platform.member.ProfileStatus;
+import com.wcc.platform.domain.platform.mentorship.LanguageProficiency;
 import com.wcc.platform.domain.platform.mentorship.Mentor;
 import com.wcc.platform.domain.platform.mentorship.Skills;
+import com.wcc.platform.domain.platform.mentorship.TechnicalAreaProficiency;
 import com.wcc.platform.domain.platform.type.RoleType;
 import com.wcc.platform.repository.MemberRepository;
 import com.wcc.platform.repository.MentorRepository;
@@ -32,6 +40,7 @@ import org.springframework.util.StringUtils;
 public class DevAdminSeeder implements ApplicationRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(DevAdminSeeder.class);
+  private static final int YEARS_EXPERIENCE = 5;
 
   private final UserAccountRepository userAccountRepository;
   private final MemberRepository memberRepository;
@@ -183,7 +192,12 @@ public class DevAdminSeeder implements ApplicationRunner {
             .slackDisplayName(slackName(user.getEmail()))
             .country(new Country("GB", "United Kingdom"))
             .profileStatus(ProfileStatus.PENDING)
-            .skills(new Skills(5, List.of(), List.of(), List.of()))
+            .skills(
+                new Skills(
+                    YEARS_EXPERIENCE,
+                    List.of(new TechnicalAreaProficiency(FULLSTACK, EXPERT)),
+                    List.of(new LanguageProficiency(JAVASCRIPT, BEGINNER)),
+                    List.of(MentorshipFocusArea.GROW_BEGINNER_TO_MID)))
             .spokenLanguages(List.of("English"))
             .bio("QA seeded mentor profile for testing the admin portal.")
             .menteeSection(

--- a/src/main/java/com/wcc/platform/bootstrap/DevAdminSeeder.java
+++ b/src/main/java/com/wcc/platform/bootstrap/DevAdminSeeder.java
@@ -24,17 +24,14 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
- * Seeds default user accounts for local testing so the frontend can authenticate against real data.
- * The default admin is enabled by default and can be disabled with app.seed.admin.enabled=false.
- * Additional role-specific accounts (for example MENTORSHIP_ADMIN, MENTOR and LEADER) are seeded
- * from the app.seed.users configuration list, each linked to a member so login returns full profile
- * information.
+ * Seeds user accounts at application startup from the {@code app.seed.users} configuration list.
+ * Can be disabled with {@code app.seed.enabled=false}. Users holding the MENTOR role are
+ * provisioned with an active mentor profile so they appear in the admin portal's mentor list.
  */
 @Component
 public class DevAdminSeeder implements ApplicationRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(DevAdminSeeder.class);
-  private static final long ADMIN_MEMBER_ID = 1L;
 
   private final UserAccountRepository userAccountRepository;
   private final MemberRepository memberRepository;
@@ -46,12 +43,13 @@ public class DevAdminSeeder implements ApplicationRunner {
 
   /**
    * Constructs a DevAdminSeeder with repositories, mentorship service and seed configuration.
+   *
    * @param userAccountRepository repository for user accounts
    * @param memberRepository repository for members
    * @param mentorRepository repository for mentors, used to activate seeded mentor profiles
    * @param mentorshipService service used to provision mentor profiles for MENTOR-role users
-   * @param seedProperties configuration for the default admin seeder
-   * @param seedUsersProperties configuration for the additional seeded users
+   * @param seedProperties configuration for the seeder enabled flag
+   * @param seedUsersProperties configuration for the list of users to seed
    * @param passwordEncoder Argon2 password encoder
    */
   public DevAdminSeeder(
@@ -73,39 +71,15 @@ public class DevAdminSeeder implements ApplicationRunner {
 
   @Override
   public void run(final ApplicationArguments args) {
-    seedAdmin();
-    seedConfiguredUsers();
+    seedUsers();
   }
 
-  private void seedAdmin() {
+  private void seedUsers() {
     if (!seedProperties.isEnabled()) {
-      LOG.info("Admin seeder disabled (app.seed.admin.enabled=false)");
+      LOG.info("Admin seeder disabled (app.seed.enabled=false)");
       return;
     }
-    final Long memberId = resolveAdminMemberId();
-    seedUser(
-        seedProperties.getEmail(), seedProperties.getPassword(), List.of(RoleType.ADMIN), memberId);
-  }
-
-  /**
-   * Resolves the member linked to the admin account. By default the admin links to the pre-existing
-   * seed member ({@link #ADMIN_MEMBER_ID}); when {@code createOwnMember} is enabled (QA), a
-   * generic member matching the admin email is created instead.
-   *
-   * @return the member id to link to the admin account
-   */
-  private Long resolveAdminMemberId() {
-    if (!seedProperties.isCreateOwnMember()) {
-      return ADMIN_MEMBER_ID;
-    }
-    final var adminSeed = new SeedUser();
-    adminSeed.setEmail(seedProperties.getEmail());
-    adminSeed.setFullName(
-        StringUtils.hasText(seedProperties.getFullName())
-            ? seedProperties.getFullName()
-            : "QA Admin");
-    adminSeed.setRoles(List.of(RoleType.ADMIN));
-    return resolveMemberId(adminSeed);
+    seedConfiguredUsers();
   }
 
   private void seedConfiguredUsers() {
@@ -120,7 +94,7 @@ public class DevAdminSeeder implements ApplicationRunner {
   }
 
   /**
-   * Ensures the configured QA account exists with the expected password and roles. When the account
+   * Ensures the configured account exists with the expected password and roles. When the account
    * was already auto-provisioned (for example by mentor creation, which assigns a random password),
    * its password and roles are reset to the configured values so the credentials are predictable.
    *
@@ -183,7 +157,7 @@ public class DevAdminSeeder implements ApplicationRunner {
     final var member =
         Member.builder()
             .fullName(displayName(user))
-            .position("QA Seed User")
+            .position("QA Seed User " + user.getFullName())
             .email(email)
             .slackDisplayName(slackName(email))
             .country(new Country("GB", "United Kingdom"))
@@ -225,35 +199,5 @@ public class DevAdminSeeder implements ApplicationRunner {
 
   private String slackName(final String email) {
     return email.split("@", 2)[0].toLowerCase(Locale.ENGLISH);
-  }
-
-  /**
-   * Creates a user account with the given credentials and roles when one does not already exist for
-   * the email. Idempotent so it can run on every startup without duplicating accounts.
-   *
-   * @param email the login email of the account to seed
-   * @param password the plain-text password to hash and store
-   * @param roles the roles to assign to the account
-   * @param memberId the member to link, or null for a role-only account
-   */
-  private void seedUser(
-      final String email, final String password, final List<RoleType> roles, final Long memberId) {
-    if (!StringUtils.hasText(email) || !StringUtils.hasText(password)) {
-      LOG.warn("Seed user skipped: email or password not provided");
-      return;
-    }
-    if (CollectionUtils.isEmpty(roles)) {
-      LOG.warn("Seed user skipped, no roles provided: {}", email);
-      return;
-    }
-    if (userAccountRepository.findByEmail(email).isPresent()) {
-      LOG.info("Seed user already exists: {}", email);
-      return;
-    }
-
-    final var hash = passwordEncoder.encode(password);
-    final var user = new UserAccount(null, memberId, email, hash, roles, true);
-    userAccountRepository.create(user);
-    LOG.info("Seeded user: {} (roles: {})", email, roles);
   }
 }

--- a/src/main/java/com/wcc/platform/bootstrap/DevAdminSeederProperties.java
+++ b/src/main/java/com/wcc/platform/bootstrap/DevAdminSeederProperties.java
@@ -24,4 +24,14 @@ public class DevAdminSeederProperties {
   private boolean enabled;
   private String email;
   private String password;
+
+  /**
+   * When true, the admin account is linked to its own generated member (matching the admin email)
+   * instead of the default pre-existing member. Intended for the QA profile so the admin login
+   * returns a generic profile rather than seed-migration data. Defaults to false.
+   */
+  private boolean createOwnMember;
+
+  /** Display name for the admin's generated member when {@link #createOwnMember} is enabled. */
+  private String fullName;
 }

--- a/src/main/java/com/wcc/platform/bootstrap/DevAdminSeederProperties.java
+++ b/src/main/java/com/wcc/platform/bootstrap/DevAdminSeederProperties.java
@@ -6,32 +6,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Configuration properties for Argon2 hashing algorithm. This class binds to properties under the
- * prefix "security.argon2" in the application configuration file and provides customization options
- * for the Argon2 password hashing algorithm.
- *
- * <p>Properties: - saltLength: The length of the salt in bytes. Default is 16. - hashLength: The
- * length of the resulting hash in bytes. Default is 32. - parallelism: The number of parallel
- * threads used for hashing. Default is 1. - memory: The memory cost parameter, representing the
- * amount of memory (in kibibytes) used during hashing. Default is 65536 (64 MiB). - iterations: The
- * number of iterations used during hashing. Default is 3.
+ * Configuration properties for the development user account seeder. Binds to the {@code app.seed}
+ * prefix and controls whether seeding is active at application startup.
  */
 @Getter
 @Setter
 @Configuration
-@ConfigurationProperties(prefix = "app.seed.admin")
+@ConfigurationProperties(prefix = "app.seed")
 public class DevAdminSeederProperties {
   private boolean enabled;
-  private String email;
-  private String password;
-
-  /**
-   * When true, the admin account is linked to its own generated member (matching the admin email)
-   * instead of the default pre-existing member. Intended for the QA profile so the admin login
-   * returns a generic profile rather than seed-migration data. Defaults to false.
-   */
-  private boolean createOwnMember;
-
-  /** Display name for the admin's generated member when {@link #createOwnMember} is enabled. */
-  private String fullName;
 }

--- a/src/main/java/com/wcc/platform/bootstrap/SeedUser.java
+++ b/src/main/java/com/wcc/platform/bootstrap/SeedUser.java
@@ -1,0 +1,23 @@
+package com.wcc.platform.bootstrap;
+
+import com.wcc.platform.domain.platform.type.MemberType;
+import com.wcc.platform.domain.platform.type.RoleType;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Defines a single user account to be seeded at application startup. Bound from each entry under
+ * the {@code app.seed.users} configuration list.
+ */
+@Getter
+@Setter
+public class SeedUser {
+
+  private boolean enabled = true;
+  private String email;
+  private String password;
+  private String fullName;
+  private List<RoleType> roles;
+  private List<MemberType> memberTypes;
+}

--- a/src/main/java/com/wcc/platform/bootstrap/SeedUser.java
+++ b/src/main/java/com/wcc/platform/bootstrap/SeedUser.java
@@ -14,7 +14,7 @@ import lombok.Setter;
 @Setter
 public class SeedUser {
 
-  private boolean enabled = true;
+  private boolean enabled;
   private String email;
   private String password;
   private String fullName;

--- a/src/main/java/com/wcc/platform/bootstrap/SeedUsersProperties.java
+++ b/src/main/java/com/wcc/platform/bootstrap/SeedUsersProperties.java
@@ -1,0 +1,22 @@
+package com.wcc.platform.bootstrap;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration properties for additional user accounts seeded at application startup. Binds to the
+ * {@code app.seed.users} list, allowing roles such as MENTORSHIP_ADMIN, MENTOR and LEADER to be
+ * provisioned automatically alongside the default admin user.
+ */
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "app.seed")
+public class SeedUsersProperties {
+
+  private List<SeedUser> users = new ArrayList<>();
+}

--- a/src/main/resources/application-qa.yml
+++ b/src/main/resources/application-qa.yml
@@ -2,22 +2,25 @@
 # Activate alongside another profile, e.g. SPRING_PROFILES_ACTIVE=docker,qa
 app:
   seed:
-    admin:
-      create-own-member: true
-      full-name: QA Admin
+    enabled: true
     users:
+      - email: admin@wcc.dev
+        password: wcc-admin
+        full-name: QA Admin
+        roles: [ ADMIN ]
+        member-types: [ MEMBER ]
       - email: mentorship-admin@wcc.dev
         password: wcc-admin
         full-name: QA Mentorship Admin
-        roles: [MENTORSHIP_ADMIN]
-        member-types: [MEMBER]
+        roles: [ MENTORSHIP_ADMIN ]
+        member-types: [ MEMBER ]
       - email: mentor@wcc.dev
         password: wcc-admin
         full-name: QA Mentor
-        roles: [MENTOR]
-        member-types: [MENTOR]
+        roles: [ MENTOR ]
+        member-types: [ MENTOR ]
       - email: leader@wcc.dev
         password: wcc-admin
         full-name: QA Leader
-        roles: [LEADER]
-        member-types: [LEADER]
+        roles: [ LEADER ]
+        member-types: [ LEADER ]

--- a/src/main/resources/application-qa.yml
+++ b/src/main/resources/application-qa.yml
@@ -1,0 +1,23 @@
+# QA profile: seeds role-specific accounts for local QA / integration testing.
+# Activate alongside another profile, e.g. SPRING_PROFILES_ACTIVE=docker,qa
+app:
+  seed:
+    admin:
+      create-own-member: true
+      full-name: QA Admin
+    users:
+      - email: mentorship-admin@wcc.dev
+        password: wcc-admin
+        full-name: QA Mentorship Admin
+        roles: [MENTORSHIP_ADMIN]
+        member-types: [MEMBER]
+      - email: mentor@wcc.dev
+        password: wcc-admin
+        full-name: QA Mentor
+        roles: [MENTOR]
+        member-types: [MENTOR]
+      - email: leader@wcc.dev
+        password: wcc-admin
+        full-name: QA Leader
+        roles: [LEADER]
+        member-types: [LEADER]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,11 +72,15 @@ app:
     base-url: ${APP_RESET_PASSWORD_BASE_URL:http://localhost:3000}
     ttl-minutes: 7200
     reset-path: /reset-password
+
   seed:
-    admin:
-      enabled: true
-      email: admin@wcc.dev
-      password: wcc-admin
+    enabled: true
+    users:
+      - email: admin@wcc.dev
+        password: wcc-admin
+        full-name: Platform Admin
+        roles: [ ADMIN ]
+        member-types: [ MEMBER ]
 
 storage:
   type: local

--- a/src/main/resources/db/migration/V38__20260601__disable_unsecure_users.sql
+++ b/src/main/resources/db/migration/V38__20260601__disable_unsecure_users.sql
@@ -1,0 +1,4 @@
+-- Disable users that is not allowed to login to the system.
+UPDATE user_accounts
+SET enabled = false
+WHERE email = 'sonali.learn.ai@gmail.com';

--- a/src/testInt/resources/application-test-db2.yml
+++ b/src/testInt/resources/application-test-db2.yml
@@ -25,5 +25,4 @@ GOOGLE_DRIVE_FOLDER_ID: "some value"
 
 app:
   seed:
-    admin:
-      enabled: false
+    enabled: false

--- a/src/testInt/resources/application-test.yml
+++ b/src/testInt/resources/application-test.yml
@@ -23,5 +23,4 @@ mentorship:
 
 app:
   seed:
-    admin:
-      enabled: false
+    enabled: false


### PR DESCRIPTION
## Summary

Adds a local **QA environment** that seeds a known set of role-based user
accounts on startup, so the QA team can exercise authentication, RBAC and
mentorship flows without manually creating members, mentors, and accounts.

Run it with a single command:

```shell
docker compose -f docker/docker-compose.qa.yml up --build
```

## What's included

A new `qa` Spring profile (`application-qa.yml`) seeds these accounts
(password `wcc-admin`):

| Email                      | Role             | Notes                                       |
|----------------------------|------------------|---------------------------------------------|
| `admin@wcc.dev`            | ADMIN            | Linked to its own generic *QA Admin* member |
| `mentorship-admin@wcc.dev` | MENTORSHIP_ADMIN | Can approve/reject mentors, manage matches  |
| `mentor@wcc.dev`           | MENTOR           | Has an **ACTIVE** mentor profile            |
| `leader@wcc.dev`           | LEADER           |                                             |

## Changes

- **Seeding** — `DevAdminSeeder` now reads a config-driven `app.seed.users`
  list. Each user gets a linked member; MENTOR-role users get a full mentor
  profile, activated directly (no approval email). Accounts auto-provisioned
  by mentor creation have their password/roles reset to the configured
  values so credentials are predictable.
- **Generic QA admin** — new `app.seed.admin.create-own-member` flag (default
  **off**) makes the admin link to its own member matching its email instead
  of the pre-existing seed member. Enabled only in the `qa` profile, so the
  default/prod admin seeding is unchanged.
- **Docker** — standalone `docker/docker-compose.qa.yml` (activates
  `docker,qa`); the Dockerfile now caches Gradle dependencies in their own
  layer so source edits don't trigger a full re-download.
- **Docs** — `docs/qa_local_setup.md` with setup, login, verification, reset,
  and how to add/change seeded users.

## How to test

```shell
docker compose -f docker/docker-compose.qa.yml down -v
docker compose -f docker/docker-compose.qa.yml up --build
```

Then log in and confirm roles + profile:

```shell
curl -s -X POST http://localhost:8080/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"mentor@wcc.dev","password":"wcc-admin"}'
```

`./gradlew test` and `./gradlew :pmdMain` pass.

## Notes

- The `qa` profile and its plaintext passwords are **local-only** and must
  never be activated in a deployed environment.
- The Dockerfile build base image is `gradle:8.7` (non-alpine); this was
  needed for the build to run reliably.
- Pre-existing seed member `sonali.learn.ai@gmail.com` (from Flyway migration
  V23) still exists in the DB but is no longer linked to the admin login.
