### PR TITLE
chore: Use valid auto_stop_machines value in fly-dev.toml

### DIFF
--- a/fly-dev.toml
+++ b/fly-dev.toml
@@ -16,7 +16,7 @@ SPRING_PROFILES_ACTIVE = "flyio"
 [http_service]
 internal_port = 8080
 force_https = true
-auto_stop_machines = 'on'
+auto_stop_machines = 'stop'
 auto_start_machines = true
 min_machines_running = 0
 processes = ['app']

--- a/fly-dev.toml
+++ b/fly-dev.toml
@@ -16,7 +16,7 @@ SPRING_PROFILES_ACTIVE = "flyio"
 [http_service]
 internal_port = 8080
 force_https = true
-auto_stop_machines = 'off'
+auto_stop_machines = 'on'
 auto_start_machines = true
 min_machines_running = 0
 processes = ['app']


### PR DESCRIPTION

Fly.io no longer accepts 'on' for autostop; 'stop' preserves idle shutdown behavior.