### PR TITLE
fix: prevent mentees from self-approving via profileStatus (#727)

### DIFF
--- a/src/main/java/com/wcc/platform/domain/platform/mentorship/Mentee.java
+++ b/src/main/java/com/wcc/platform/domain/platform/mentorship/Mentee.java
@@ -1,5 +1,6 @@
 package com.wcc.platform.domain.platform.mentorship;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.wcc.platform.domain.cms.attributes.Country;
 import com.wcc.platform.domain.cms.attributes.Image;
 import com.wcc.platform.domain.cms.attributes.PronounCategory;
@@ -29,6 +30,12 @@ import org.springframework.validation.annotation.Validated;
 @SuppressWarnings({"PMD.ExcessiveParameterList", "PMD.ImmutableField"})
 public class Mentee extends Member {
 
+  /**
+   * Approval status of the mentee. Read-only over the API: clients cannot set or change it through
+   * the registration payload; it is managed server-side (defaults to PENDING on creation and is
+   * only changed via the admin approval flow).
+   */
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   private ProfileStatus profileStatus;
 
   @NotNull(message = "Skills must be provided")


### PR DESCRIPTION
## Summary

Fixes #727 — a mentee could set their own `profileStatus` (e.g. `ACTIVE`) through the public registration endpoint, bypassing the admin approval queue.

`Mentee.profileStatus` was deserialized from the request body. This PR marks it read-only for deserialization, mirroring the existing protection already present on `MentorDto.profileStatus`:

```java
@JsonProperty(access = JsonProperty.Access.READ_ONLY)
private ProfileStatus profileStatus;
```

Jackson now ignores any client-supplied `profileStatus`, so the field arrives as `null`, and the mentee repository already defaults `null` → `PENDING` on insert and preserves the existing server-side status on update. No other changes are required.

## Impact

- New registrations are always created as `PENDING` and appear in the admin approval queue (`GET /mentees/pending`), regardless of what the client sends.
- A previously `REJECTED` mentee can no longer reactivate themselves by resubmitting with `"profileStatus": "ACTIVE"` — the server-side status is preserved.

## Verification

Tested locally end-to-end against a Postgres-backed instance:

| Scenario | Before | After |
|---|---|---|
| Register with `"profileStatus":"ACTIVE"` | stored as `ACTIVE` (self-approved) | stored as `PENDING` |
| REJECTED mentee resubmits with `ACTIVE` | flips back to `ACTIVE` | stays `REJECTED` |

## Notes

- Related issue #725 (rejecting a mentee does not cancel their applications) interacts with this: fixing #725 widens the path where the reactivation was reachable, which makes this fix more important.
- A regression test for this behaviour exists locally but is not included in this commit; happy to add it in this PR if reviewers prefer.