### PR TITLE
fix: Enable seeded user accounts

### DIFF
--- a/src/main/resources/application-qa.yml
+++ b/src/main/resources/application-qa.yml
@@ -4,22 +4,26 @@ app:
   seed:
     enabled: true
     users:
-      - email: admin@wcc.dev
+      - enabled: true
+        email: admin@wcc.dev
         password: wcc-admin
         full-name: QA Admin
         roles: [ ADMIN ]
         member-types: [ MEMBER ]
-      - email: mentorship-admin@wcc.dev
+      - enabled: true
+        email: mentorship-admin@wcc.dev
         password: wcc-admin
         full-name: QA Mentorship Admin
         roles: [ MENTORSHIP_ADMIN ]
         member-types: [ MEMBER ]
-      - email: mentor@wcc.dev
+      - enabled: true
+        email: mentor@wcc.dev
         password: wcc-admin
         full-name: QA Mentor
         roles: [ MENTOR ]
         member-types: [ MENTOR ]
-      - email: leader@wcc.dev
+      - enabled: true
+        email: leader@wcc.dev
         password: wcc-admin
         full-name: QA Leader
         roles: [ LEADER ]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,7 +76,8 @@ app:
   seed:
     enabled: true
     users:
-      - email: admin@wcc.dev
+      - enabled: true
+        email: admin@wcc.dev
         password: wcc-admin
         full-name: Platform Admin
         roles: [ ADMIN ]


### PR DESCRIPTION
## Description

Add `enabled: true` to each user entry under `app.seed.users` in both `application.yml` and `application-qa.yml`.                                                         
                                                                                                                                                                            
Without this flag, `SeedUser.enabled` defaults to `false` (Java boolean default), so `DevAdminSeeder` logs `Seed user disabled, skipping` for every entry on startup. This leaves fresh-database setups without any usable login credentials.


## Change Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Test
- [ ] Other


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.

