### PR TITLE
feat: Admin UI: Add Mentee Profile Card to Reviewing Mentor Application page

### DIFF
--- a/admin-wcc-app/__tests__/pages/admin/mentor.test.tsx
+++ b/admin-wcc-app/__tests__/pages/admin/mentor.test.tsx
@@ -49,6 +49,48 @@ const reviewingApp = {
   reviewed: false,
   matched: false,
   daysSinceApplied: 3,
+  mentee: {
+    id: 7,
+    fullName: 'Mentee #7',
+    position: 'Frontend Developer',
+    email: 'mentee7@example.com',
+    slackDisplayName: '@mentee7',
+    country: {
+      countryCode: 'GB',
+      countryName: 'United Kingdom',
+    },
+    city: 'London',
+    companyName: 'Test Company',
+    memberTypes: ['Mentee'],
+    images: [],
+    network: [
+      {
+        type: 'linkedin',
+        link: 'https://www.linkedin.com/in/test-mentee',
+      },
+    ],
+    isWomen: true,
+    profileStatus: 'ACTIVE',
+    skills: {
+      yearsExperience: 2,
+      areas: [
+        {
+          technicalArea: 'FRONTEND',
+          proficiencyLevel: 'INTERMEDIATE',
+        },
+      ],
+      languages: [
+        {
+          language: 'JAVASCRIPT',
+          proficiencyLevel: 'INTERMEDIATE',
+        },
+      ],
+      mentorshipFocus: ['GROW_BEGINNER_TO_MID'],
+    },
+    bio: 'Test mentee bio',
+    spokenLanguages: ['English'],
+    availableHsMonth: 4,
+  },
 };
 
 const pendingApp = {

--- a/admin-wcc-app/pages/admin/mentor.tsx
+++ b/admin-wcc-app/pages/admin/mentor.tsx
@@ -33,6 +33,7 @@ import {
 } from '@/services/menteeService';
 import { MenteeApplication } from '@/types/menteeApplication';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import MenteeCard from '@/components/mentorship/MenteeCard';
 
 interface MemberWithId {
   id: number;
@@ -314,9 +315,6 @@ export default function MentorDashboardPage() {
                         <strong>Mentee</strong>
                       </TableCell>
                       <TableCell>
-                        <strong>Bio</strong>
-                      </TableCell>
-                      <TableCell>
                         <strong>Message</strong>
                       </TableCell>
                       <TableCell>
@@ -329,86 +327,12 @@ export default function MentorDashboardPage() {
                   </TableHead>
                   <TableBody>
                     {pendingApplications.map((app) => {
-                      const name = app.menteeName || `Mentee #${app.menteeId}`;
                       return (
                         <TableRow key={app.applicationId} hover>
                           <TableCell>
                             <Stack direction="row" alignItems="center" spacing={1}>
-                              <Avatar
-                                sx={{
-                                  width: 32,
-                                  height: 32,
-                                  fontSize: 13,
-                                  bgcolor: 'secondary.main',
-                                }}
-                              >
-                                {getInitials(name)}
-                              </Avatar>
-                              <Typography variant="body2">{name}</Typography>
-                              {app.menteeLinkedIn && (
-                                <Button
-                                  href={app.menteeLinkedIn}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  size="small"
-                                  sx={{ minWidth: 'auto', p: 0.5 }}
-                                >
-                                  <LinkedInIcon fontSize="small" sx={{ color: '#0077b5' }} />
-                                </Button>
-                              )}
+                              <MenteeCard mentee={app.mentee} />
                             </Stack>
-                          </TableCell>
-                          <TableCell sx={{ maxWidth: 250 }}>
-                            {app.menteeBio ? (
-                              expandedBioId === app.applicationId ? (
-                                <Box>
-                                  <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
-                                    {app.menteeBio}
-                                  </Typography>
-                                  <Button
-                                    size="small"
-                                    onClick={() => setExpandedBioId(null)}
-                                    sx={{ p: 0, minWidth: 'auto', textTransform: 'none' }}
-                                  >
-                                    Show less
-                                  </Button>
-                                </Box>
-                              ) : (
-                                <Box>
-                                  <Typography
-                                    variant="body2"
-                                    ref={(el) => {
-                                      if (el) {
-                                        bioRefs.current.set(app.applicationId, el);
-                                      } else {
-                                        bioRefs.current.delete(app.applicationId);
-                                      }
-                                    }}
-                                    sx={{
-                                      display: '-webkit-box',
-                                      WebkitLineClamp: 2,
-                                      WebkitBoxOrient: 'vertical',
-                                      overflow: 'hidden',
-                                    }}
-                                  >
-                                    {app.menteeBio}
-                                  </Typography>
-                                  {overflowingBioIds.has(app.applicationId) && (
-                                    <Button
-                                      size="small"
-                                      onClick={() => setExpandedBioId(app.applicationId)}
-                                      sx={{ p: 0, minWidth: 'auto', textTransform: 'none' }}
-                                    >
-                                      Show more
-                                    </Button>
-                                  )}
-                                </Box>
-                              )
-                            ) : (
-                              <Typography variant="body2" color="text.secondary">
-                                -
-                              </Typography>
-                            )}
                           </TableCell>
                           <TableCell sx={{ maxWidth: 300 }}>
                             {expandedMessageId === app.applicationId ? (

--- a/admin-wcc-app/types/menteeApplication.ts
+++ b/admin-wcc-app/types/menteeApplication.ts
@@ -1,3 +1,6 @@
+import { MenteeItem } from '@/types/mentorship';
+import type { SocialNetwork } from '@/types/member';
+
 export type ApplicationStatus =
   | 'PENDING'
   | 'MENTOR_REVIEWING'
@@ -29,6 +32,7 @@ export interface MenteeApplication {
   menteeName?: string;
   menteeLinkedIn?: string;
   menteeBio?: string;
+  mentee: MenteeItem;
 }
 
 export interface MenteeSkillArea {
@@ -56,7 +60,6 @@ export interface MenteeImage {
 
 export { SocialNetworkType } from '@/types/member';
 export type { SocialNetwork, SocialNetworkTypeValue } from '@/types/member';
-import type { SocialNetwork } from '@/types/member';
 
 export interface DashboardMentee {
   id: number;

--- a/src/main/java/com/wcc/platform/domain/platform/mentorship/MenteeApplicationResponse.java
+++ b/src/main/java/com/wcc/platform/domain/platform/mentorship/MenteeApplicationResponse.java
@@ -29,7 +29,24 @@ public record MenteeApplicationResponse(
     long daysSinceApplied,
     String menteeName,
     String menteeLinkedIn,
-    String menteeBio) {
+    String menteeBio,
+    Mentee mentee) {
+
+  /**
+   * Creates an enriched response from a MenteeApplication and full mentee profile.
+   *
+   * @param application the base application
+   * @param mentee the mentee profile
+   * @return enriched response with mentee information
+   */
+  public static MenteeApplicationResponse from(
+      final MenteeApplication application, final Mentee mentee) {
+    if (mentee == null) {
+      return from(application);
+    }
+
+    return from(application, mentee.getFullName(), mentee.getNetwork(), mentee.getBio(), mentee);
+  }
 
   /**
    * Creates an enriched response from a MenteeApplication and mentee details.
@@ -45,6 +62,15 @@ public record MenteeApplicationResponse(
       final String menteeName,
       final List<SocialNetwork> networks,
       final String bio) {
+    return from(application, menteeName, networks, bio, null);
+  }
+
+  private static MenteeApplicationResponse from(
+      final MenteeApplication application,
+      final String menteeName,
+      final List<SocialNetwork> networks,
+      final String bio,
+      final Mentee mentee) {
 
     final String linkedIn = extractLinkedIn(networks);
 
@@ -68,7 +94,8 @@ public record MenteeApplicationResponse(
         application.getDaysSinceApplied(),
         menteeName,
         linkedIn,
-        bio);
+        bio,
+        mentee);
   }
 
   /**
@@ -79,7 +106,7 @@ public record MenteeApplicationResponse(
    * @return response without enriched mentee information
    */
   public static MenteeApplicationResponse from(final MenteeApplication application) {
-    return from(application, null, List.of(), null);
+    return from(application, null, List.of(), null, null);
   }
 
   private static String extractLinkedIn(final List<SocialNetwork> networks) {

--- a/src/main/java/com/wcc/platform/service/MenteeWorkflowService.java
+++ b/src/main/java/com/wcc/platform/service/MenteeWorkflowService.java
@@ -298,8 +298,7 @@ public class MenteeWorkflowService {
             app -> {
               final Mentee mentee = menteeMap.get(app.getMenteeId());
               if (mentee != null) {
-                return MenteeApplicationResponse.from(
-                    app, mentee.getFullName(), mentee.getNetwork(), mentee.getBio());
+                return MenteeApplicationResponse.from(app, mentee);
               }
               return MenteeApplicationResponse.from(app);
             })

--- a/src/test/java/com/wcc/platform/service/MenteeApplicationEnrichedTest.java
+++ b/src/test/java/com/wcc/platform/service/MenteeApplicationEnrichedTest.java
@@ -65,11 +65,18 @@ class MenteeApplicationEnrichedTest {
     final List<MenteeApplicationResponse> result = service.getMentorApplications(MENTOR_ID);
 
     assertThat(result).hasSize(1);
-    assertThat(result.get(0).menteeName()).isEqualTo("Jane Doe");
-    assertThat(result.get(0).menteeLinkedIn()).isEqualTo("https://linkedin.com/in/janedoe");
-    assertThat(result.get(0).menteeBio()).isEqualTo("A passionate developer");
-    assertThat(result.get(0).applicationId()).isEqualTo(1L);
-    assertThat(result.get(0).menteeId()).isEqualTo(MENTEE_ID);
+    final MenteeApplicationResponse response = result.get(0);
+
+    assertThat(response.menteeName()).isEqualTo("Jane Doe");
+    assertThat(response.menteeLinkedIn()).isEqualTo("https://linkedin.com/in/janedoe");
+    assertThat(response.menteeBio()).isEqualTo("A passionate developer");
+    assertThat(response.applicationId()).isEqualTo(1L);
+    assertThat(response.menteeId()).isEqualTo(MENTEE_ID);
+
+    assertThat(response.mentee()).isNotNull();
+    assertThat(response.mentee().getId()).isEqualTo(MENTEE_ID);
+    assertThat(response.mentee().getFullName()).isEqualTo("Jane Doe");
+    assertThat(response.mentee().getBio()).isEqualTo("A passionate developer");
   }
 
   @Test
@@ -99,6 +106,7 @@ class MenteeApplicationEnrichedTest {
     assertThat(result.get(0).menteeName()).isNull();
     assertThat(result.get(0).menteeLinkedIn()).isNull();
     assertThat(result.get(0).menteeBio()).isNull();
+    assertThat(result.get(0).mentee()).isNull();
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR adds the mentee profile card to the Mentor Dashboard Mentee Applications section.

Changes included:

- Extended GET /api/platform/v1/mentors/{mentorId}/applications to return nested mentee profile data.
- Updated the Mentor Dashboard page to render the existing MenteeCard for reviewing mentor applications.
- Removed redundant Bio and LinkedIn columns from the applications table because this information is now covered by the mentee profile card. Kept application-specific information visible, including the application message, applied date, and accept/decline actions.
- Updated frontend test mocks to include the nested mentee object returned by the API.

## Related Issue

Please link to the issue here
Closes #683
Closes #686

## Change Type

- [ ] Bug Fix
- [x] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [x] Test
- [ ] Other

## Screenshots

Added locally verified Mentor Dashboard UI showing the mentee profile card in the Mentee Applications section.

<img width="1656" height="901" alt="Screenshot 2026-06-08 at 14 21 53" src="https://github.com/user-attachments/assets/df7cecf9-69bc-4697-b2ed-270c2c6d6eb3" />

## Testing
./gradlew test
npm run lint
npm test -- --watch=false
npm run build
Verified locally that GET /api/platform/v1/mentors/{mentorId}/applications returns nested mentee profile data.
Verified locally that /admin/mentor renders the mentee profile card for reviewing mentor applications.

## Notes

The recommendations endpoint was not used for this page because it requires elevated Platform Administrator / Platform Leader permissions. The Mentor Dashboard now uses the mentor applications endpoint directly with the full nested mentee profile data.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.