### PR TITLE
bugfix: Fix profile status issue

### DIFF
--- a/src/main/java/com/wcc/platform/repository/postgres/mentorship/PostgresMenteeRepository.java
+++ b/src/main/java/com/wcc/platform/repository/postgres/mentorship/PostgresMenteeRepository.java
@@ -187,7 +187,10 @@ public class PostgresMenteeRepository implements MenteeRepository {
   }
 
   private void updateMenteeDetails(final Mentee mentee, final Long memberId) {
-    final var profileStatus = mentee.getProfileStatus();
+    var profileStatus = mentee.getProfileStatus();
+    if (profileStatus == null) {
+      profileStatus = ProfileStatus.PENDING;
+    }
     final var skills = mentee.getSkills();
     jdbc.update(
         SQL_UPDATE_MENTEE,


### PR DESCRIPTION
## Description

Fixes the issue with POST /mentee endpoint if the PROFILE_STATUS is missing
Closes #705 

<!--
Example PR: https://github.com/Women-Coding-Community/wcc-backend/pull/118
-->

## Related Issue

Please link to the issue here
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Change Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Test
- [ ] Other

## Screenshots

When No profile status is passed on POST /mentee endpoint

<img width="814" height="521" alt="image" src="https://github.com/user-attachments/assets/28b9129a-4434-40c0-bce1-df32f111ed54" />

Mentee details get updated without any issues
<img width="755" height="537" alt="image" src="https://github.com/user-attachments/assets/56d4d11e-6f57-411e-b8fd-44588a852f06" />


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [ ] I have tested my changes locally.

<!--  Thanks for sending a pull request! -->