### PR TITLE
fix: preserve existing member types when registering as a mentor (#731)

### DIFF
--- a/src/main/java/com/wcc/platform/service/MentorshipService.java
+++ b/src/main/java/com/wcc/platform/service/MentorshipService.java
@@ -107,7 +107,6 @@ public class MentorshipService {
               .acceptMale(mentor.getAcceptMale())
               .acceptPromotion(mentor.getAcceptPromotion())
               .meetingLink(mentor.getMeetingLink())
-              .memberTypes(mentor.getMemberTypes())
               .build();
 
       return mentorRepository.create(mentorWithExistingId);


### PR DESCRIPTION
## Summary

Fixes #731 — when an existing member registered as a mentor, their other member types were silently discarded.

In `MentorshipService.create`, the existing-member branch built the mentor with the correctly-merged member types, then a duplicate `.memberTypes(mentor.getMemberTypes())` builder call overwrote it. Because the builder's last call wins and `mentor`'s types had been forced to `[MENTOR]` earlier in the method, the merged list was lost. This PR removes the duplicate call (one line), so the merged `[existing types + MENTOR]` list is retained.

## Impact

A member with types such as `[MEMBER, LEADER]` who registers as a mentor now keeps those types (`[MEMBER, LEADER, MENTOR]`) instead of being reduced to `[MENTOR]`.

## Verification

Tested locally end-to-end against a Postgres-backed instance (member types read from `member_member_types`):

| Member (prior type) | After registering as mentor |
|---|---|
| Before fix | `MENTOR` only (prior type wiped) |
| After fix | prior type + `MENTOR` preserved |

## Notes

- A regression test strengthening `MentorshipServiceTest.shouldPreserveAllFieldsWhenMentorReRegistersWithExistingEmail` (adding a `memberTypes` assertion — the field the bug corrupted) exists locally but is not included in this commit; happy to add it to this PR if reviewers prefer. It fails on the un-fixed code and passes with the fix.