### PR TITLE
fix: exclude 0-hour ad-hoc availability from mentor cycle list (#726, #762)

### DIFF
--- a/admin-wcc-app/components/EditMentor/EditMentorForm.tsx
+++ b/admin-wcc-app/components/EditMentor/EditMentorForm.tsx
@@ -101,6 +101,7 @@ export default function EditMentorForm({ mentorId }: EditMentorFormProps) {
     control,
     handleSubmit,
     reset,
+    setValue,
     formState: { errors },
   } = useForm<EditMentorFormData>({
     resolver: zodResolver(editMentorSchema),
@@ -165,7 +166,7 @@ export default function EditMentorForm({ mentorId }: EditMentorFormProps) {
       longTerm: data.mentorshipType.includes('LONG_TERM') ? { numMentee: 1, hours: 2 } : null,
       adHoc: data.mentorshipType.includes('AD_HOC')
         ? data.monthAvailability
-            .filter((m) => m.enabled)
+            .filter((m) => m.enabled && m.hours > 0)
             .map((m) => ({ month: m.month, hours: m.hours }))
         : [],
     },
@@ -321,7 +322,7 @@ export default function EditMentorForm({ mentorId }: EditMentorFormProps) {
         <PersonalInfoSection control={control} errors={errors} />
         <BioSection control={control} errors={errors} />
         <SkillsSection control={control} errors={errors} />
-        <MentorshipAvailabilitySection control={control} errors={errors} />
+        <MentorshipAvailabilitySection control={control} errors={errors} setValue={setValue} />
         <ResourcesSection control={control} />
       </Stack>
 

--- a/admin-wcc-app/components/EditMentor/MentorshipAvailabilitySection.tsx
+++ b/admin-wcc-app/components/EditMentor/MentorshipAvailabilitySection.tsx
@@ -30,7 +30,11 @@ const MONTHS = [
 
 const monthLabel = (month: string) => month.charAt(0) + month.slice(1).toLowerCase();
 
-export default function MentorshipAvailabilitySection({ control, errors }: FormSectionProps) {
+export default function MentorshipAvailabilitySection({
+  control,
+  errors,
+  setValue,
+}: FormSectionProps) {
   const mentorshipType = useWatch({
     control,
     name: 'mentorshipType',
@@ -143,7 +147,12 @@ export default function MentorshipAvailabilitySection({ control, errors }: FormS
                           control={
                             <Checkbox
                               checked={field.value}
-                              onChange={(e) => field.onChange(e.target.checked)}
+                              onChange={(e) => {
+                                field.onChange(e.target.checked);
+                                if (!e.target.checked) {
+                                  setValue?.(`monthAvailability.${index}.hours`, 0);
+                                }
+                              }}
                               size="small"
                             />
                           }
@@ -159,9 +168,11 @@ export default function MentorshipAvailabilitySection({ control, errors }: FormS
                         <TextField
                           {...field}
                           value={value}
-                          onChange={(e) =>
-                            onChange(e.target.value === '' ? 0 : Number(e.target.value))
-                          }
+                          onChange={(e) => {
+                            const nextHours = e.target.value === '' ? 0 : Number(e.target.value);
+                            onChange(nextHours);
+                            setValue?.(`monthAvailability.${index}.enabled`, nextHours > 0);
+                          }}
                           type="number"
                           size="small"
                           label="hours"

--- a/admin-wcc-app/components/EditMentor/types.ts
+++ b/admin-wcc-app/components/EditMentor/types.ts
@@ -1,4 +1,4 @@
-import { Control, FieldErrors } from 'react-hook-form';
+import { Control, FieldErrors, UseFormSetValue } from 'react-hook-form';
 import { EditMentorFormData } from './schema';
 
 export type { EditMentorFormData } from './schema';
@@ -6,4 +6,5 @@ export type { EditMentorFormData } from './schema';
 export interface FormSectionProps {
   control: Control<EditMentorFormData>;
   errors: FieldErrors<EditMentorFormData>;
+  setValue?: UseFormSetValue<EditMentorFormData>;
 }

--- a/src/main/java/com/wcc/platform/domain/cms/pages/mentorship/MenteeSection.java
+++ b/src/main/java/com/wcc/platform/domain/cms/pages/mentorship/MenteeSection.java
@@ -52,11 +52,13 @@ public record MenteeSection(
 
   /**
    * Converts to a DTO scoped to the given mentorship cycle. For AD_HOC cycles the adHoc
-   * availability list is filtered to only the entries whose month matches the cycle month, so that
-   * mentors unavailable in the current cycle month are not surfaced by the AD_HOC type filter.
+   * availability list is filtered to only the entries whose month matches the cycle month and that
+   * declare more than zero hours, so that mentors unavailable in the current cycle month (or with no
+   * real availability, i.e. 0 hours) are not surfaced by the AD_HOC type filter.
    *
    * @param cycle the active mentorship cycle; when null or LONG_TERM the full adHoc list is kept
-   * @return a MenteeSection DTO with adHoc availability filtered to the current cycle month
+   * @return a MenteeSection DTO with adHoc availability filtered to the current cycle month and to
+   *     entries with positive hours
    */
   public MenteeSection toDtoForCycle(final MentorshipCycle cycle) {
     if (cycle == null
@@ -66,7 +68,10 @@ public record MenteeSection(
       return toDto();
     }
     final List<MentorMonthAvailability> filteredAdHoc =
-        adHoc.stream().filter(a -> Objects.equals(a.month(), cycle.month())).toList();
+        adHoc.stream()
+            .filter(a -> Objects.equals(a.month(), cycle.month()))
+            .filter(a -> a.hours() != null && a.hours() > 0)
+            .toList();
     return new MenteeSection(idealMentee, additional, longTerm, filteredAdHoc);
   }
 }


### PR DESCRIPTION
## Summary

A mentor who declared a month with **0 hours** of ad-hoc availability was still surfaced in that cycle's public mentor list, because a ticked-but-zero-hour month was treated as real availability. This fixes it on both the backend (display) and the admin form (data entry).

### Backend — exclude 0-hour availability from the cycle list
`MenteeSection.toDtoForCycle` now drops ad-hoc entries with zero (or null) hours in addition to the existing current-month filter. A mentor whose only availability for the cycle month is 0 hours no longer derives the `AD_HOC` type, so they are excluded from the ad-hoc mentor list. This also cleans up any existing 0-hour data.

### Admin (edit-mentor form) — keep the checkbox in sync with hours
In `admin-wcc-app`'s `MentorshipAvailabilitySection`:
- Typing **hours > 0 auto-ticks** the month; setting **hours = 0 auto-unticks** it.
- Unticking a month resets its hours to 0.
- `transformFormData` submits only months with `hours > 0`, so a 0-hour month is never saved as available in the first place.

## Testing

- Backend: verified locally end-to-end — with the open cycle set to ad-hoc/July, a mentor set to July/0h is excluded from `GET /api/cms/v1/mentorship/mentors?mentorshipTypes=AD_HOC`, while a mentor with July/3h remains.
- Admin: verified the checkbox/hours sync and that a 0-hour month is not submitted; `tsc`, `eslint`, and `prettier` pass on the changed files.

> Note: a backend regression test for the 0-hour exclusion was prepared but is **not included in this PR** (excluded intentionally). Happy to add it in a follow-up.

## Closes
- Closes #726 (backend: mentor with 0 available hours included in the cycle list)
- Closes #762 (admin edit-mentor form submits ad-hoc months with 0 hours)

## Related (not fixed here)
Part of the broader mentor availability / admin-form and mentors-display cluster:
- #606 — mentor edit field binding/hydration
- #684 — create mentor loses gender/availability
- #688 — admin long-term availability hardcoded default
- #720 — unable to update mentor with missing languages
- #654 — mentors page returns empty list when the CMS page is missing
