### PR TITLE
Feat/adhoc application flow

### DIFF
--- a/src/main/java/com/wcc/platform/domain/platform/mentorship/MenteeRegistration.java
+++ b/src/main/java/com/wcc/platform/domain/platform/mentorship/MenteeRegistration.java
@@ -38,12 +38,17 @@ public record MenteeRegistration(
                 builder.applicationMessage(application.applicationMessage());
               }
 
+              final var initialStatus =
+                  cycle.getMentorshipType() == MentorshipType.AD_HOC
+                      ? ApplicationStatus.MENTOR_REVIEWING
+                      : ApplicationStatus.PENDING;
+
               return builder
                   .menteeId(menteeId)
                   .mentorId(application.mentorId())
                   .whyMentor(application.whyMentor())
                   .priorityOrder(application.priorityOrder())
-                  .status(ApplicationStatus.PENDING)
+                  .status(initialStatus)
                   .cycleId(cycle.getCycleId())
                   .build();
             })

--- a/src/main/java/com/wcc/platform/service/MenteeService.java
+++ b/src/main/java/com/wcc/platform/service/MenteeService.java
@@ -8,6 +8,7 @@ import com.wcc.platform.domain.platform.mentorship.Mentee;
 import com.wcc.platform.domain.platform.mentorship.MenteeApplication;
 import com.wcc.platform.domain.platform.mentorship.MenteeRegistration;
 import com.wcc.platform.domain.platform.mentorship.MentorshipCycleEntity;
+import com.wcc.platform.domain.platform.mentorship.MentorshipType;
 import com.wcc.platform.domain.platform.type.MemberType;
 import com.wcc.platform.domain.platform.type.RoleType;
 import com.wcc.platform.repository.MemberRepository;
