### PR TITLE
fix(#701): hide month availability for long-term mentors

### DIFF
--- a/admin-wcc-app/components/EditMentor/MentorshipAvailabilitySection.tsx
+++ b/admin-wcc-app/components/EditMentor/MentorshipAvailabilitySection.tsx
@@ -9,8 +9,8 @@ import {
   Typography,
 } from '@mui/material';
 import Grid from '@mui/material/Grid2';
-import { Controller } from 'react-hook-form';
-import { MENTORSHIP_TYPES } from '@/lib/mentorshipTypes';
+import { Controller, useWatch } from 'react-hook-form';
+import { MENTORSHIP_TYPE_VALUES, MENTORSHIP_TYPES } from '@/lib/mentorshipTypes';
 import { FormSectionProps } from './types';
 
 const MONTHS = [
@@ -31,6 +31,13 @@ const MONTHS = [
 const monthLabel = (month: string) => month.charAt(0) + month.slice(1).toLowerCase();
 
 export default function MentorshipAvailabilitySection({ control, errors }: FormSectionProps) {
+  const mentorshipType = useWatch({
+    control,
+    name: 'mentorshipType',
+  });
+
+  const hasAdHocMentorship = mentorshipType?.includes(MENTORSHIP_TYPE_VALUES.AD_HOC);
+
   return (
     <Paper variant="outlined" sx={{ p: 3 }}>
       <Typography variant="h6" sx={{ mb: 2 }}>
@@ -119,54 +126,56 @@ export default function MentorshipAvailabilitySection({ control, errors }: FormS
           />
         </Grid>
 
-        <Grid size={12}>
-          <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 600 }}>
-            Month Availability
-          </Typography>
-          <Grid container spacing={2}>
-            {MONTHS.map((month, index) => (
-              <Grid size={{ xs: 12, sm: 4 }} key={month}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <Controller
-                    name={`monthAvailability.${index}.enabled`}
-                    control={control}
-                    render={({ field }) => (
-                      <FormControlLabel
-                        control={
-                          <Checkbox
-                            checked={field.value}
-                            onChange={(e) => field.onChange(e.target.checked)}
-                            size="small"
-                          />
-                        }
-                        label={monthLabel(month)}
-                        sx={{ minWidth: 110 }}
-                      />
-                    )}
-                  />
-                  <Controller
-                    name={`monthAvailability.${index}.hours`}
-                    control={control}
-                    render={({ field: { onChange, value, ...field } }) => (
-                      <TextField
-                        {...field}
-                        value={value}
-                        onChange={(e) =>
-                          onChange(e.target.value === '' ? 0 : Number(e.target.value))
-                        }
-                        type="number"
-                        size="small"
-                        label="hours"
-                        slotProps={{ htmlInput: { min: 0, max: 200 } }}
-                        sx={{ width: 80 }}
-                      />
-                    )}
-                  />
-                </Box>
-              </Grid>
-            ))}
+        {hasAdHocMentorship && (
+          <Grid size={12}>
+            <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 600 }}>
+              Month Availability
+            </Typography>
+            <Grid container spacing={2}>
+              {MONTHS.map((month, index) => (
+                <Grid size={{ xs: 12, sm: 4 }} key={month}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Controller
+                      name={`monthAvailability.${index}.enabled`}
+                      control={control}
+                      render={({ field }) => (
+                        <FormControlLabel
+                          control={
+                            <Checkbox
+                              checked={field.value}
+                              onChange={(e) => field.onChange(e.target.checked)}
+                              size="small"
+                            />
+                          }
+                          label={monthLabel(month)}
+                          sx={{ minWidth: 110 }}
+                        />
+                      )}
+                    />
+                    <Controller
+                      name={`monthAvailability.${index}.hours`}
+                      control={control}
+                      render={({ field: { onChange, value, ...field } }) => (
+                        <TextField
+                          {...field}
+                          value={value}
+                          onChange={(e) =>
+                            onChange(e.target.value === '' ? 0 : Number(e.target.value))
+                          }
+                          type="number"
+                          size="small"
+                          label="hours"
+                          slotProps={{ htmlInput: { min: 0, max: 200 } }}
+                          sx={{ width: 80 }}
+                        />
+                      )}
+                    />
+                  </Box>
+                </Grid>
+              ))}
+            </Grid>
           </Grid>
-        </Grid>
+        )}
       </Grid>
     </Paper>
   );

--- a/admin-wcc-app/lib/mentorshipTypes.ts
+++ b/admin-wcc-app/lib/mentorshipTypes.ts
@@ -1,4 +1,9 @@
+export const MENTORSHIP_TYPE_VALUES = {
+  AD_HOC: 'AD_HOC',
+  LONG_TERM: 'LONG_TERM',
+} as const;
+
 export const MENTORSHIP_TYPES = [
-  { value: 'AD_HOC', label: 'Ad Hoc' },
-  { value: 'LONG_TERM', label: 'Long Term' },
+  { value: MENTORSHIP_TYPE_VALUES.AD_HOC, label: 'Ad Hoc' },
+  { value: MENTORSHIP_TYPE_VALUES.LONG_TERM, label: 'Long Term' },
 ];


### PR DESCRIPTION
## Description

- Hide the Month Availability section when a mentor only has the Long Term mentorship type selected.
- Keep Month Availability visible when Ad Hoc is selected, either alone or together with Long Term.

## Related Issue

Closes #701

## Change Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Test
- [ ] Other

## Screenshots

<img width="1638" height="857" alt="Screenshot 2026-06-14 at 22 40 00" src="https://github.com/user-attachments/assets/590cb5fa-e540-4475-928c-8bc616f692d2" />
<img width="1672" height="908" alt="Screenshot 2026-06-14 at 22 39 17" src="https://github.com/user-attachments/assets/40204117-c318-4817-899a-034fcea8ed48" />
<img width="1626" height="851" alt="Screenshot 2026-06-14 at 22 40 32" src="https://github.com/user-attachments/assets/fa1a99c4-9dfb-4ba8-b78a-b71be88c1cc1" />

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->