### PR TITLE
chore: Auto Stop Dev App

### DIFF
--- a/fly-dev.toml
+++ b/fly-dev.toml
@@ -16,7 +16,7 @@ SPRING_PROFILES_ACTIVE = "flyio"
 [http_service]
 internal_port = 8080
 force_https = true
-auto_stop_machines = 'off'
+auto_stop_machines = 'on'
 auto_start_machines = true
 min_machines_running = 0
 processes = ['app']


### PR DESCRIPTION
## Description

To reduce costs with DEV machines, it will automatically turn off after some time of not been in use