@@ -34,6 +35,7 @@ public class MenteeService {
   private final MemberRepository memberRepository;
   private final MentorRepository mentorRepository;
   private final UserProvisionService userProvisionService;
+  private final MentorshipService mentorshipService;
 
   /**
    * Return all active mentees (status_id = 1).
@@ -207,7 +209,22 @@ public class MenteeService {
     final var applications = menteeRegistration.toApplications(cycle, menteeId);
     applications.forEach(registrationsRepo::create);
 
+    if (cycle.getMentorshipType() == MentorshipType.AD_HOC) {
+      applications.forEach(app -> notifyMentorForAdHocApplication(app, cycle));
+    }
+
     return menteeRepository.findById(menteeId).orElseThrow();
+  }
+
+  private void notifyMentorForAdHocApplication(
+      final MenteeApplication application, final MentorshipCycleEntity cycle) {
+    mentorRepository
+        .findById(application.getMentorId())
+        .ifPresent(
+            mentor ->
+                mentorshipService
+                    .getNotificationService()
+                    .sendNewMenteesNotification(mentor, cycle));
   }
 
   /**

--- a/src/main/java/com/wcc/platform/service/MenteeWorkflowService.java
+++ b/src/main/java/com/wcc/platform/service/MenteeWorkflowService.java
@@ -13,6 +13,7 @@ import com.wcc.platform.domain.platform.mentorship.MenteeApplicationAdminRespons
 import com.wcc.platform.domain.platform.mentorship.MenteeApplicationResponse;
 import com.wcc.platform.domain.platform.mentorship.Mentor;
 import com.wcc.platform.domain.platform.mentorship.MentorshipCycleEntity;
+import com.wcc.platform.domain.platform.mentorship.MentorshipType;
 import com.wcc.platform.repository.MenteeApplicationRepository;
 import com.wcc.platform.repository.MenteeRepository;
 import com.wcc.platform.repository.MentorRepository;
@@ -46,6 +47,7 @@ public class MenteeWorkflowService {
   private final MenteeRepository menteeRepository;
   private final MentorshipService mentorshipService;
   private final MentorRepository mentorRepository;
+  private final MentorshipMatchingService mentorshipMatchingService;
 
   /**
    * Find applications for admin view by cycle, statuses, and optionally mentor.
@@ -190,7 +192,13 @@ public class MenteeWorkflowService {
     final MenteeApplication application = getApplicationOrThrow(applicationId);
 
     validateApplicationCanBeAccepted(application);
-    checkMentorCapacity(application.getMentorId(), application.getCycleId());
+    final MentorshipCycleEntity cycle =
+        checkMentorCapacity(application.getMentorId(), application.getCycleId());
+
+    if (cycle.getMentorshipType() == MentorshipType.AD_HOC) {
+      mentorshipMatchingService.confirmMatch(applicationId);
+      return getApplicationOrThrow(applicationId);
+    }
 
     final MenteeApplication updated =
         applicationRepository.updateStatus(
@@ -458,7 +466,7 @@ public class MenteeWorkflowService {
     }
   }
 
-  private void checkMentorCapacity(final Long mentorId, final Long cycleId) {
+  private MentorshipCycleEntity checkMentorCapacity(final Long mentorId, final Long cycleId) {
     final MentorshipCycleEntity cycle =
         cycleRepository
             .findById(cycleId)
@@ -473,6 +481,8 @@ public class MenteeWorkflowService {
               "Mentor %d has reached maximum capacity (%d) for cycle %d",
               mentorId, cycle.getMaxMenteesPerMentor(), cycleId));
     }
+
+    return cycle;
   }
 
   /**

--- a/src/main/java/com/wcc/platform/service/MenteeWorkflowService.java
+++ b/src/main/java/com/wcc/platform/service/MenteeWorkflowService.java
@@ -38,6 +38,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@SuppressWarnings("PMD.ExcessiveImports")
 public class MenteeWorkflowService {
 
   public static final String CYCLE_NOT_FOUND = "Cycle not found: ";
@@ -47,7 +48,7 @@ public class MenteeWorkflowService {
   private final MenteeRepository menteeRepository;
   private final MentorshipService mentorshipService;
   private final MentorRepository mentorRepository;
-  private final MentorshipMatchingService mentorshipMatchingService;
+  private final MentorshipMatchingService matchingService;
 
   /**
    * Find applications for admin view by cycle, statuses, and optionally mentor.
@@ -196,7 +197,7 @@ public class MenteeWorkflowService {
         checkMentorCapacity(application.getMentorId(), application.getCycleId());
 
     if (cycle.getMentorshipType() == MentorshipType.AD_HOC) {
-      mentorshipMatchingService.confirmMatch(applicationId);
+      matchingService.confirmMatch(applicationId);
       return getApplicationOrThrow(applicationId);
     }
 

--- a/src/main/java/com/wcc/platform/service/MentorshipMatchingService.java
+++ b/src/main/java/com/wcc/platform/service/MentorshipMatchingService.java
@@ -9,6 +9,7 @@ import com.wcc.platform.domain.platform.mentorship.MatchStatus;
 import com.wcc.platform.domain.platform.mentorship.MenteeApplication;
 import com.wcc.platform.domain.platform.mentorship.MentorshipCycleEntity;
 import com.wcc.platform.domain.platform.mentorship.MentorshipMatch;
+import com.wcc.platform.domain.platform.mentorship.MentorshipType;
 import com.wcc.platform.repository.MenteeApplicationRepository;
 import com.wcc.platform.repository.MenteeRepository;
 import com.wcc.platform.repository.MentorshipCycleRepository;
@@ -37,7 +38,6 @@ public class MentorshipMatchingService {
   private final MentorshipCycleRepository cycleRepository;
   private final MentorshipService mentorshipService;
   private final MenteeRepository menteeRepository;
-
   /**
    * Confirm a match from an accepted application. This is typically done by mentorship team after
    * mentor acceptance.
@@ -58,10 +58,6 @@ public class MentorshipMatchingService {
             .findById(applicationId)
             .orElseThrow(() -> new ApplicationNotFoundException(applicationId));
 
-    validateApplicationCanBeMatched(application);
-    checkMentorCapacity(application.getMentorId(), application.getCycleId());
-    checkMenteeNotAlreadyMatched(application.getMenteeId(), application.getCycleId());
-
     final MentorshipCycleEntity cycle =
         cycleRepository
             .findById(application.getCycleId())
@@ -69,6 +65,10 @@ public class MentorshipMatchingService {
                 () ->
                     new MentorshipCycleClosedException(
                         "Cycle not found: " + application.getCycleId()));
+
+    validateApplicationCanBeMatched(application, cycle);
+    checkMentorCapacity(application.getMentorId(), application.getCycleId());
+    checkMenteeNotAlreadyMatched(application.getMenteeId(), application.getCycleId());
 
     final MentorshipMatch match =
         MentorshipMatch.builder()
@@ -289,11 +289,19 @@ public class MentorshipMatchingService {
         .orElseThrow(() -> new IllegalArgumentException("Match not found: " + matchId));
   }
 
-  private void validateApplicationCanBeMatched(final MenteeApplication application) {
-    if (application.getStatus() != ApplicationStatus.MENTOR_ACCEPTED) {
+  private void validateApplicationCanBeMatched(
+      final MenteeApplication application, final MentorshipCycleEntity cycle) {
+    final ApplicationStatus requiredStatus =
+        cycle.getMentorshipType() == MentorshipType.AD_HOC
+            ? ApplicationStatus.MENTOR_REVIEWING
+            : ApplicationStatus.MENTOR_ACCEPTED;
+
+    if (application.getStatus() != requiredStatus) {
       throw new IllegalStateException(
-          "Can only confirm matches from MENTOR_ACCEPTED applications, current status: "
-              + application.getStatus());
+          "Can only confirm matches from "
+              + requiredStatus.name()
+              + " applications, current status: "
+              + application.getStatus().name());
     }
   }
 

--- a/src/test/java/com/wcc/platform/service/MenteeServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/MenteeServiceTest.java
@@ -6,9 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -54,6 +57,8 @@ class MenteeServiceTest {
   @Mock private MemberRepository memberRepository;
   @Mock private MentorRepository mentorRepository;
   @Mock private UserProvisionService userProvisionService;
+  @Mock private MentorshipService mentorshipService;
+  @Mock private MentorshipNotificationService notificationService;
 
   private MenteeService menteeService;
   private Mentee mentee;
@@ -68,7 +73,9 @@ class MenteeServiceTest {
             menteeRepository,
             memberRepository,
             mentorRepository,
-            userProvisionService);
+            userProvisionService,
+            mentorshipService);
+    lenient().when(mentorshipService.getNotificationService()).thenReturn(notificationService);
     mentee = createMenteeTest(null, "Test Mentee", "test@wcc.com");
     when(mentorRepository.findById(any())).thenReturn(Optional.of(Mentor.mentorBuilder().build()));
 
@@ -374,7 +381,7 @@ class MenteeServiceTest {
     assertThat(result).isEqualTo(mentee);
     verify(menteeRepository).create(any(Mentee.class));
     verify(cycleRepository, atLeastOnce()).findOpenCycle();
-    verify(mentorRepository).findById(1L);
+    verify(mentorRepository, times(2)).findById(1L);
   }
 
   @Test
@@ -674,6 +681,112 @@ class MenteeServiceTest {
     verify(memberRepository).findByEmail("mentor@wcc.com");
     verify(memberRepository).findById(100L);
     verify(menteeRepository).create(any(Mentee.class));
+  }
+
+  @Test
+  @DisplayName(
+      "Given an AD_HOC cycle, when registering a mentee, "
+          + "then applications are created with MENTOR_REVIEWING status")
+  void shouldCreateApplicationsWithMentorReviewingStatusForAdHocCycle() {
+    var currentYear = Year.now();
+    var existingMentee = createMenteeTest(5L, "Test Mentee", "test@wcc.com");
+    var registration =
+        new MenteeRegistration(
+            existingMentee,
+            MentorshipType.AD_HOC,
+            currentYear,
+            List.of(new MenteeApplicationDto(1L, 1, "msg", "why")));
+
+    var cycle =
+        MentorshipCycleEntity.builder()
+            .cycleId(1L)
+            .cycleYear(currentYear)
+            .mentorshipType(MentorshipType.AD_HOC)
+            .status(CycleStatus.OPEN)
+            .build();
+
+    when(cycleRepository.findOpenCycle()).thenReturn(Optional.of(cycle));
+    when(menteeRepository.findById(5L)).thenReturn(Optional.of(existingMentee));
+    when(applicationRepository.findByMenteeAndCycle(any(), any())).thenReturn(List.of());
+    when(applicationRepository.countMenteeApplications(any(), any())).thenReturn(0L);
+    when(menteeRepository.update(eq(5L), any(Mentee.class)))
+        .thenAnswer(invocation -> invocation.getArgument(1));
+
+    menteeService.saveRegistration(registration);
+
+    verify(applicationRepository)
+        .create(argThat(app -> app.getStatus() == ApplicationStatus.MENTOR_REVIEWING));
+  }
+
+  @Test
+  @DisplayName(
+      "Given an AD_HOC cycle, when registering a mentee, "
+          + "then sendNewMenteesNotification is sent to each mentor")
+  void shouldSendMentorNotificationForAdHocRegistration() {
+    var currentYear = Year.now();
+    var existingMentee = createMenteeTest(5L, "Test Mentee", "test@wcc.com");
+    var registration =
+        new MenteeRegistration(
+            existingMentee,
+            MentorshipType.AD_HOC,
+            currentYear,
+            List.of(new MenteeApplicationDto(1L, 1, "msg", "why")));
+
+    var cycle =
+        MentorshipCycleEntity.builder()
+            .cycleId(1L)
+            .cycleYear(currentYear)
+            .mentorshipType(MentorshipType.AD_HOC)
+            .status(CycleStatus.OPEN)
+            .build();
+    var mentor = Mentor.mentorBuilder().build();
+
+    when(cycleRepository.findOpenCycle()).thenReturn(Optional.of(cycle));
+    when(menteeRepository.findById(5L)).thenReturn(Optional.of(existingMentee));
+    when(applicationRepository.findByMenteeAndCycle(any(), any())).thenReturn(List.of());
+    when(applicationRepository.countMenteeApplications(any(), any())).thenReturn(0L);
+    when(menteeRepository.update(eq(5L), any(Mentee.class)))
+        .thenAnswer(invocation -> invocation.getArgument(1));
+    when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+
+    menteeService.saveRegistration(registration);
+
+    verify(notificationService).sendNewMenteesNotification(mentor, cycle);
+  }
+
+  @Test
+  @DisplayName(
+      "Given a LONG_TERM cycle, when registering a mentee, "
+          + "then applications are created with PENDING status")
+  void shouldCreateApplicationsWithPendingStatusForLongTermCycle() {
+    var currentYear = Year.now();
+    var existingMentee = createMenteeTest(5L, "Test Mentee", "test@wcc.com");
+    var registration =
+        new MenteeRegistration(
+            existingMentee,
+            MentorshipType.LONG_TERM,
+            currentYear,
+            List.of(new MenteeApplicationDto(1L, 1, "msg", "why")));
+
+    var cycle =
+        MentorshipCycleEntity.builder()
+            .cycleId(1L)
+            .cycleYear(currentYear)
+            .mentorshipType(MentorshipType.LONG_TERM)
+            .status(CycleStatus.OPEN)
+            .build();
+
+    when(cycleRepository.findOpenCycle()).thenReturn(Optional.of(cycle));
+    when(menteeRepository.findById(5L)).thenReturn(Optional.of(existingMentee));
+    when(applicationRepository.findByMenteeAndCycle(any(), any())).thenReturn(List.of());
+    when(applicationRepository.countMenteeApplications(any(), any())).thenReturn(0L);
+    when(menteeRepository.update(eq(5L), any(Mentee.class)))
+        .thenAnswer(invocation -> invocation.getArgument(1));
+
+    menteeService.saveRegistration(registration);
+
+    verify(applicationRepository)
+        .create(argThat(app -> app.getStatus() == ApplicationStatus.PENDING));
   }
 
   @Test

--- a/src/test/java/com/wcc/platform/service/MenteeWorkflowAcceptApplicationTest.java
+++ b/src/test/java/com/wcc/platform/service/MenteeWorkflowAcceptApplicationTest.java
@@ -1,0 +1,157 @@
+package com.wcc.platform.service;
+
+import static com.wcc.platform.utils.MenteeApplicationTestBuilder.accepted;
+import static com.wcc.platform.utils.MenteeApplicationTestBuilder.matched;
+import static com.wcc.platform.utils.MenteeApplicationTestBuilder.reviewing;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.wcc.platform.domain.exceptions.ApplicationMenteeWorkflowException;
+import com.wcc.platform.domain.exceptions.ApplicationNotFoundException;
+import com.wcc.platform.domain.exceptions.MentorCapacityExceededException;
+import com.wcc.platform.domain.platform.mentorship.ApplicationStatus;
+import com.wcc.platform.domain.platform.mentorship.MenteeApplication;
+import com.wcc.platform.domain.platform.mentorship.MentorshipCycleEntity;
+import com.wcc.platform.domain.platform.mentorship.MentorshipMatch;
+import com.wcc.platform.domain.platform.mentorship.MentorshipType;
+import com.wcc.platform.repository.MenteeApplicationRepository;
+import com.wcc.platform.repository.MenteeRepository;
+import com.wcc.platform.repository.MentorRepository;
+import com.wcc.platform.repository.MentorshipCycleRepository;
+import com.wcc.platform.repository.MentorshipMatchRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MenteeWorkflowAcceptApplicationTest {
+
+  private static final Long MENTEE_ID = 10L;
+  private static final Long MENTOR_ID = 20L;
+  private static final Long CYCLE_ID = 5L;
+
+  @Mock private MenteeApplicationRepository applicationRepository;
+  @Mock private MentorshipMatchRepository matchRepository;
+  @Mock private MentorshipCycleRepository cycleRepository;
+  @Mock private MenteeRepository menteeRepository;
+  @Mock private MentorRepository mentorRepository;
+  @Mock private MentorshipService mentorshipService;
+  @Mock private MentorshipNotificationService notificationService;
+  @Mock private MentorshipMatchingService mentorshipMatchingService;
+
+  @InjectMocks private MenteeWorkflowService service;
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(mentorshipService.getNotificationService()).thenReturn(notificationService);
+    lenient().when(mentorshipService.getMentorRepository()).thenReturn(mentorRepository);
+  }
+
+  @Test
+  @DisplayName(
+      "Given a LONG_TERM cycle and MENTOR_REVIEWING application, "
+          + "when mentor accepts, then status becomes MENTOR_ACCEPTED")
+  void shouldSetStatusToMentorAcceptedForLongTermCycle() {
+    final MenteeApplication reviewingApp = reviewing(1L, MENTEE_ID, 1);
+    final MenteeApplication accepted = accepted(1L, MENTEE_ID, 1);
+    final MentorshipCycleEntity longTermCycle =
+        MentorshipCycleEntity.builder()
+            .cycleId(CYCLE_ID)
+            .mentorshipType(MentorshipType.LONG_TERM)
+            .maxMenteesPerMentor(3)
+            .build();
+
+    when(applicationRepository.findById(1L)).thenReturn(Optional.of(reviewingApp));
+    when(cycleRepository.findById(CYCLE_ID)).thenReturn(Optional.of(longTermCycle));
+    when(matchRepository.countActiveMenteesByMentorAndCycle(MENTOR_ID, CYCLE_ID)).thenReturn(0);
+    when(applicationRepository.updateStatus(1L, ApplicationStatus.MENTOR_ACCEPTED, null))
+        .thenReturn(accepted);
+
+    final MenteeApplication result = service.acceptApplication(1L, null);
+
+    assertThat(result.getStatus()).isEqualTo(ApplicationStatus.MENTOR_ACCEPTED);
+    verify(mentorshipMatchingService, never()).confirmMatch(any());
+  }
+
+  @Test
+  @DisplayName(
+      "Given an AD_HOC cycle and MENTOR_REVIEWING application, "
+          + "when mentor accepts, then confirmMatch is called and MATCHED application is returned")
+  void shouldDelegateToConfirmMatchForAdHocCycle() {
+    final MenteeApplication reviewingApp = reviewing(1L, MENTEE_ID, 1);
+    final MenteeApplication matchedApp = matched(1L, MENTEE_ID, 1);
+    final MentorshipCycleEntity adHocCycle =
+        MentorshipCycleEntity.builder()
+            .cycleId(CYCLE_ID)
+            .mentorshipType(MentorshipType.AD_HOC)
+            .maxMenteesPerMentor(3)
+            .build();
+
+    when(applicationRepository.findById(1L))
+        .thenReturn(Optional.of(reviewingApp))
+        .thenReturn(Optional.of(matchedApp));
+    when(cycleRepository.findById(CYCLE_ID)).thenReturn(Optional.of(adHocCycle));
+    when(matchRepository.countActiveMenteesByMentorAndCycle(MENTOR_ID, CYCLE_ID)).thenReturn(0);
+    when(mentorshipMatchingService.confirmMatch(1L)).thenReturn(MentorshipMatch.builder().build());
+
+    final MenteeApplication result = service.acceptApplication(1L, null);
+
+    verify(mentorshipMatchingService).confirmMatch(1L);
+    assertThat(result.getStatus()).isEqualTo(ApplicationStatus.MATCHED);
+  }
+
+  @Test
+  @DisplayName(
+      "Given mentor at full capacity, when mentor accepts, then MentorCapacityExceededException is thrown")
+  void shouldThrowMentorCapacityExceededExceptionWhenMentorAtCapacity() {
+    final MenteeApplication reviewingApp = reviewing(1L, MENTEE_ID, 1);
+    final MentorshipCycleEntity cycle =
+        MentorshipCycleEntity.builder()
+            .cycleId(CYCLE_ID)
+            .mentorshipType(MentorshipType.AD_HOC)
+            .maxMenteesPerMentor(2)
+            .build();
+
+    when(applicationRepository.findById(1L)).thenReturn(Optional.of(reviewingApp));
+    when(cycleRepository.findById(CYCLE_ID)).thenReturn(Optional.of(cycle));
+    when(matchRepository.countActiveMenteesByMentorAndCycle(MENTOR_ID, CYCLE_ID)).thenReturn(2);
+
+    assertThatThrownBy(() -> service.acceptApplication(1L, null))
+        .isInstanceOf(MentorCapacityExceededException.class);
+  }
+
+  @Test
+  @DisplayName(
+      "Given application in terminal state, when mentor accepts, "
+          + "then ApplicationMenteeWorkflowException is thrown")
+  void shouldThrowExceptionWhenApplicationIsInTerminalState() {
+    final MenteeApplication matchedApp = matched(1L, MENTEE_ID, 1);
+
+    when(applicationRepository.findById(1L)).thenReturn(Optional.of(matchedApp));
+
+    assertThatThrownBy(() -> service.acceptApplication(1L, null))
+        .isInstanceOf(ApplicationMenteeWorkflowException.class)
+        .hasMessageContaining("terminal state");
+  }
+
+  @Test
+  @DisplayName(
+      "Given application not found, when mentor accepts, then ApplicationNotFoundException is thrown")
+  void shouldThrowApplicationNotFoundExceptionWhenApplicationDoesNotExist() {
+    when(applicationRepository.findById(99L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.acceptApplication(99L, null))
+        .isInstanceOf(ApplicationNotFoundException.class)
+        .hasMessageContaining("Application not found with ID: 99");
+  }
+}

--- a/src/test/java/com/wcc/platform/service/MentorshipMatchingServiceTest.java
+++ b/src/test/java/com/wcc/platform/service/MentorshipMatchingServiceTest.java
@@ -1,6 +1,7 @@
 package com.wcc.platform.service;
 
 import static com.wcc.platform.utils.MenteeApplicationTestBuilder.baseBuilder;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
@@ -13,6 +14,7 @@ import com.wcc.platform.domain.platform.mentorship.MenteeApplication;
 import com.wcc.platform.domain.platform.mentorship.Mentor;
 import com.wcc.platform.domain.platform.mentorship.MentorshipCycleEntity;
 import com.wcc.platform.domain.platform.mentorship.MentorshipMatch;
+import com.wcc.platform.domain.platform.mentorship.MentorshipType;
 import com.wcc.platform.repository.MenteeApplicationRepository;
 import com.wcc.platform.repository.MenteeRepository;
 import com.wcc.platform.repository.MentorRepository;
@@ -134,5 +136,73 @@ class MentorshipMatchingServiceTest {
     service.confirmMatch(APPLICATION_ID);
 
     verify(notificationService).sendPairingConfirmation(mentor, mentee, cycle);
+  }
+
+  @Test
+  @DisplayName(
+      "Given an AD_HOC cycle and MENTOR_REVIEWING application, "
+          + "when confirmMatch is called, then match is created successfully")
+  void shouldConfirmMatchForAdHocCycleWithMentorReviewingStatus() {
+    final MenteeApplication application =
+        baseBuilder(APPLICATION_ID, MENTEE_ID, MENTOR_ID, 1)
+            .status(ApplicationStatus.MENTOR_REVIEWING)
+            .build();
+    final MentorshipCycleEntity cycle =
+        MentorshipCycleEntity.builder()
+            .cycleId(CYCLE_ID)
+            .mentorshipType(MentorshipType.AD_HOC)
+            .maxMenteesPerMentor(3)
+            .build();
+    final Mentee mentee =
+        Mentee.menteeBuilder().id(MENTEE_ID).spokenLanguages(List.of("ENGLISH")).build();
+    final MentorshipMatch createdMatch =
+        MentorshipMatch.builder()
+            .matchId(MATCH_ID)
+            .mentorId(MENTOR_ID)
+            .menteeId(MENTEE_ID)
+            .cycleId(CYCLE_ID)
+            .applicationId(APPLICATION_ID)
+            .status(MatchStatus.ACTIVE)
+            .startDate(FIXED_DATE)
+            .build();
+
+    when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(application));
+    when(cycleRepository.findById(CYCLE_ID)).thenReturn(Optional.of(cycle));
+    when(matchRepository.countActiveMenteesByMentorAndCycle(MENTOR_ID, CYCLE_ID)).thenReturn(0);
+    when(matchRepository.isMenteeMatchedInCycle(MENTEE_ID, CYCLE_ID)).thenReturn(false);
+    when(matchRepository.create(any(MentorshipMatch.class))).thenReturn(createdMatch);
+    when(applicationRepository.findByMenteeAndCycleOrderByPriority(MENTEE_ID, CYCLE_ID))
+        .thenReturn(List.of(application));
+    when(mentorRepository.findById(MENTOR_ID))
+        .thenReturn(Optional.of(Mentor.mentorBuilder().build()));
+    when(menteeRepository.findById(MENTEE_ID)).thenReturn(Optional.of(mentee));
+
+    service.confirmMatch(APPLICATION_ID);
+
+    verify(matchRepository).create(any(MentorshipMatch.class));
+  }
+
+  @Test
+  @DisplayName(
+      "Given a LONG_TERM cycle and MENTOR_REVIEWING application, "
+          + "when confirmMatch is called, then IllegalStateException is thrown")
+  void shouldThrowExceptionForLongTermCycleWithMentorReviewingStatus() {
+    final MenteeApplication application =
+        baseBuilder(APPLICATION_ID, MENTEE_ID, MENTOR_ID, 1)
+            .status(ApplicationStatus.MENTOR_REVIEWING)
+            .build();
+    final MentorshipCycleEntity cycle =
+        MentorshipCycleEntity.builder()
+            .cycleId(CYCLE_ID)
+            .mentorshipType(MentorshipType.LONG_TERM)
+            .maxMenteesPerMentor(3)
+            .build();
+
+    when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(application));
+    when(cycleRepository.findById(CYCLE_ID)).thenReturn(Optional.of(cycle));
+
+    assertThatThrownBy(() -> service.confirmMatch(APPLICATION_ID))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("MENTOR_ACCEPTED");
   }
 }

--- a/src/test/java/com/wcc/platform/utils/MenteeApplicationTestBuilder.java
+++ b/src/test/java/com/wcc/platform/utils/MenteeApplicationTestBuilder.java
@@ -73,6 +73,21 @@ public final class MenteeApplicationTestBuilder {
   }
 
   /**
+   * Creates a MENTOR_ACCEPTED application.
+   *
+   * @param applicationId the application ID
+   * @param menteeId the mentee ID
+   * @param priority the priority order
+   * @return a mentor-accepted MenteeApplication
+   */
+  public static MenteeApplication accepted(
+      final Long applicationId, final Long menteeId, final int priority) {
+    return baseBuilder(applicationId, menteeId, priority)
+        .status(ApplicationStatus.MENTOR_ACCEPTED)
+        .build();
+  }
+
+  /**
    * Creates a MATCHED application.
    *
    * @param applicationId the application ID


### PR DESCRIPTION
## Description
 - AD_HOC mentee applications are created directly in `MENTOR_REVIEWING` status, bypassing the admin approval step
   - `acceptApplication` delegates to `MentorshipMatchingService.confirmMatch()` for AD_HOC cycles, moving directly to `MATCHED`
   - `confirmMatch` validates expected status based on cycle type: `MENTOR_REVIEWING` for AD_HOC, `MENTOR_ACCEPTED` for LONG_TERM
   - Mentor is notified via `sendNewMenteesNotification` at registration time for AD_HOC (mirrors `approveApplication` behaviour for LONG_TERM)
   - TODO added on `MentorshipMatchingService` injection in `MenteeWorkflowService` to flag cyclic-dependency risk for future
   refactor

## Related Issue
#712 

## Change Type

- [ ] Bug Fix
- [X] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Test
- [ ] Other

## Screenshots
<img width="2632" height="1340" alt="image" src="https://github.com/user-attachments/assets/e72a4334-76cb-40af-96e9-719ff7aeae94" />
<img width="1627" height="432" alt="image" src="https://github.com/user-attachments/assets/d2429c30-46d0-4e19-8de1-8bf570c57084" />

<img width="2940" height="140" alt="image" src="https://github.com/user-attachments/assets/b202d961-520b-4854-b667-e1c0682ea486" />
<img width="52" height="65" alt="image" src="https://github.com/user-attachments/assets/d576fc1d-ab50-408e-b7db-21baacbcf4d5" />
<img width="1912" height="655" alt="image" src="https://github.com/user-attachments/assets/501ba2e8-fca0-46c1-a898-a9376c990f94" />
<img width="2120" height="835" alt="image" src="https://github.com/user-attachments/assets/2c7d8524-bf85-4317-8499-0d0ac3836dea" />


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [X] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->